### PR TITLE
feat: Add comprehensive download state indicators and improvements

### DIFF
--- a/app/(tabs)/(c.collection)/collection/loved.tsx
+++ b/app/(tabs)/(c.collection)/collection/loved.tsx
@@ -1,10 +1,15 @@
-import React, {useState, useEffect, useCallback, useMemo, useRef} from 'react';
-import {View, Text, TouchableOpacity, StyleSheet, Alert} from 'react-native';
+import React, {useState, useEffect, useCallback, useRef} from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+  StatusBar,
+} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {TrackItem} from '@/components/TrackItem';
 import {getReciterById, getSurahById} from '@/services/dataService';
-import {useRouter} from 'expo-router';
 import {moderateScale} from 'react-native-size-matters';
 import {Icon} from '@rneui/themed';
 import {FlatList, ListRenderItem} from 'react-native';
@@ -23,11 +28,9 @@ import {getReciterArtwork} from '@/utils/artworkUtils';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {useDownloadStore} from '@/services/player/store/downloadStore';
 import {LovedHeader} from '@/components/playlist-detail/LovedHeader';
-import {
-  useDownload,
-  DownloadedSurah,
-} from '@/services/player/store/downloadStore';
+import {useDownload} from '@/services/player/store/downloadStore';
 import {downloadSurah} from '@/services/downloadService';
