### PR TITLE
fix: update EAS configuration - remove deprecated teamId fields

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -8,8 +8,7 @@
       "developmentClient": true,
       "distribution": "internal",
       "ios": {
-        "resourceClass": "m-medium",
-        "teamId": "S4W5Q2L53W"
+        "resourceClass": "m-medium"
       },
       "android": {
         "buildType": "apk"
@@ -21,8 +20,7 @@
     "preview": {
       "distribution": "internal",
       "ios": {
-        "resourceClass": "m-medium",
-        "teamId": "S4W5Q2L53W"
+        "resourceClass": "m-medium"
       },
       "android": {
         "buildType": "apk"
@@ -36,8 +34,7 @@
       "ios": {
         "resourceClass": "m-medium",
         "credentialsSource": "remote",
-        "enterpriseProvisioning": "universal",
-        "teamId": "S4W5Q2L53W"
+        "enterpriseProvisioning": "universal"
       },
       "android": {
         "buildType": "app-bundle",
@@ -51,8 +48,7 @@
   "submit": {
     "production": {
       "ios": {
-        "ascAppId": "YOUR_APP_STORE_CONNECT_APP_ID",
-        "appleTeamId": "YOUR_APPLE_TEAM_ID"
+        "appleTeamId": "S4W5Q2L53W"
       },
       "android": {
         "track": "internal",


### PR DESCRIPTION
## Summary
This PR updates the EAS configuration to fix validation errors and prepare for iOS Distribution Certificate renewal.

## Changes
- ✅ Removed deprecated `teamId` field from iOS build configurations (development, preview, production)
- ✅ Fixed submit configuration with correct `appleTeamId`
- ✅ Resolves EAS CLI validation errors

## Context
- Apple sent notification about iOS Distribution Certificate expiring in 30 days
- Updated EAS config to enable automatic certificate management
- `credentialsSource: remote` allows EAS to handle certificates automatically

## Testing
- ✅ EAS CLI validation passes
- ✅ Configuration tested with `npx eas-cli credentials`

## Impact
- No impact on existing apps
- Future builds will use updated certificate automatically