### PR TITLE
Fix: Handle randomReciter selection and improve SurahCard icons

### DIFF
--- a/app/(tabs)/(a.home)/browse-all-surahs.tsx
+++ b/app/(tabs)/(a.home)/browse-all-surahs.tsx
@@ -19,6 +19,7 @@ import {useSettings} from '@/hooks/useSettings';
 import {useReciterStore} from '@/store/reciterStore';
 import {useModal} from '@/components/providers/ModalProvider';
 import {GRADIENT_COLORS} from '@/utils/gradientColors';
+import {useReciterSelection} from '@/hooks/useReciterSelection';
 
 // Define types for clarity, matching the ones in useSettings
 type ViewMode = 'card' | 'list';
@@ -113,6 +114,7 @@ export default function BrowseAllSurahsScreen() {
   const {askEveryTime, defaultReciterSelection} = useSettings();
   const defaultReciter = useReciterStore(state => state.defaultReciter);
   const {showSelectReciter} = useModal();
+  const {playWithReciter, playWithRandomReciter} = useReciterSelection();
   // Retrieve persisted settings
   const browseViewModeSetting = useSettings(state => state.browseViewMode);
   const setBrowseViewModeSetting = useSettings(
@@ -194,13 +196,19 @@ export default function BrowseAllSurahsScreen() {
           break;
         case 'useDefault':
           if (defaultReciter) {
-            router.push({
-              pathname: '/player',
-              params: {reciterImageUrl: defaultReciter.image_url},
-            });
+            playWithReciter(defaultReciter, surah.id.toString()).catch(
+              error => {
+                console.error('Error playing with default reciter:', error);
+              },
+            );
           } else {
             showSelectReciter(surah.id.toString(), 'home');
           }
+          break;
+        case 'randomReciter':
+          playWithRandomReciter(surah.id.toString()).catch(error => {
+            console.error('Error playing with random reciter:', error);
+          });
           break;
         default:
           showSelectReciter(surah.id.toString(), 'home');
@@ -212,6 +220,8 @@ export default function BrowseAllSurahsScreen() {
       defaultReciter,
       router,
       showSelectReciter,
+      playWithReciter,
+      playWithRandomReciter,
     ],
   );
 

--- a/app/(tabs)/(a.home)/index.tsx
+++ b/app/(tabs)/(a.home)/index.tsx
@@ -25,6 +25,7 @@ import Animated from 'react-native-reanimated';
 import {Theme} from '@/utils/themeUtils';
 import {EdgeInsets} from 'react-native-safe-area-context';
 import {useModal} from '@/components/providers/ModalProvider';
+import {useReciterSelection} from '@/hooks/useReciterSelection';
 
 interface HeaderProps {
   activeView: 'Reciters' | 'Surahs';
@@ -288,6 +289,7 @@ function HomeScreen() {
   const {showSelectReciter} = useModal();
   const {askEveryTime, defaultReciterSelection} = useSettings();
   const defaultReciter = useReciterStore(state => state.defaultReciter);
+  const {playWithReciter, playWithRandomReciter} = useReciterSelection();
 
   const handleSurahPress = useCallback(
     (surah: Surah) => {
@@ -314,13 +316,17 @@ function HomeScreen() {
           break;
         case 'useDefault':
           if (defaultReciter) {
-            router.push({
-              pathname: '/player',
-              params: {reciterImageUrl: defaultReciter.image_url},
+            playWithReciter(defaultReciter, surah.id.toString()).catch(error => {
+              console.error('Error playing with default reciter:', error);
             });
           } else {
             showSelectReciter(surah.id.toString(), 'home');
           }
+          break;
+        case 'randomReciter':
+          playWithRandomReciter(surah.id.toString()).catch(error => {
+            console.error('Error playing with random reciter:', error);
+          });
           break;
         default:
           showSelectReciter(surah.id.toString(), 'home');
@@ -332,6 +338,8 @@ function HomeScreen() {
       defaultReciterSelection,
       defaultReciter,
       showSelectReciter,
+      playWithReciter,
+      playWithRandomReciter,
     ],
   );
 

--- a/components/cards/SurahCard.tsx
+++ b/components/cards/SurahCard.tsx
@@ -13,13 +13,9 @@ import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {surahGlyphMap} from '@/utils/surahGlyphMap';
 import {LinearGradient} from 'expo-linear-gradient';
 import Color from 'color';
-import {
-  MakkahIcon,
-  MadinahIcon,
-  HeartIcon,
-  DownloadIcon,
-} from '@/components/Icons';
+import {MakkahIcon, MadinahIcon, HeartIcon} from '@/components/Icons';
 import {Icon} from '@rneui/themed';
+import {Ionicons} from '@expo/vector-icons';
 import Animated, {
   useAnimatedStyle,
   withSpring,
@@ -244,7 +240,10 @@ export const SurahCard: React.FC<SurahCardProps> = ({
       bottom: verticalScale(5),
       left: 0,
       right: 0,
+      flexDirection: 'row',
       alignItems: 'center',
+      justifyContent: 'center',
+      gap: moderateScale(4),
     },
     optionsButton: {
       position: 'absolute',
@@ -349,10 +348,10 @@ export const SurahCard: React.FC<SurahCardProps> = ({
             />
           )}
           {isDownloaded && (
-            <DownloadIcon
+            <Ionicons
+              name="arrow-down-circle"
               size={moderateScale(14)}
-              color={theme.colors.text}
-              filled={true}
+              color={theme.colors.textSecondary}
             />
           )}
         </View>

--- a/components/playlist-detail/index.ts
+++ b/components/playlist-detail/index.ts
@@ -1,3 +1,2 @@
 export {default} from './PlaylistDetail';
 export {PlaylistHeader} from './PlaylistHeader';
-

--- a/components/search/SearchView.tsx
+++ b/components/search/SearchView.tsx
@@ -30,6 +30,7 @@ import Color from 'color';
 import Animated, {FadeIn, FadeOut} from 'react-native-reanimated';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useModal} from '@/components/providers/ModalProvider';
+import {useReciterSelection} from '@/hooks/useReciterSelection';
 
 const RECENT_SEARCHES_KEY = 'recentSearches';
 const MAX_RECENT_SEARCHES = 10;
@@ -117,6 +118,7 @@ export function SearchView({onClose, visible}: SearchViewProps) {
   const defaultReciter = useReciterStore(state => state.defaultReciter);
   const insets = useSafeAreaInsets();
   const {showSelectReciter} = useModal();
+  const {playWithReciter, playWithRandomReciter} = useReciterSelection();
 
   // Clear query when closing
   useEffect(() => {
@@ -285,13 +287,19 @@ export function SearchView({onClose, visible}: SearchViewProps) {
             break;
           case 'useDefault':
             if (defaultReciter) {
-              router.push({
-                pathname: '/player',
-                params: {reciterImageUrl: defaultReciter.image_url},
-              });
+              playWithReciter(defaultReciter, surah.id.toString()).catch(
+                error => {
+                  console.error('Error playing with default reciter:', error);
+                },
+              );
             } else {
               showSelectReciter(surah.id.toString(), 'search');
             }
+            break;
+          case 'randomReciter':
+            playWithRandomReciter(surah.id.toString()).catch(error => {
+              console.error('Error playing with random reciter:', error);
+            });
             break;
           default:
             showSelectReciter(surah.id.toString(), 'search');
@@ -306,6 +314,8 @@ export function SearchView({onClose, visible}: SearchViewProps) {
       defaultReciterSelection,
       defaultReciter,
       showSelectReciter,
+      playWithReciter,
+      playWithRandomReciter,
     ],
   );
 

--- a/services/AppInitializer.ts
+++ b/services/AppInitializer.ts
@@ -241,4 +241,3 @@ appInitializer.registerService({
  *   },
  * });
  */
-


### PR DESCRIPTION
- Add missing 'randomReciter' case handler in surah selection for home, search, and browse-all-surahs screens
- Fix routing issue where selecting random reciter option would fall through to default case
- Update 'useDefault' case to use playWithReciter for consistent behavior
- Improve SurahCard icon layout: display loved and downloaded icons side by side
- Replace DownloadIcon with Ionicons arrow-down-circle for consistency with TrackCard
- Update download icon color to textSecondary to match SurahItem styling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds random-reciter handling and switches default playback to use useReciterSelection across home/search/browse; updates SurahCard icons layout and download icon.
> 
> - **Playback/Selection**:
>   - Handle `randomReciter` action in `app/(tabs)/(a.home)/index.tsx`, `app/(tabs)/(a.home)/browse-all-surahs.tsx`, and `components/search/SearchView.tsx`.
>   - Replace `router.push('/player')` in `useDefault` path with `playWithReciter`; add error handling and dependencies.
>   - Integrate `useReciterSelection` for `playWithReciter` and `playWithRandomReciter` across screens.
> - **UI**:
>   - `components/cards/SurahCard.tsx`: show loved and downloaded icons side-by-side; replace `DownloadIcon` with Ionicons `arrow-down-circle` using `textSecondary` color.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 338de296e6f3b1e72aeee9f2288f62755017888e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->