+import {useCollectionDownloadState} from '@/hooks/useCollectionDownloadState';
 
 interface LovedTrack {
   reciterId: string;
@@ -42,11 +45,9 @@ interface LovedTrackData {
 }
 
 const LovedScreen = () => {
-  const router = useRouter();
   const {theme} = useTheme();
-  const insets = useSafeAreaInsets();
   const {lovedTracks, toggleLoved} = useLoved();
-  const {updateQueue, play, pause, playback} = useUnifiedPlayer();
+  const {pause, playback} = useUnifiedPlayer();
   const queueContext = QueueContext.getInstance();
   const {addRecentTrack} = useRecentlyPlayedStore();
   const playerStore = usePlayerStore();
@@ -54,6 +55,7 @@ const LovedScreen = () => {
     isDownloaded,
     isDownloadedWithRewayat,
     isDownloading,
+    isDownloadingWithRewayat,
     setDownloading,
     clearDownloading,
     addDownload,
@@ -108,7 +110,7 @@ const LovedScreen = () => {
 
   // Use ref to track previous lovedTracks content to prevent infinite loops
   const prevLovedTracksRef = useRef<string>('');
-  
+
   const loadLovedData = useCallback(async () => {
     try {
       setLoading(true);
@@ -145,9 +147,9 @@ const LovedScreen = () => {
   useEffect(() => {
     // Create a stable string representation of lovedTracks
     const currentTracksString = JSON.stringify(
-      lovedTracks.map(t => `${t.reciterId}:${t.surahId}:${t.rewayatId || ''}`)
+      lovedTracks.map(t => `${t.reciterId}:${t.surahId}:${t.rewayatId || ''}`),
     );
-    
+
     // Only reload if the content actually changed
     if (prevLovedTracksRef.current !== currentTracksString) {
       prevLovedTracksRef.current = currentTracksString;
@@ -233,7 +235,8 @@ const LovedScreen = () => {
           Promise.all(
             remainingItems.map(async item => {
               if (!item.reciter || !item.surah) return null;
-              const itemRewayatId = item.track.rewayatId || item.reciter.rewayat[0]?.id;
+              const itemRewayatId =
+                item.track.rewayatId || item.reciter.rewayat[0]?.id;
               const url = generateSmartAudioUrl(
                 item.reciter,
                 item.surah.id.toString(),
@@ -259,7 +262,9 @@ const LovedScreen = () => {
 
               // Check if operation is still valid
               if (currentOperationRef.current !== operationId) {
-                console.log('[LovedScreen] Operation cancelled, skipping track addition');
+                console.log(
+                  '[LovedScreen] Operation cancelled, skipping track addition',
+                );
                 return;
               }
 
@@ -268,7 +273,9 @@ const LovedScreen = () => {
                 .then(() => {
                   // Double-check operation is still valid before updating store
                   if (currentOperationRef.current !== operationId) {
-                    console.log('[LovedScreen] Operation cancelled, skipping store update');
+                    console.log(
+                      '[LovedScreen] Operation cancelled, skipping store update',
+                    );
                     return;
                   }
 
@@ -325,7 +332,8 @@ const LovedScreen = () => {
       useDownloadStore.getState();
 
       // Create ONLY first track (instant!)
-      const rewayatId = firstItem.track.rewayatId || firstItem.reciter.rewayat[0]?.id;
+      const rewayatId =
+        firstItem.track.rewayatId || firstItem.reciter.rewayat[0]?.id;
       const firstTrack = {
         id: `${firstItem.reciter.id}:${firstItem.surah.id}`,
         url: generateSmartAudioUrl(
@@ -372,7 +380,8 @@ const LovedScreen = () => {
         Promise.all(
           remainingItems.map(async item => {
             if (!item.reciter || !item.surah) return null;
-            const itemRewayatId = item.track.rewayatId || item.reciter.rewayat[0]?.id;
+            const itemRewayatId =
+              item.track.rewayatId || item.reciter.rewayat[0]?.id;
             const url = generateSmartAudioUrl(
               item.reciter,
               item.surah.id.toString(),
@@ -397,14 +406,18 @@ const LovedScreen = () => {
             );
 
             if (currentOperationRef.current !== operationId) {
-              console.log('[LovedScreen] Operation cancelled, skipping track addition');
+              console.log(
+                '[LovedScreen] Operation cancelled, skipping track addition',
+              );
               return;
             }
 
             TrackPlayer.add(validRemainingTracks)
               .then(() => {
                 if (currentOperationRef.current !== operationId) {
-                  console.log('[LovedScreen] Operation cancelled, skipping store update');
+                  console.log(
+                    '[LovedScreen] Operation cancelled, skipping store update',
+                  );
                   return;
                 }
 
@@ -459,7 +472,8 @@ const LovedScreen = () => {
       useDownloadStore.getState();
 
       // Create ONLY first track (instant!)
-      const rewayatId = firstItem.track.rewayatId || firstItem.reciter.rewayat[0]?.id;
+      const rewayatId =
+        firstItem.track.rewayatId || firstItem.reciter.rewayat[0]?.id;
       const firstTrack = {
         id: `${firstItem.reciter.id}:${firstItem.surah.id}`,
         url: generateSmartAudioUrl(
@@ -511,7 +525,8 @@ const LovedScreen = () => {
         Promise.all(
           remainingItems.map(async item => {
             if (!item.reciter || !item.surah) return null;
-            const itemRewayatId = item.track.rewayatId || item.reciter.rewayat[0]?.id;
+            const itemRewayatId =
+              item.track.rewayatId || item.reciter.rewayat[0]?.id;
             const url = generateSmartAudioUrl(
               item.reciter,
               item.surah.id.toString(),
@@ -536,14 +551,18 @@ const LovedScreen = () => {
             );
 
             if (currentOperationRef.current !== operationId) {
-              console.log('[LovedScreen] Operation cancelled, skipping track addition');
+              console.log(
+                '[LovedScreen] Operation cancelled, skipping track addition',
+              );
               return;
             }
 
             TrackPlayer.add(validRemainingTracks)
               .then(() => {
                 if (currentOperationRef.current !== operationId) {
-                  console.log('[LovedScreen] Operation cancelled, skipping store update');
+                  console.log(
+                    '[LovedScreen] Operation cancelled, skipping store update',
+                  );
                   return;
                 }
 
@@ -612,10 +631,21 @@ const LovedScreen = () => {
         if (!item.reciter || !item.surah) continue;
 
         const surahId = parseInt(item.track.surahId, 10);
-        const downloadId = `${item.track.reciterId}-${surahId}`;
+        // Generate download ID with rewayatId if provided for proper tracking
+        const downloadId = item.track.rewayatId
+          ? `${item.track.reciterId}-${surahId}-${item.track.rewayatId}`
+          : `${item.track.reciterId}-${surahId}`;
 
-        // Skip if already downloading
-        if (isDownloading(item.track.reciterId, item.track.surahId)) {
+        // Skip if already downloading - use rewayat-aware check if rewayatId is provided
+        const isCurrentlyDownloading = item.track.rewayatId
+          ? isDownloadingWithRewayat(
+              item.track.reciterId,
+              item.track.surahId,
+              item.track.rewayatId,
+            )
+          : isDownloading(item.track.reciterId, item.track.surahId);
+
+        if (isCurrentlyDownloading) {
           continue;
         }
 
@@ -630,7 +660,10 @@ const LovedScreen = () => {
             progress => {
               // Throttle progress updates to prevent AsyncStorage queue overflow
               const now = Date.now();
-              if (now - lastProgressUpdateRef.current < progressUpdateThrottle) {
+              if (
+                now - lastProgressUpdateRef.current <
+                progressUpdateThrottle
+              ) {
                 return;
               }
               lastProgressUpdateRef.current = now;
@@ -662,7 +695,10 @@ const LovedScreen = () => {
         }
       }
 
-      Alert.alert('Download Complete', 'All loved surahs have been downloaded.');
+      Alert.alert(
+        'Download Complete',
+        'All loved surahs have been downloaded.',
+      );
     } catch (error) {
       console.error('Error in bulk download:', error);
       Alert.alert('Download Error', 'Some downloads may have failed.');
@@ -670,14 +706,15 @@ const LovedScreen = () => {
       setIsDownloadingBulk(false);
     }
   }, [
-    lovedData,
     isDownloadingBulk,
+    lovedData,
     isDownloaded,
     isDownloadedWithRewayat,
+    isDownloadingWithRewayat,
     isDownloading,
     setDownloading,
-    clearDownloading,
     addDownload,
+    clearDownloading,
     setDownloadProgress,
   ]);
 
@@ -689,6 +726,9 @@ const LovedScreen = () => {
     [toggleLoved],
   );
 
+  // Calculate download state for all loved tracks using custom hook
+  const downloadState = useCollectionDownloadState(lovedData);
+
   const ListHeaderComponent = useCallback(() => {
     return (
       <LovedHeader
@@ -699,6 +739,8 @@ const LovedScreen = () => {
         onShufflePress={handleShuffle}
         onDownloadPress={handleBulkDownload}
         theme={theme}
+        allDownloaded={downloadState.allDownloaded}
+        hasNoTracks={downloadState.hasNoTracks}
       />
     );
   }, [
@@ -707,6 +749,8 @@ const LovedScreen = () => {
     handleShuffle,
     handleBulkDownload,
     theme,
+    downloadState.allDownloaded,
+    downloadState.hasNoTracks,
   ]);
 
   const renderItem: ListRenderItem<LovedTrackData> = ({item}) => {
@@ -760,6 +804,7 @@ const LovedScreen = () => {
 
   return (
     <View style={styles.container}>
+      <StatusBar barStyle="light-content" />
       <FlatList
         data={lovedData}
         renderItem={renderItem}

--- a/components/SurahItem.tsx
+++ b/components/SurahItem.tsx
@@ -60,6 +60,7 @@ export const SurahItem: React.FC<SurahItemProps> = React.memo(
       isDownloaded: checkIsDownloaded,
       isDownloadedWithRewayat,
       isDownloading,
+      isDownloadingWithRewayat,
       getDownloadProgress,
     } = useDownload();
 
@@ -70,9 +71,12 @@ export const SurahItem: React.FC<SurahItemProps> = React.memo(
         : checkIsDownloaded(reciterId, item.id.toString())
       : false;
 
-    // Check if currently downloading
-    const isCurrentlyDownloading =
-      reciterId && isDownloading(reciterId, item.id.toString());
+    // Check if currently downloading - use isDownloadingWithRewayat if rewayatId is provided
+    const isCurrentlyDownloading = reciterId
+      ? rewayatId
+        ? isDownloadingWithRewayat(reciterId, item.id.toString(), rewayatId)
+        : isDownloading(reciterId, item.id.toString())
+      : false;
 
     // Get download progress
     const downloadProgress = reciterId

--- a/components/TrackItem.tsx
+++ b/components/TrackItem.tsx
@@ -16,6 +16,9 @@ import Color from 'color';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {State as TrackPlayerState} from 'react-native-track-player';
 import {NowPlayingIndicator} from '@/components/NowPlayingIndicator';
+import {useDownload} from '@/services/player/store/downloadStore';
+import {CircularProgress} from '@/components/CircularProgress';
+import {Ionicons} from '@expo/vector-icons';
 
 interface TrackItemProps {
   reciterId: string;
@@ -37,6 +40,34 @@ export const TrackItem: React.FC<TrackItemProps> = React.memo(
     const playbackStatus = usePlayerStore(state => state.playback.state);
     const currentIndex = usePlayerStore(state => state.queue.currentIndex);
     const tracks = usePlayerStore(state => state.queue.tracks);
+
+    // Get download state
+    const {
+      isDownloaded: checkIsDownloaded,
+      isDownloadedWithRewayat,
+      isDownloading,
+      isDownloadingWithRewayat,
+      getDownloadProgress,
+    } = useDownload();
+
+    // Calculate download state - use isDownloadedWithRewayat if rewayatId is provided
+    const isDownloadedState = reciterId
+      ? rewayatId
+        ? isDownloadedWithRewayat(reciterId, surahId, rewayatId)
+        : checkIsDownloaded(reciterId, surahId)
+      : false;
+
+    // Check if currently downloading - use isDownloadingWithRewayat if rewayatId is provided
+    const isCurrentlyDownloading = reciterId
+      ? rewayatId
+        ? isDownloadingWithRewayat(reciterId, surahId, rewayatId)
+        : isDownloading(reciterId, surahId)
+      : false;
+
+    // Get download progress
+    const downloadProgress = reciterId
+      ? getDownloadProgress(reciterId, surahId)
+      : 0;
 
     // Check if this item is the currently active track
     const isCurrentlyPlaying = useMemo(() => {
@@ -145,7 +176,24 @@ export const TrackItem: React.FC<TrackItemProps> = React.memo(
                   </TouchableOpacity>
                 )}
               </View>
-              <Text style={styles.reciterName}>{reciter.name}</Text>
+              <View style={styles.reciterInfoRow}>
+                {isCurrentlyDownloading ? (
+                  <CircularProgress
+                    progress={downloadProgress}
+                    size={moderateScale(12)}
+                    strokeWidth={moderateScale(1.5)}
+                    color={theme.colors.textSecondary}
+                  />
+                ) : isDownloadedState ? (
+                  <Ionicons
+                    name="arrow-down-circle"
+                    size={moderateScale(12)}
+                    color={theme.colors.textSecondary}
+                    style={styles.downloadIcon}
+                  />
+                ) : null}
+                <Text style={styles.reciterName}>{reciter.name}</Text>
+              </View>
               {renderRewayatBadge()}
             </View>
 
@@ -203,10 +251,19 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.text,
       textAlign: 'right',
     },
+    reciterInfoRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: moderateScale(4),
+      marginBottom: moderateScale(3),
+    },
     reciterName: {
       fontSize: moderateScale(12),
       fontFamily: theme.fonts.regular,
       color: theme.colors.textSecondary,
+    },
+    downloadIcon: {
+      marginTop: moderateScale(1),
     },
     rewayatBadge: {
       marginTop: moderateScale(3),

--- a/components/cards/TrackCard.tsx
+++ b/components/cards/TrackCard.tsx
@@ -9,6 +9,9 @@ import {Reciter, Rewayat} from '@/data/reciterData';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {State as TrackPlayerState} from 'react-native-track-player';
 import {NowPlayingIndicator} from '@/components/NowPlayingIndicator';
+import {useDownload} from '@/services/player/store/downloadStore';
+import {CircularProgress} from '@/components/CircularProgress';
+import {Ionicons} from '@expo/vector-icons';
 
 interface TrackCardProps {
   reciterId: string;
@@ -35,6 +38,34 @@ export const TrackCard: React.FC<TrackCardProps> = ({
   const playbackStatus = usePlayerStore(state => state.playback.state);
   const currentIndex = usePlayerStore(state => state.queue.currentIndex);
   const tracks = usePlayerStore(state => state.queue.tracks);
+
+  // Get download state
+  const {
+    isDownloaded: checkIsDownloaded,
+    isDownloadedWithRewayat,
+    isDownloading,
+    isDownloadingWithRewayat,
+    getDownloadProgress,
+  } = useDownload();
+
+  // Calculate download state - use isDownloadedWithRewayat if rewayatId is provided
+  const isDownloadedState = reciterId
+    ? rewayatId
+      ? isDownloadedWithRewayat(reciterId, surahId, rewayatId)
+      : checkIsDownloaded(reciterId, surahId)
+    : false;
+
+  // Check if currently downloading - use isDownloadingWithRewayat if rewayatId is provided
+  const isCurrentlyDownloading = reciterId
+    ? rewayatId
+      ? isDownloadingWithRewayat(reciterId, surahId, rewayatId)
+      : isDownloading(reciterId, surahId)
+    : false;
+
+  // Get download progress
+  const downloadProgress = reciterId
+    ? getDownloadProgress(reciterId, surahId)
+    : 0;
 
   // Check if this item is the currently active track
   const isCurrentlyPlaying = useMemo(() => {
@@ -100,7 +131,7 @@ export const TrackCard: React.FC<TrackCardProps> = ({
       height: cardHeight,
       marginBottom: verticalScale(5),
       overflow: 'hidden',
-      borderRadius: moderateScale(15),
+      borderRadius: moderateScale(5),
       position: 'relative',
     },
     reciterImage: {
@@ -134,18 +165,25 @@ export const TrackCard: React.FC<TrackCardProps> = ({
       fontFamily: 'SurahNames',
       color: theme.colors.text,
     },
+    reciterInfoRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: moderateScale(4),
+      marginBottom: verticalScale(1),
+    },
     reciterName: {
       fontSize: moderateScale(10),
       fontFamily: 'Manrope-Regular',
       color: theme.colors.textSecondary,
-      marginBottom: verticalScale(1),
-      marginLeft: moderateScale(4),
+    },
+    downloadIcon: {
+      marginTop: moderateScale(1),
     },
     rewayatText: {
       fontSize: moderateScale(9),
       fontFamily: 'Manrope-Regular',
       color: theme.colors.textSecondary,
-      marginLeft: moderateScale(4),
+      textTransform: 'capitalize',
     },
   });
 
@@ -181,9 +219,26 @@ export const TrackCard: React.FC<TrackCardProps> = ({
         </Text>
         <Text style={styles.surahGlyph}>{surahGlyph}</Text>
       </View>
-      <Text style={styles.reciterName} numberOfLines={1}>
-        {reciter.name}
-      </Text>
+      <View style={styles.reciterInfoRow}>
+        {isCurrentlyDownloading ? (
+          <CircularProgress
+            progress={downloadProgress}
+            size={moderateScale(12)}
+            strokeWidth={moderateScale(1.5)}
+            color={theme.colors.textSecondary}
+          />
+        ) : isDownloadedState ? (
+          <Ionicons
+            name="arrow-down-circle"
+            size={moderateScale(12)}
+            color={theme.colors.textSecondary}
+            style={styles.downloadIcon}
+          />
+        ) : null}
+        <Text style={styles.reciterName} numberOfLines={1}>
+          {reciter.name}
+        </Text>
+      </View>
       {rewayat && (
         <Text style={styles.rewayatText} numberOfLines={1}>
           {rewayat.name}

--- a/components/modals/PlaylistContextMenu.tsx
+++ b/components/modals/PlaylistContextMenu.tsx
@@ -9,6 +9,9 @@ import {usePlaylistsStore} from '@/store/playlistsStore';
 import {downloadSurah} from '@/services/downloadService';
 import {useDownloadStore} from '@/services/player/store/downloadStore';
 import {ActivityIndicator} from 'react-native';
+import {CheckIcon} from '@/components/Icons';
+import {Ionicons} from '@expo/vector-icons';
+import {useCollectionDownloadState} from '@/hooks/useCollectionDownloadState';
 
 interface PlaylistContextMenuProps {
   bottomSheetRef: React.RefObject<BottomSheet>;
@@ -39,23 +42,24 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
     isDownloaded,
     isDownloadedWithRewayat,
     isDownloading,
+    isDownloadingWithRewayat,
     setPlaylistDownloadProgress,
   } = useDownloadStore();
-  
+
   const isMountedRef = useRef(true);
   const downloadCancelledRef = useRef(false);
   const lastProgressUpdateRef = useRef(0);
   const progressUpdateThrottle = 50; // Update progress max once per 50ms (more responsive)
-  
+
   // Get playlist download progress from store (persists across unmounts)
   // Subscribe to store changes to get reactive updates
-  const playlistProgress = useDownloadStore(state => 
-    state.playlistDownloads[playlistId] || null
+  const playlistProgress = useDownloadStore(
+    state => state.playlistDownloads[playlistId] || null,
   );
-  const isDownloadingPlaylist = useDownloadStore(state => 
-    state.playlistDownloads[playlistId] !== undefined
+  const isDownloadingPlaylist = useDownloadStore(
+    state => state.playlistDownloads[playlistId] !== undefined,
   );
-  
+
   const [downloadProgress, setDownloadProgressState] = useState(
     playlistProgress || {current: 0, total: 0, percentage: 0},
   );
@@ -77,6 +81,39 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
       // Don't cancel downloads on unmount, let them continue in background
     };
   }, []);
+
+  // Get playlist items and transform to format compatible with useCollectionDownloadState
+  const [playlistData, setPlaylistData] = useState<
+    Array<{
+      reciter: {id: string};
+      surah: {id: number};
+      track: {
+        reciterId: string;
+        surahId: string;
+        rewayatId?: string;
+      };
+    }>
+  >([]);
+
+  useEffect(() => {
+    const loadPlaylistData = async () => {
+      const items = await getPlaylistItems(playlistId);
+      const transformedData = items.map(item => ({
+        reciter: {id: item.reciterId},
+        surah: {id: parseInt(item.surahId, 10)},
+        track: {
+          reciterId: item.reciterId,
+          surahId: item.surahId,
+          rewayatId: item.rewayatId,
+        },
+      }));
+      setPlaylistData(transformedData);
+    };
+    loadPlaylistData();
+  }, [getPlaylistItems, playlistId]);
+
+  // Calculate download state using custom hook
+  const downloadState = useCollectionDownloadState(playlistData);
 
   const handleEdit = () => {
     if (onEdit) {
@@ -122,10 +159,10 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
       };
       setPlaylistDownloadProgress(playlistId, initialProgress);
       setDownloadProgressState(initialProgress);
-      
+
       // Get all playlist items
       const playlistItems = await getPlaylistItems(playlistId);
-      
+
       if (playlistItems.length === 0) {
         setPlaylistDownloadProgress(playlistId, null);
         if (isMountedRef.current) {
@@ -169,12 +206,26 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
       }
 
       // Download items sequentially with proper async yielding to prevent blocking
-      const downloadItem = async (item: typeof itemsToDownload[0], index: number) => {
+      const downloadItem = async (
+        item: (typeof itemsToDownload)[0],
+        index: number,
+      ) => {
         const surahId = parseInt(item.surahId, 10);
-        const downloadId = `${item.reciterId}-${surahId}`;
+        // Generate download ID with rewayatId if provided for proper tracking
+        const downloadId = item.rewayatId
+          ? `${item.reciterId}-${surahId}-${item.rewayatId}`
+          : `${item.reciterId}-${surahId}`;
 
-        // Skip if already downloading
-        if (isDownloading(item.reciterId, item.surahId)) {
+        // Skip if already downloading - use rewayat-aware check if rewayatId is provided
+        const isCurrentlyDownloading = item.rewayatId
+          ? isDownloadingWithRewayat(
+              item.reciterId,
+              item.surahId,
+              item.rewayatId,
+            )
+          : isDownloading(item.reciterId, item.surahId);
+
+        if (isCurrentlyDownloading) {
           return;
         }
 
@@ -189,7 +240,10 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
             progressValue => {
               // Throttle progress updates to prevent UI blocking
               const now = Date.now();
-              if (now - lastProgressUpdateRef.current < progressUpdateThrottle) {
+              if (
+                now - lastProgressUpdateRef.current <
+                progressUpdateThrottle
+              ) {
                 return;
               }
               lastProgressUpdateRef.current = now;
@@ -198,16 +252,16 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
               const itemProgress = progressValue / itemsToDownload.length;
               const completedProgress = index / itemsToDownload.length;
               const overallProgress = completedProgress + itemProgress;
-              
+
               // Update individual item progress (lightweight, store-only)
               setDownloadProgress(downloadId, progressValue);
-              
+
               const newProgress = {
                 current: index + 1,
                 total: itemsToDownload.length,
                 percentage: Math.min(overallProgress * 100, 99),
               };
-              
+
               // ONLY update persistent store - let React subscription handle UI updates
               // This prevents blocking when component is unmounted
               // Use setTimeout to ensure this doesn't block the download callback
@@ -242,17 +296,14 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
             total: itemsToDownload.length,
             percentage: ((index + 1) / itemsToDownload.length) * 100,
           };
-          
+
           // ONLY update persistent store - React subscription will update UI
           // Use setTimeout to prevent blocking
           setTimeout(() => {
             setPlaylistDownloadProgress(playlistId, newProgress);
           }, 0);
         } catch (error) {
-          console.error(
-            `Failed to download surah ${surahId}:`,
-            error,
-          );
+          console.error(`Failed to download surah ${surahId}:`, error);
           clearDownloading(downloadId);
         }
       };
@@ -279,7 +330,7 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
           total: itemsToDownload.length,
           percentage: 100,
         };
-        
+
         // Update store asynchronously to prevent blocking
         setTimeout(() => {
           setPlaylistDownloadProgress(playlistId, finalProgress);
@@ -329,6 +380,10 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
     setDownloadProgress,
     addDownload,
     setPlaylistDownloadProgress,
+    isDownloaded,
+    isDownloadedWithRewayat,
+    isDownloading,
+    isDownloadingWithRewayat,
   ]);
 
   const options = [
@@ -340,11 +395,15 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
       disabled: false,
     },
     {
-      label: 'Download Playlist',
+      label: downloadState.allDownloaded ? 'Downloaded' : 'Download Playlist',
       icon: 'download',
       onPress: handleDownloadPlaylist,
       destructive: false,
-      disabled: isDownloadingPlaylist,
+      disabled:
+        isDownloadingPlaylist ||
+        downloadState.hasNoTracks ||
+        downloadState.allDownloaded,
+      isDownloadOption: true,
     },
     {
       label: 'Delete Playlist',
@@ -420,12 +479,33 @@ export const PlaylistContextMenu: React.FC<PlaylistContextMenuProps> = ({
               onPress={option.onPress}
               disabled={option.disabled}
               activeOpacity={option.disabled ? 1 : 0.7}>
-              {isDownloadingPlaylist && option.label === 'Download Playlist' ? (
+              {isDownloadingPlaylist && option.isDownloadOption ? (
                 <ActivityIndicator
                   size="small"
                   color={theme.colors.primary}
                   style={styles.downloadIcon}
                 />
+              ) : option.isDownloadOption ? (
+                downloadState.allDownloaded && !downloadState.hasNoTracks ? (
+                  <CheckIcon
+                    color={
+                      option.disabled
+                        ? theme.colors.textSecondary
+                        : theme.colors.text
+                    }
+                    size={moderateScale(20)}
+                  />
+                ) : (
+                  <Ionicons
+                    name="arrow-down"
+                    size={moderateScale(20)}
+                    color={
+                      option.disabled
+                        ? theme.colors.textSecondary
+                        : theme.colors.text
+                    }
+                  />
+                )
               ) : (
                 <Icon
                   name={option.icon}

--- a/components/modals/SurahOptionsModal.tsx
+++ b/components/modals/SurahOptionsModal.tsx
@@ -20,12 +20,13 @@ import RenderHtml, {
   RenderHTMLProps,
   defaultSystemFonts,
 } from 'react-native-render-html';
-import {CheckIcon, DownloadIcon} from '@/components/Icons';
+import {CheckIcon} from '@/components/Icons';
 import {useDownload} from '@/services/player/store/downloadStore';
 import {downloadSurah} from '@/services/downloadService';
 import {SelectPlaylistModal} from './SelectPlaylistModal';
 import Color from 'color';
 import {CircularProgress} from '@/components/CircularProgress';
+import {Ionicons} from '@expo/vector-icons';
 
 interface SurahOptionsModalProps {
   bottomSheetRef: React.RefObject<BottomSheet>;
@@ -138,6 +139,7 @@ export const SurahOptionsModal: React.FC<SurahOptionsModalProps> = ({
     isDownloaded,
     isDownloadedWithRewayat,
     isDownloading,
+    isDownloadingWithRewayat,
     setDownloading,
     addDownload,
     clearDownloading,
@@ -165,13 +167,21 @@ export const SurahOptionsModal: React.FC<SurahOptionsModalProps> = ({
       return;
     }
 
-    if (isDownloading(reciterId, surah.id.toString())) {
+    // Check if downloading - use rewayat-aware check if rewayatId is provided
+    const isCurrentlyDownloading = rewayatId
+      ? isDownloadingWithRewayat(reciterId, surah.id.toString(), rewayatId)
+      : isDownloading(reciterId, surah.id.toString());
+
+    if (isCurrentlyDownloading) {
       console.log('Track is already downloading');
       return;
     }
 
     try {
-      const downloadId = `${reciterId}-${surah.id}`;
+      // Generate download ID with rewayatId if provided for proper tracking
+      const downloadId = rewayatId
+        ? `${reciterId}-${surah.id}-${rewayatId}`
+        : `${reciterId}-${surah.id}`;
       setDownloading(downloadId);
 
       const downloadResult = await downloadSurah(
@@ -196,7 +206,10 @@ export const SurahOptionsModal: React.FC<SurahOptionsModalProps> = ({
       clearDownloading(downloadId);
     } catch (error) {
       console.error('Download failed:', error);
-      clearDownloading(`${reciterId}-${surah.id}`);
+      const downloadId = rewayatId
+        ? `${reciterId}-${surah.id}-${rewayatId}`
+        : `${reciterId}-${surah.id}`;
+      clearDownloading(downloadId);
     }
   }, [
     reciterId,
@@ -204,6 +217,7 @@ export const SurahOptionsModal: React.FC<SurahOptionsModalProps> = ({
     rewayatId,
     isTrackDownloaded,
     isDownloading,
+    isDownloadingWithRewayat,
     setDownloading,
     addDownload,
     clearDownloading,
@@ -290,7 +304,15 @@ export const SurahOptionsModal: React.FC<SurahOptionsModalProps> = ({
                 onPressIn={() => setPressedOption('download')}
                 onPressOut={() => setPressedOption(null)}
                 activeOpacity={1}>
-                {isDownloading(reciterId || '', surah.id.toString()) ? (
+                {(
+                  rewayatId
+                    ? isDownloadingWithRewayat(
+                        reciterId || '',
+                        surah.id.toString(),
+                        rewayatId,
+                      )
+                    : isDownloading(reciterId || '', surah.id.toString())
+                ) ? (
                   <CircularProgress
                     progress={downloadProgress}
                     size={moderateScale(20)}
@@ -303,13 +325,22 @@ export const SurahOptionsModal: React.FC<SurahOptionsModalProps> = ({
                     size={moderateScale(20)}
                   />
                 ) : (
-                  <DownloadIcon
-                    color={theme.colors.text}
+                  <Ionicons
+                    name="arrow-down"
                     size={moderateScale(20)}
+                    color={theme.colors.text}
                   />
                 )}
                 <Text style={[styles.optionText]}>
-                  {isDownloading(reciterId || '', surah.id.toString())
+                  {(
+                    rewayatId
+                      ? isDownloadingWithRewayat(
+                          reciterId || '',
+                          surah.id.toString(),
+                          rewayatId,
+                        )
+                      : isDownloading(reciterId || '', surah.id.toString())
+                  )
                     ? `Downloading ${Math.round(downloadProgress * 100)}%`
                     : isTrackDownloaded
                       ? 'Downloaded'

--- a/components/player/PlayerOptionsModal.tsx
+++ b/components/player/PlayerOptionsModal.tsx
@@ -18,18 +18,14 @@ import RenderHtml, {
   RenderHTMLProps,
   defaultSystemFonts,
 } from 'react-native-render-html';
-import {
-  CheckIcon,
-  DownloadIcon,
-  ProfileIcon,
-  HeartIcon,
-} from '@/components/Icons';
+import {CheckIcon, ProfileIcon, HeartIcon} from '@/components/Icons';
 import {useDownload} from '@/services/player/store/downloadStore';
 import {downloadSurah} from '@/services/downloadService';
 import {SelectPlaylistModal} from '@/components/modals/SelectPlaylistModal';
 import {useLoved} from '@/hooks/useLoved';
 import Color from 'color';
 import {CircularProgress} from '@/components/CircularProgress';
+import {Ionicons} from '@expo/vector-icons';
 
 interface PlayerOptionsModalProps {
   bottomSheetRef: React.RefObject<BottomSheet>;
@@ -125,6 +121,7 @@ export const PlayerOptionsModal: React.FC<PlayerOptionsModalProps> = ({
     isDownloaded,
     isDownloadedWithRewayat,
     isDownloading,
+    isDownloadingWithRewayat,
     setDownloading,
     addDownload,
     clearDownloading,
@@ -145,13 +142,21 @@ export const PlayerOptionsModal: React.FC<PlayerOptionsModalProps> = ({
       return;
     }
 
-    if (isDownloading(reciterId, surah.id.toString())) {
+    // Check if downloading - use rewayat-aware check if rewayatId is provided
+    const isCurrentlyDownloading = rewayatId
+      ? isDownloadingWithRewayat(reciterId, surah.id.toString(), rewayatId)
+      : isDownloading(reciterId, surah.id.toString());
+
+    if (isCurrentlyDownloading) {
       console.log('Track is already downloading');
       return;
     }
 
     try {
-      const downloadId = `${reciterId}-${surah.id}`;
+      // Generate download ID with rewayatId if provided for proper tracking
+      const downloadId = rewayatId
+        ? `${reciterId}-${surah.id}-${rewayatId}`
+        : `${reciterId}-${surah.id}`;
       setDownloading(downloadId);
 
       const downloadResult = await downloadSurah(
@@ -176,7 +181,10 @@ export const PlayerOptionsModal: React.FC<PlayerOptionsModalProps> = ({
       clearDownloading(downloadId);
     } catch (error) {
       console.error('Download failed:', error);
-      clearDownloading(`${reciterId}-${surah.id}`);
+      const downloadId = rewayatId
+        ? `${reciterId}-${surah.id}-${rewayatId}`
+        : `${reciterId}-${surah.id}`;
+      clearDownloading(downloadId);
     }
   }, [
     reciterId,
@@ -184,6 +192,7 @@ export const PlayerOptionsModal: React.FC<PlayerOptionsModalProps> = ({
     rewayatId,
     isTrackDownloaded,
     isDownloading,
+    isDownloadingWithRewayat,
     setDownloading,
     addDownload,
     clearDownloading,
@@ -253,7 +262,15 @@ export const PlayerOptionsModal: React.FC<PlayerOptionsModalProps> = ({
                 onPressIn={() => setPressedOption('download')}
                 onPressOut={() => setPressedOption(null)}
                 activeOpacity={1}>
-                {isDownloading(reciterId, surah.id.toString()) ? (
+                {(
+                  rewayatId
+                    ? isDownloadingWithRewayat(
+                        reciterId,
+                        surah.id.toString(),
+                        rewayatId,
+                      )
+                    : isDownloading(reciterId, surah.id.toString())
+                ) ? (
                   <CircularProgress
                     progress={downloadProgress}
                     size={moderateScale(20)}
@@ -266,13 +283,22 @@ export const PlayerOptionsModal: React.FC<PlayerOptionsModalProps> = ({
                     size={moderateScale(20)}
                   />
                 ) : (
-                  <DownloadIcon
-                    color={theme.colors.text}
+                  <Ionicons
+                    name="arrow-down"
                     size={moderateScale(20)}
+                    color={theme.colors.text}
                   />
                 )}
                 <Text style={[styles.optionText]}>
-                  {isDownloading(reciterId, surah.id.toString())
+                  {(
+                    rewayatId
+                      ? isDownloadingWithRewayat(
+                          reciterId,
+                          surah.id.toString(),
+                          rewayatId,
+                        )
+                      : isDownloading(reciterId, surah.id.toString())
+                  )
                     ? `Downloading ${Math.round(downloadProgress * 100)}%`
                     : isTrackDownloaded
                       ? 'Downloaded'

--- a/components/playlist-detail/LovedHeader.tsx
+++ b/components/playlist-detail/LovedHeader.tsx
@@ -7,7 +7,8 @@ import {Icon} from '@rneui/themed';
 import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {Theme} from '@/utils/themeUtils';
-import {PlayIcon, ShuffleIcon, DownloadIcon, HeartIcon} from '@/components/Icons';
+import {PlayIcon, ShuffleIcon, HeartIcon, CheckIcon} from '@/components/Icons';
+import {Ionicons} from '@expo/vector-icons';
 import Color from 'color';
 import Animated, {
   useSharedValue,
@@ -26,6 +27,8 @@ interface LovedHeaderProps {
   onShufflePress: () => void;
   onDownloadPress: () => void;
   theme: Theme;
+  allDownloaded: boolean;
+  hasNoTracks: boolean;
 }
 
 export const LovedHeader: React.FC<LovedHeaderProps> = ({
@@ -36,6 +39,8 @@ export const LovedHeader: React.FC<LovedHeaderProps> = ({
   onShufflePress,
   onDownloadPress,
   theme,
+  allDownloaded,
+  hasNoTracks,
 }) => {
   const insets = useSafeAreaInsets();
   const router = useRouter();
@@ -122,11 +127,13 @@ export const LovedHeader: React.FC<LovedHeaderProps> = ({
                     .toString(),
                 },
               ]}>
-              <HeartIcon
-                color="white"
-                size={moderateScale(30)}
-                filled={true}
-              />
+              <View style={{marginTop: moderateScale(6)}}>
+                <HeartIcon
+                  color="white"
+                  size={moderateScale(30)}
+                  filled={true}
+                />
+              </View>
             </View>
           </View>
 
@@ -142,11 +149,35 @@ export const LovedHeader: React.FC<LovedHeaderProps> = ({
           {/* Download button on the left */}
           <AnimatedTouchableOpacity
             activeOpacity={0.7}
-            style={[styles.downloadButton, downloadAnimatedStyle]}
-            onPress={onDownloadPress}
-            onPressIn={() => handlePressIn('download')}
-            onPressOut={() => handlePressOut('download')}>
-            <DownloadIcon color={theme.colors.text} size={moderateScale(20)} />
+            style={[
+              styles.downloadButton,
+              downloadAnimatedStyle,
+              hasNoTracks && styles.disabledButton,
+            ]}
+            onPress={hasNoTracks ? undefined : onDownloadPress}
+            onPressIn={
+              hasNoTracks ? undefined : () => handlePressIn('download')
+            }
+            onPressOut={
+              hasNoTracks ? undefined : () => handlePressOut('download')
+            }
+            disabled={hasNoTracks}>
+            {allDownloaded && !hasNoTracks ? (
+              <CheckIcon
+                color={
+                  hasNoTracks ? theme.colors.textSecondary : theme.colors.text
+                }
+                size={moderateScale(20)}
+              />
+            ) : (
+              <Ionicons
+                name="arrow-down"
+                size={moderateScale(20)}
+                color={
+                  hasNoTracks ? theme.colors.textSecondary : theme.colors.text
+                }
+              />
+            )}
           </AnimatedTouchableOpacity>
 
           {/* Right side buttons */}
@@ -285,5 +316,7 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
     playIconContainer: {
       paddingLeft: moderateScale(4),
     },
+    disabledButton: {
+      opacity: 0.4,
+    },
   });
-

--- a/components/playlist-detail/PlaylistDetail.tsx
+++ b/components/playlist-detail/PlaylistDetail.tsx
@@ -1,5 +1,11 @@
 import React, {useState, useEffect, useCallback, useRef} from 'react';
-import {View, Text, TouchableOpacity, StyleSheet} from 'react-native';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  StatusBar,
+} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {TrackItem} from '@/components/TrackItem';
 import {usePlaylists} from '@/hooks/usePlaylists';
@@ -464,6 +470,7 @@ const PlaylistDetail: React.FC<PlaylistDetailProps> = ({id}) => {
 
   return (
     <View style={styles.container}>
+      <StatusBar barStyle="light-content" />
       <DraggableFlatList
         data={playlistData}
         renderItem={renderItem}

--- a/components/playlist-detail/index.ts
+++ b/components/playlist-detail/index.ts
@@ -1,2 +1,3 @@
 export {default} from './PlaylistDetail';
 export {PlaylistHeader} from './PlaylistHeader';
+

--- a/hooks/useCollectionDownloadState.ts
+++ b/hooks/useCollectionDownloadState.ts
@@ -1,0 +1,80 @@
+import {useMemo} from 'react';
+import {useDownload} from '@/services/player/store/downloadStore';
+
+interface CollectionItem {
+  reciter: {id: string} | null;
+  surah: {id: number} | null;
+  track: {
+    reciterId: string;
+    surahId: string;
+    rewayatId?: string;
+  };
+}
+
+interface DownloadState {
+  allDownloaded: boolean;
+  hasNoTracks: boolean;
+  totalTracks: number;
+  downloadedCount: number;
+}
+
+/**
+ * Custom hook to calculate download state for a collection of tracks
+ * Abstracts the business logic from UI components
+ *
+ * @param items - Array of collection items (loved tracks, playlist items, etc.)
+ * @returns Download state including whether all tracks are downloaded, if collection is empty, and counts
+ */
+export function useCollectionDownloadState(
+  items: CollectionItem[],
+): DownloadState {
+  const {isDownloaded, isDownloadedWithRewayat} = useDownload();
+
+  return useMemo(() => {
+    // Empty collection
+    if (items.length === 0) {
+      return {
+        allDownloaded: false,
+        hasNoTracks: true,
+        totalTracks: 0,
+        downloadedCount: 0,
+      };
+    }
+
+    // Count valid tracks and downloaded tracks
+    let validTrackCount = 0;
+    let downloadedCount = 0;
+
+    items.forEach(item => {
+      // Skip invalid items
+      if (!item.reciter || !item.surah) return;
+
+      validTrackCount++;
+
+      // Check if downloaded (with or without rewayatId)
+      const isTrackDownloaded = item.track.rewayatId
+        ? isDownloadedWithRewayat(
+            item.track.reciterId,
+            item.track.surahId,
+            item.track.rewayatId,
+          )
+        : isDownloaded(item.track.reciterId, item.track.surahId);
+
+      if (isTrackDownloaded) {
+        downloadedCount++;
+      }
+    });
+
+    // All tracks are downloaded if downloaded count equals valid track count
+    const allDownloaded =
+      validTrackCount > 0 && downloadedCount === validTrackCount;
+
+    return {
+      allDownloaded,
+      hasNoTracks: validTrackCount === 0,
+      totalTracks: validTrackCount,
+      downloadedCount,
+    };
+  }, [items, isDownloaded, isDownloadedWithRewayat]);
+}
+

--- a/services/AppInitializer.ts
+++ b/services/AppInitializer.ts
@@ -241,3 +241,4 @@ appInitializer.registerService({
  *   },
  * });
  */
+

--- a/services/player/store/downloadStore.ts
+++ b/services/player/store/downloadStore.ts
@@ -104,6 +104,11 @@ interface DownloadStoreState {
     rewayatId: string,
   ) => boolean;
   isDownloading: (reciterId: string, surahId: string) => boolean;
+  isDownloadingWithRewayat: (
+    reciterId: string,
+    surahId: string,
+    rewayatId: string,
+  ) => boolean;
   getDownload: (
     reciterId: string,
     surahId: string,
@@ -295,6 +300,16 @@ export const useDownloadStore = create<DownloadStoreState>()(
         return downloading.includes(id);
       },
 
+      isDownloadingWithRewayat: (
+        reciterId: string,
+        surahId: string,
+        rewayatId: string,
+      ) => {
+        const {downloading} = get();
+        const id = `${reciterId}-${surahId}-${rewayatId}`;
+        return downloading.includes(id);
+      },
+
       getDownload: (reciterId: string, surahId: string) => {
         const {downloads} = get();
         return downloads.find(
@@ -405,6 +420,7 @@ export const useDownload = () => {
     isDownloaded: store.isDownloaded,
     isDownloadedWithRewayat: store.isDownloadedWithRewayat,
     isDownloading: store.isDownloading,
+    isDownloadingWithRewayat: store.isDownloadingWithRewayat,
     getDownload: store.getDownload,
     setDownloading: store.setDownloading,
     clearDownloading: store.clearDownloading,


### PR DESCRIPTION
- Add download progress and status indicators to TrackItem and TrackCard
- Extend isDownloading to handle rewayat differences (add isDownloadingWithRewayat)
- Create useCollectionDownloadState hook to abstract download state logic
- Update download icons to use consistent arrow-down/check pattern across app
- Add smart download state to LovedHeader (shows check when all downloaded, arrow when not, disabled when empty)
- Extend same logic to PlaylistContextMenu
- Add white status bars to loved and playlist detail screens
- Fix heart icon vertical centering in LovedHeader
- Update all download IDs to include rewayatId for proper tracking

Components updated:
- SurahItem, TrackItem, TrackCard: Added download indicators
- SurahOptionsModal, PlayerOptionsModal: Changed to arrow-down icon
- LovedHeader: Added allDownloaded/hasNoTracks state management
- PlaylistContextMenu: Added download state indicators
- PlaylistDetail, loved screen: Added white status bars
- downloadStore: Added isDownloadingWithRewayat function

New files:
- hooks/useCollectionDownloadState.ts: Reusable hook for download state calculation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds unified download indicators with progress and rewayat-aware tracking, plus collection-wide download state and related UI updates.
> 
> - **Download infrastructure**:
>   - Add `isDownloadingWithRewayat` and propagate rewayat-aware download IDs (`reciterId-surahId-rewayatId`) in `services/player/store/downloadStore` and all callers.
>   - Expose/store throttled progress updates; playlist download progress persisted and surfaced.
> - **New hook**:
>   - `hooks/useCollectionDownloadState`: computes `allDownloaded`/`hasNoTracks` for collections.
> - **Collection screens**:
>   - Loved screen (`app/(tabs)/(c.collection)/collection/loved.tsx`): rewayat-aware bulk download, throttled progress, and header wired to collection download state; add light `StatusBar`.
>   - Playlist detail (`components/playlist-detail/PlaylistDetail.tsx`): add light `StatusBar`.
> - **UI components**:
>   - `TrackItem`, `TrackCard`, `SurahItem`: show inline download progress or downloaded icon; handle rewayat-aware downloading; minor layout tweaks (info rows, border radius).
>   - `playlist-detail/LovedHeader`: download button shows check when all downloaded, arrow otherwise; disabled when empty; heart icon vertically centered.
> - **Modals**:
>   - `SurahOptionsModal`, `PlayerOptionsModal`: switch to arrow-down icon; rewayat-aware download checks/IDs; show circular progress.
>   - `PlaylistContextMenu`: integrates collection download state, shows progress, disables or marks as downloaded when applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b7216fa76713f4b213b2d825aa16a7921f74710. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->