### PR TITLE
feat: enhance collection screen with rewayat-aware downloads and UI i…

### DIFF
--- a/app/(tabs)/(a.home)/index.tsx
+++ b/app/(tabs)/(a.home)/index.tsx
@@ -316,9 +316,11 @@ function HomeScreen() {
           break;
         case 'useDefault':
           if (defaultReciter) {
-            playWithReciter(defaultReciter, surah.id.toString()).catch(error => {
-              console.error('Error playing with default reciter:', error);
-            });
+            playWithReciter(defaultReciter, surah.id.toString()).catch(
+              error => {
+                console.error('Error playing with default reciter:', error);
+              },
+            );
           } else {
             showSelectReciter(surah.id.toString(), 'home');
           }

--- a/app/(tabs)/(a.home)/settings/index.tsx
+++ b/app/(tabs)/(a.home)/settings/index.tsx
@@ -237,7 +237,8 @@ export default function SettingsScreen() {
                   },
                   index === 0 && styles.firstThemeOption,
                   index === themeOptions.length - 1 && styles.lastThemeOption,
-                  pressedOption === `theme-${option.value}` && styles.optionPressed,
+                  pressedOption === `theme-${option.value}` &&
+                    styles.optionPressed,
                 ]}
                 onPress={() => setThemeMode(option.value)}
                 onPressIn={() => setPressedOption(`theme-${option.value}`)}
@@ -285,7 +286,8 @@ export default function SettingsScreen() {
                   key={color}
                   style={[
                     styles.colorOptionContainer,
-                    pressedOption === `color-${color}` && styles.colorOptionPressed,
+                    pressedOption === `color-${color}` &&
+                      styles.colorOptionPressed,
                   ]}
                   onPress={() => setPrimaryColor(color as PrimaryColor)}
                   onPressIn={() => setPressedOption(`color-${color}`)}
@@ -329,10 +331,8 @@ export default function SettingsScreen() {
           </ScrollView>
         </View>
 
-        {settingsItems.map((section, sectionIndex) => (
-          <View
-            key={section.section}
-            style={styles.section}>
+        {settingsItems.map(section => (
+          <View key={section.section} style={styles.section}>
             <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
               {section.section}
             </Text>
@@ -344,7 +344,8 @@ export default function SettingsScreen() {
                     styles.settingsItem,
                     styles.settingsItemCard,
                     itemIndex > 0 && styles.settingsItemMarginTop,
-                    pressedOption === `setting-${item.type}` && styles.optionPressed,
+                    pressedOption === `setting-${item.type}` &&
+                      styles.optionPressed,
                   ]}
                   onPress={() => handleSettingPress(item.type)}
                   onPressIn={() => setPressedOption(`setting-${item.type}`)}

--- a/app/(tabs)/(c.collection)/collection/downloads.tsx
+++ b/app/(tabs)/(c.collection)/collection/downloads.tsx
@@ -177,7 +177,11 @@ export default function DownloadsScreen() {
 
   const handleRemoveDownload = useCallback(
     (download: DownloadedSurah) => {
-      removeDownload(download.reciterId, download.surahId);
+      removeDownload(
+        download.reciterId,
+        download.surahId,
+        download.rewayatId || undefined,
+      );
     },
     [removeDownload],
   );

--- a/app/(tabs)/(c.collection)/collection/reciter-downloads/[reciterId].tsx
+++ b/app/(tabs)/(c.collection)/collection/reciter-downloads/[reciterId].tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {StatusBar} from 'react-native';
+import {useLocalSearchParams} from 'expo-router';
+import {ReciterDownloadsList} from '@/components/reciter-downloads/ReciterDownloadsList';
+
+const ReciterDownloadsScreen = () => {
+  const {reciterId} = useLocalSearchParams<{reciterId: string}>();
+
+  if (!reciterId) {
+    return null;
+  }
+
+  return (
+    <>
+      <StatusBar barStyle="light-content" />
+      <ReciterDownloadsList reciterId={reciterId} />
+    </>
+  );
+};
+
+export default ReciterDownloadsScreen;

--- a/app/(tabs)/(c.collection)/index.tsx
+++ b/app/(tabs)/(c.collection)/index.tsx
@@ -25,10 +25,12 @@ import {
   ReciterItemData,
   DownloadItemData,
   TrackItemData,
+  ReciterDownloadsItemData,
 } from '@/components/collection/CollectionGrid';
 import {PlaylistItem} from '@/components/PlaylistItem';
 import {ReciterItem} from '@/components/ReciterItem';
 import {TrackItem} from '@/components/TrackItem';
+import {ReciterDownloadsListItem} from '@/components/ReciterDownloadsListItem';
 import {useDownload} from '@/services/player/store/downloadStore';
 import {usePlaylists} from '@/hooks/usePlaylists';
 import {useModal} from '@/components/providers/ModalProvider';
@@ -234,41 +236,76 @@ export default function CollectionScreen() {
       });
     }
 
-    // Add Individual Downloaded Tracks
+    // Add Downloads - grouped by reciter
     if (activeFilter === '' || activeFilter === 'downloads') {
-      downloads.forEach(download => {
-        items.push({
-          id: `download-${download.reciterId}-${download.surahId}-${download.rewayatId || 'default'}`,
-          type: 'track',
-          timestamp: download.downloadDate || 0,
-          data: {
-            reciterId: download.reciterId,
-            surahId: download.surahId,
-            rewayatId: download.rewayatId,
-            onPress: async () => {
-              try {
-                const [reciter, surah] = await Promise.all([
-                  getReciterById(download.reciterId),
-                  getSurahById(parseInt(download.surahId, 10)),
-                ]);
+      // Group downloads by reciterId
+      const downloadsByReciter = downloads.reduce(
+        (acc, download) => {
+          if (!acc[download.reciterId]) {
+            acc[download.reciterId] = [];
+          }
+          acc[download.reciterId].push(download);
+          return acc;
+        },
+        {} as Record<string, typeof downloads>,
+      );
 
-                if (reciter && surah) {
-                  const track = createDownloadedTrack(
-                    reciter,
-                    surah,
-                    download.filePath,
-                    download.rewayatId,
-                  );
-                  await updateQueue([track], 0);
-                  await play();
-                }
-              } catch (error) {
-                console.error('Error playing downloaded track:', error);
-              }
-            },
-          },
-        });
-      });
+      Object.entries(downloadsByReciter).forEach(
+        ([reciterId, reciterDownloads]) => {
+          const mostRecentTimestamp = Math.max(
+            ...reciterDownloads.map(d => d.downloadDate || 0),
+          );
+
+          if (reciterDownloads.length === 1) {
+            // Single download - show as individual track
+            const download = reciterDownloads[0];
+            items.push({
+              id: `download-${download.reciterId}-${download.surahId}-${download.rewayatId || 'default'}`,
+              type: 'track',
+              timestamp: download.downloadDate || 0,
+              data: {
+                reciterId: download.reciterId,
+                surahId: download.surahId,
+                rewayatId: download.rewayatId,
+                onPress: async () => {
+                  try {
+                    const [reciter, surah] = await Promise.all([
+                      getReciterById(download.reciterId),
+                      getSurahById(parseInt(download.surahId, 10)),
+                    ]);
+
+                    if (reciter && surah) {
+                      const track = createDownloadedTrack(
+                        reciter,
+                        surah,
+                        download.filePath,
+                        download.rewayatId,
+                      );
+                      await updateQueue([track], 0);
+                      await play();
+                    }
+                  } catch (error) {
+                    console.error('Error playing downloaded track:', error);
+                  }
+                },
+              },
+            });
+          } else {
+            // Multiple downloads from same reciter - show as stacked card
+            items.push({
+              id: `reciter-downloads-${reciterId}`,
+              type: 'reciter-downloads',
+              timestamp: mostRecentTimestamp,
+              data: {
+                reciterId,
+                downloadCount: reciterDownloads.length,
+                onPress: () =>
+                  router.push(`/collection/reciter-downloads/${reciterId}`),
+              },
+            });
+          }
+        },
+      );
     }
 
     // Sort by most recent first (descending order: highest timestamp at top)
@@ -416,6 +453,17 @@ export default function CollectionScreen() {
             rewayatId={trackData.rewayatId}
             onPress={trackData.onPress}
             onPlayPress={trackData.onPress}
+          />
+        );
+      }
+      case 'reciter-downloads': {
+        const reciterDownloadsData = item.data as ReciterDownloadsItemData;
+        return (
+          <ReciterDownloadsListItem
+            key={item.id}
+            reciterId={reciterDownloadsData.reciterId}
+            downloadCount={reciterDownloadsData.downloadCount}
+            onPress={reciterDownloadsData.onPress}
           />
         );
       }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -194,6 +194,7 @@ export default function RootLayout() {
     }
 
     prepare();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run once on mount
 
   // Setup event listeners

--- a/components/ReciterDownloadsListItem.tsx
+++ b/components/ReciterDownloadsListItem.tsx
@@ -1,0 +1,107 @@
+import React, {useEffect, useState} from 'react';
+import {View, Text, TouchableOpacity} from 'react-native';
+import {ScaledSheet, moderateScale} from 'react-native-size-matters';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import {Reciter} from '@/data/reciterData';
+import {ReciterImage} from '@/components/ReciterImage';
+import {getReciterById} from '@/services/dataService';
+
+interface ReciterDownloadsListItemProps {
+  reciterId: string;
+  downloadCount: number;
+  onPress: () => void;
+}
+
+export const ReciterDownloadsListItem: React.FC<ReciterDownloadsListItemProps> =
+  React.memo(({reciterId, downloadCount, onPress}) => {
+    const {theme} = useTheme();
+    const styles = createStyles(theme);
+    const [reciter, setReciter] = useState<Reciter | null>(null);
+
+    useEffect(() => {
+      let mounted = true;
+      const loadReciter = async () => {
+        try {
+          const data = await getReciterById(reciterId);
+          if (mounted && data) {
+            setReciter(data);
+          }
+        } catch (error) {
+          console.error('Error loading reciter:', error);
+        }
+      };
+      loadReciter();
+      return () => {
+        mounted = false;
+      };
+    }, [reciterId]);
+
+    if (!reciter) return null;
+
+    return (
+      <TouchableOpacity
+        activeOpacity={0.99}
+        style={styles.container}
+        onPress={onPress}>
+        {/* Rectangular image for downloaded reciters */}
+        <View style={styles.imageContainer}>
+          <ReciterImage
+            imageUrl={reciter.image_url || undefined}
+            reciterName={reciter.name}
+            style={styles.reciterImage}
+            profileIconSize={moderateScale(20)}
+          />
+        </View>
+        <View style={styles.reciterInfo}>
+          <Text style={styles.reciterName}>{reciter.name}</Text>
+          <Text style={styles.reciterSubtitle} numberOfLines={1}>
+            Downloaded • {downloadCount}{' '}
+            {downloadCount === 1 ? 'surah' : 'surahs'}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    );
+  });
+
+ReciterDownloadsListItem.displayName = 'ReciterDownloadsListItem';
+
+const createStyles = (theme: Theme) =>
+  ScaledSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: moderateScale(8),
+      paddingHorizontal: moderateScale(18),
+    },
+    imageContainer: {
+      width: moderateScale(50),
+      height: moderateScale(50),
+      marginRight: moderateScale(12),
+      justifyContent: 'center',
+      alignItems: 'center',
+      overflow: 'hidden',
+      borderRadius: moderateScale(4), // Rectangular with rounded corners
+      borderWidth: moderateScale(1),
+      borderColor: 'transparent',
+    },
+    reciterImage: {
+      width: moderateScale(50),
+      height: moderateScale(50),
+    },
+    reciterInfo: {
+      flex: 1,
+      justifyContent: 'center',
+    },
+    reciterName: {
+      fontSize: moderateScale(14),
+      fontFamily: theme.fonts.semiBold,
+      color: theme.colors.text,
+      marginBottom: moderateScale(1),
+    },
+    reciterSubtitle: {
+      fontSize: moderateScale(12),
+      fontFamily: theme.fonts.regular,
+      color: theme.colors.textSecondary,
+    },
+  });

--- a/components/SurahItem.tsx
+++ b/components/SurahItem.tsx
@@ -37,6 +37,7 @@ interface SurahItemProps {
   enableHaptics?: boolean;
   enableAnimation?: boolean;
   rewayatId?: string;
+  rewayatName?: string;
 }
 
 // Create Animated component
@@ -53,6 +54,7 @@ export const SurahItem: React.FC<SurahItemProps> = React.memo(
     enableHaptics = false,
     enableAnimation = false,
     rewayatId,
+    rewayatName,
   }) => {
     const {theme} = useTheme();
     const styles = createStyles(theme);
@@ -80,7 +82,7 @@ export const SurahItem: React.FC<SurahItemProps> = React.memo(
 
     // Get download progress
     const downloadProgress = reciterId
-      ? getDownloadProgress(reciterId, item.id.toString())
+      ? getDownloadProgress(reciterId, item.id.toString(), rewayatId)
       : 0;
 
     // Get necessary state slices from player store
@@ -237,28 +239,38 @@ export const SurahItem: React.FC<SurahItemProps> = React.memo(
               {item.translated_name_english}
             </Text>
           </View>
-          <View
-            style={[
-              styles.locationIndicator,
-              {backgroundColor: Color(theme.colors.card).alpha(0.8).toString()},
-            ]}>
-            {revelationPlace === 'makkah' ? (
-              <MakkahIcon
-                size={moderateScale(13)}
-                color={theme.colors.textSecondary}
-                secondaryColor={Color(theme.colors.card).alpha(0.8).toString()}
-              />
-            ) : (
-              <MadinahIcon
-                size={moderateScale(13)}
-                color={theme.colors.textSecondary}
-              />
-            )}
-            <Text style={styles.locationText}>
-              {revelationPlace.charAt(0).toUpperCase() +
-                revelationPlace.slice(1)}
-            </Text>
-          </View>
+          {rewayatName ? (
+            <Text style={styles.rewayatText}>{rewayatName}</Text>
+          ) : (
+            <View
+              style={[
+                styles.locationIndicator,
+                {
+                  backgroundColor: Color(theme.colors.card)
+                    .alpha(0.8)
+                    .toString(),
+                },
+              ]}>
+              {revelationPlace === 'makkah' ? (
+                <MakkahIcon
+                  size={moderateScale(13)}
+                  color={theme.colors.textSecondary}
+                  secondaryColor={Color(theme.colors.card)
+                    .alpha(0.8)
+                    .toString()}
+                />
+              ) : (
+                <MadinahIcon
+                  size={moderateScale(13)}
+                  color={theme.colors.textSecondary}
+                />
+              )}
+              <Text style={styles.locationText}>
+                {revelationPlace.charAt(0).toUpperCase() +
+                  revelationPlace.slice(1)}
+              </Text>
+            </View>
+          )}
         </View>
         {/* Conditional Rendering: Indicator or Options Button */}
         <View style={styles.rightActionContainer}>
@@ -401,6 +413,12 @@ const createStyles = (theme: Theme) =>
       fontSize: moderateScale(9),
       fontFamily: 'Manrope-Medium',
       color: theme.colors.textSecondary,
+    },
+    rewayatText: {
+      fontSize: moderateScale(10),
+      fontFamily: theme.fonts.regular,
+      color: theme.colors.textSecondary,
+      marginTop: moderateScale(2),
     },
     rightActionContainer: {
       width: moderateScale(35),

--- a/components/TrackItem.tsx
+++ b/components/TrackItem.tsx
@@ -66,7 +66,7 @@ export const TrackItem: React.FC<TrackItemProps> = React.memo(
 
     // Get download progress
     const downloadProgress = reciterId
-      ? getDownloadProgress(reciterId, surahId)
+      ? getDownloadProgress(reciterId, surahId, rewayatId)
       : 0;
 
     // Check if this item is the currently active track
@@ -180,14 +180,14 @@ export const TrackItem: React.FC<TrackItemProps> = React.memo(
                 {isCurrentlyDownloading ? (
                   <CircularProgress
                     progress={downloadProgress}
-                    size={moderateScale(12)}
+                    size={moderateScale(13)}
                     strokeWidth={moderateScale(1.5)}
                     color={theme.colors.textSecondary}
                   />
                 ) : isDownloadedState ? (
                   <Ionicons
                     name="arrow-down-circle"
-                    size={moderateScale(12)}
+                    size={moderateScale(13)}
                     color={theme.colors.textSecondary}
                     style={styles.downloadIcon}
                   />

--- a/components/cards/ReciterDownloadsStackCard.tsx
+++ b/components/cards/ReciterDownloadsStackCard.tsx
@@ -1,0 +1,128 @@
+import React, {useEffect, useState} from 'react';
+import {Text, TouchableOpacity, View, StyleSheet} from 'react-native';
+import {useTheme} from '@/hooks/useTheme';
+import {moderateScale, verticalScale} from 'react-native-size-matters';
+import {ReciterImage} from '@/components/ReciterImage';
+import {getReciterById} from '@/services/dataService';
+import {Reciter} from '@/data/reciterData';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+} from 'react-native-reanimated';
+
+interface ReciterDownloadsStackCardProps {
+  reciterId: string;
+  downloadCount: number;
+  onPress: () => void;
+  width?: number;
+  height?: number;
+}
+
+const AnimatedTouchableOpacity =
+  Animated.createAnimatedComponent(TouchableOpacity);
+
+export const ReciterDownloadsStackCard: React.FC<
+  ReciterDownloadsStackCardProps
+> = ({reciterId, downloadCount, onPress, width, height}) => {
+  const {theme} = useTheme();
+  const [reciter, setReciter] = useState<Reciter | null>(null);
+
+  // Animation values
+  const scale = useSharedValue(1);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      transform: [{scale: scale.value}],
+    };
+  });
+
+  const handlePressIn = () => {
+    scale.value = withSpring(0.95, {
+      damping: 15,
+      stiffness: 300,
+    });
+  };
+
+  const handlePressOut = () => {
+    scale.value = withSpring(1, {
+      damping: 15,
+      stiffness: 300,
+    });
+  };
+
+  useEffect(() => {
+    let mounted = true;
+    const loadReciter = async () => {
+      try {
+        const data = await getReciterById(reciterId);
+        if (mounted && data) {
+          setReciter(data);
+        }
+      } catch (error) {
+        console.error('Error loading reciter:', error);
+      }
+    };
+    loadReciter();
+    return () => {
+      mounted = false;
+    };
+  }, [reciterId]);
+
+  // Use provided dimensions or fall back to default
+  const cardWidth = width || moderateScale(120);
+  const cardHeight = height || moderateScale(120);
+
+  const styles = StyleSheet.create({
+    container: {
+      width: cardWidth,
+    },
+    imageContainer: {
+      width: cardWidth,
+      height: cardHeight,
+      borderRadius: moderateScale(5),
+      overflow: 'hidden',
+      marginBottom: verticalScale(5),
+    },
+    reciterImage: {
+      width: '100%',
+      height: '100%',
+    },
+    name: {
+      fontSize: moderateScale(12),
+      fontFamily: 'Manrope-SemiBold',
+      color: theme.colors.text,
+      marginBottom: verticalScale(2),
+    },
+    subtitle: {
+      fontSize: moderateScale(10),
+      fontFamily: 'Manrope-Regular',
+      color: theme.colors.textSecondary,
+    },
+  });
+
+  if (!reciter) return null;
+
+  return (
+    <AnimatedTouchableOpacity
+      activeOpacity={1}
+      style={[styles.container, animatedStyle]}
+      onPress={onPress}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}>
+      <View style={styles.imageContainer}>
+        <ReciterImage
+          reciterName={reciter.name}
+          imageUrl={reciter.image_url || undefined}
+          style={styles.reciterImage}
+        />
+      </View>
+      <Text style={styles.name} numberOfLines={1}>
+        {reciter.name}
+      </Text>
+      <Text style={styles.subtitle} numberOfLines={1}>
+        Downloaded • {downloadCount} {downloadCount === 1 ? 'surah' : 'surahs'}
+      </Text>
+    </AnimatedTouchableOpacity>
+  );
+};

--- a/components/cards/SurahCard.tsx
+++ b/components/cards/SurahCard.tsx
@@ -25,6 +25,7 @@ import * as Haptics from 'expo-haptics';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {State as TrackPlayerState} from 'react-native-track-player';
 import {NowPlayingIndicator} from '@/components/NowPlayingIndicator';
+import {useDownload} from '@/services/player/store/downloadStore';
 
 interface SurahCardProps {
   id: number;
@@ -65,6 +66,17 @@ export const SurahCard: React.FC<SurahCardProps> = ({
   rewayatId,
 }) => {
   const {theme} = useTheme();
+
+  // Get download state
+  const {isDownloaded: checkIsDownloaded, isDownloadedWithRewayat} =
+    useDownload();
+
+  // Calculate actual download state - use isDownloadedWithRewayat if rewayatId is provided
+  const isActuallyDownloaded = reciterId
+    ? rewayatId
+      ? isDownloadedWithRewayat(reciterId, id.toString(), rewayatId)
+      : checkIsDownloaded(reciterId, id.toString())
+    : isDownloaded; // Fallback to prop if no reciterId
 
   // Get necessary state slices from player store
   const playbackStatus = usePlayerStore(state => state.playback.state);
@@ -347,7 +359,7 @@ export const SurahCard: React.FC<SurahCardProps> = ({
               filled={true}
             />
           )}
-          {isDownloaded && (
+          {isActuallyDownloaded && (
             <Ionicons
               name="arrow-down-circle"
               size={moderateScale(14)}

--- a/components/cards/TrackCard.tsx
+++ b/components/cards/TrackCard.tsx
@@ -64,7 +64,7 @@ export const TrackCard: React.FC<TrackCardProps> = ({
 
   // Get download progress
   const downloadProgress = reciterId
-    ? getDownloadProgress(reciterId, surahId)
+    ? getDownloadProgress(reciterId, surahId, rewayatId)
     : 0;
 
   // Check if this item is the currently active track

--- a/components/collection/CollectionGrid.tsx
+++ b/components/collection/CollectionGrid.tsx
@@ -8,6 +8,7 @@ import {CircularReciterCard} from '@/components/cards/CircularReciterCard';
 import {LovedCard} from '@/components/cards/LovedCard';
 import {DownloadCard} from '@/components/cards/DownloadCard';
 import {TrackCard} from '@/components/cards/TrackCard';
+import {ReciterDownloadsStackCard} from '@/components/cards/ReciterDownloadsStackCard';
 
 export interface PlaylistItemData {
   name: string;
@@ -40,15 +41,28 @@ export interface TrackItemData {
   onPress: () => void;
 }
 
+export interface ReciterDownloadsItemData {
+  reciterId: string;
+  downloadCount: number;
+  onPress: () => void;
+}
+
 export interface CollectionItem {
   id: string;
-  type: 'playlist' | 'loved' | 'reciter' | 'download' | 'track';
+  type:
+    | 'playlist'
+    | 'loved'
+    | 'reciter'
+    | 'download'
+    | 'track'
+    | 'reciter-downloads';
   data:
     | PlaylistItemData
     | LovedItemData
     | ReciterItemData
     | DownloadItemData
-    | TrackItemData;
+    | TrackItemData
+    | ReciterDownloadsItemData;
 }
 
 interface CollectionGridProps {
@@ -184,6 +198,19 @@ export const CollectionGrid = React.memo(
                 surahId={trackData.surahId}
                 rewayatId={trackData.rewayatId}
                 onPress={trackData.onPress}
+                width={itemDimensions.width}
+                height={itemDimensions.width}
+              />
+            );
+          }
+          case 'reciter-downloads': {
+            const reciterDownloadsData = item.data as ReciterDownloadsItemData;
+            return (
+              <ReciterDownloadsStackCard
+                key={item.id}
+                reciterId={reciterDownloadsData.reciterId}
+                downloadCount={reciterDownloadsData.downloadCount}
+                onPress={reciterDownloadsData.onPress}
                 width={itemDimensions.width}
                 height={itemDimensions.width}
               />

--- a/components/modals/SurahOptionsModal.tsx
+++ b/components/modals/SurahOptionsModal.tsx
@@ -150,6 +150,7 @@ export const SurahOptionsModal: React.FC<SurahOptionsModalProps> = ({
   const downloadProgress = getDownloadProgress(
     reciterId || '',
     surah.id.toString(),
+    rewayatId,
   );
 
   // Calculate download state - use isDownloadedWithRewayat if rewayatId is provided, otherwise use isDownloaded

--- a/components/player/v2/Modals/PlayerOptionsModal.tsx
+++ b/components/player/v2/Modals/PlayerOptionsModal.tsx
@@ -129,7 +129,11 @@ export const PlayerOptionsModal: React.FC<PlayerOptionsModalProps> = ({
     getDownloadProgress,
   } = useDownload();
 
-  const downloadProgress = getDownloadProgress(reciterId, surah.id.toString());
+  const downloadProgress = getDownloadProgress(
+    reciterId,
+    surah.id.toString(),
+    rewayatId,
+  );
 
   // Calculate download state - use isDownloadedWithRewayat if rewayatId is provided, otherwise use isDownloaded
   const isTrackDownloaded = rewayatId

--- a/components/playlist-detail/ReciterDownloadsHeader.tsx
+++ b/components/playlist-detail/ReciterDownloadsHeader.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import {View, Text, TouchableOpacity} from 'react-native';
+import {moderateScale} from 'react-native-size-matters';
+import {ScaledSheet} from 'react-native-size-matters';
+import {LinearGradient} from 'expo-linear-gradient';
+import {Icon} from '@rneui/themed';
+import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
+import {useRouter} from 'expo-router';
+import {Theme} from '@/utils/themeUtils';
+import {PlayIcon, ShuffleIcon} from '@/components/Icons';
+import {ReciterImage} from '@/components/ReciterImage';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+} from 'react-native-reanimated';
+import Color from 'color';
+
+const AnimatedTouchableOpacity =
+  Animated.createAnimatedComponent(TouchableOpacity);
+
+interface ReciterDownloadsHeaderProps {
+  reciterName: string;
+  reciterImageUrl?: string;
+  subtitle: string;
+  onPlayPress: () => void;
+  onShufflePress: () => void;
+  theme: Theme;
+}
+
+export const ReciterDownloadsHeader: React.FC<ReciterDownloadsHeaderProps> = ({
+  reciterName,
+  reciterImageUrl,
+  subtitle,
+  onPlayPress,
+  onShufflePress,
+  theme,
+}) => {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const styles = createStyles(theme, insets);
+
+  // Animation values for button press feedback
+  const shuffleScale = useSharedValue(1);
+  const playScale = useSharedValue(1);
+
+  const shuffleAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{scale: shuffleScale.value}],
+  }));
+
+  const playAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{scale: playScale.value}],
+  }));
+
+  const handlePressIn = (button: 'shuffle' | 'play') => {
+    const scale = button === 'shuffle' ? shuffleScale : playScale;
+    scale.value = withSpring(0.92, {
+      damping: 15,
+      stiffness: 300,
+    });
+  };
+
+  const handlePressOut = (button: 'shuffle' | 'play') => {
+    const scale = button === 'shuffle' ? shuffleScale : playScale;
+    scale.value = withSpring(1, {
+      damping: 15,
+      stiffness: 300,
+    });
+  };
+
+  return (
+    <View style={styles.headerContainer}>
+      <LinearGradient
+        colors={['#10B981', theme.colors.background]}
+        style={styles.gradientContainer}>
+        {/* Back Button */}
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={() => router.back()}
+          activeOpacity={0.7}>
+          <Icon
+            name="arrow-left"
+            type="feather"
+            size={moderateScale(24)}
+            color="white"
+          />
+        </TouchableOpacity>
+
+        {/* Header Content */}
+        <View style={styles.contentContainer}>
+          {/* Reciter Image */}
+          <View style={styles.reciterImageContainer}>
+            <ReciterImage
+              reciterName={reciterName}
+              imageUrl={reciterImageUrl}
+              style={styles.reciterImage}
+            />
+          </View>
+
+          {/* Title and Subtitle */}
+          <Text style={styles.title}>{reciterName}</Text>
+          <Text style={styles.subtitle}>{subtitle}</Text>
+        </View>
+      </LinearGradient>
+
+      {/* Action Buttons */}
+      <View style={styles.contentWrapper}>
+        <View style={styles.actionButtons}>
+          {/* Spacer for alignment */}
+          <View style={styles.spacer} />
+
+          {/* Right side buttons */}
+          <View style={styles.rightAlignedButtons}>
+            <AnimatedTouchableOpacity
+              activeOpacity={0.7}
+              style={[styles.circleButton, shuffleAnimatedStyle]}
+              onPress={onShufflePress}
+              onPressIn={() => handlePressIn('shuffle')}
+              onPressOut={() => handlePressOut('shuffle')}>
+              <ShuffleIcon color={theme.colors.text} size={moderateScale(20)} />
+            </AnimatedTouchableOpacity>
+            <AnimatedTouchableOpacity
+              activeOpacity={0.7}
+              style={[
+                styles.circleButton,
+                styles.playButton,
+                playAnimatedStyle,
+              ]}
+              onPress={onPlayPress}
+              onPressIn={() => handlePressIn('play')}
+              onPressOut={() => handlePressOut('play')}>
+              <View style={styles.playIconContainer}>
+                <PlayIcon
+                  color={theme.colors.background}
+                  size={moderateScale(16)}
+                />
+              </View>
+            </AnimatedTouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const createStyles = (theme: Theme, insets: EdgeInsets) =>
+  ScaledSheet.create({
+    headerContainer: {
+      width: '100%',
+      overflow: 'hidden',
+    },
+    gradientContainer: {
+      width: '100%',
+      alignItems: 'center',
+      paddingTop: insets.top + moderateScale(20),
+      paddingBottom: moderateScale(30),
+      overflow: 'hidden',
+    },
+    backButton: {
+      position: 'absolute',
+      top: insets.top + moderateScale(10),
+      left: moderateScale(15),
+      zIndex: 10,
+      padding: moderateScale(8),
+    },
+    contentContainer: {
+      alignItems: 'center',
+      paddingHorizontal: moderateScale(20),
+    },
+    reciterImageContainer: {
+      width: moderateScale(80),
+      height: moderateScale(80),
+      borderRadius: moderateScale(6),
+      overflow: 'hidden',
+      marginBottom: moderateScale(12),
+    },
+    reciterImage: {
+      width: '100%',
+      height: '100%',
+    },
+    title: {
+      fontSize: moderateScale(17),
+      fontFamily: theme.fonts.bold,
+      color: theme.colors.text,
+      textAlign: 'center',
+      marginBottom: moderateScale(8),
+      letterSpacing: -0.3,
+    },
+    subtitle: {
+      fontSize: moderateScale(12),
+      color: theme.colors.text,
+      fontFamily: theme.fonts.regular,
+      textAlign: 'center',
+      marginBottom: moderateScale(8),
+    },
+    contentWrapper: {
+      paddingHorizontal: moderateScale(16),
+    },
+    actionButtons: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingVertical: moderateScale(5),
+      paddingHorizontal: moderateScale(5),
+    },
+    spacer: {
+      width: moderateScale(40),
+    },
+    rightAlignedButtons: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: moderateScale(8),
+    },
+    circleButton: {
+      width: moderateScale(42),
+      height: moderateScale(42),
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderRadius: moderateScale(12),
+      backgroundColor: Color(theme.colors.textSecondary).alpha(0.08).toString(),
+      padding: moderateScale(8),
+    },
+    playButton: {
+      width: moderateScale(42),
+      height: moderateScale(42),
+      backgroundColor: theme.colors.text,
+    },
+    playIconContainer: {
+      paddingLeft: moderateScale(4),
+    },
+  });

--- a/components/reciter-downloads/ReciterDownloadsList.tsx
+++ b/components/reciter-downloads/ReciterDownloadsList.tsx
@@ -1,0 +1,568 @@
+import React, {useState, useEffect, useCallback, useRef, useMemo} from 'react';
+import {View, Text, TouchableOpacity, StyleSheet} from 'react-native';
+import {useTheme} from '@/hooks/useTheme';
+import {SurahItem} from '@/components/SurahItem';
+import {getReciterById, getSurahById} from '@/services/dataService';
+import {moderateScale} from 'react-native-size-matters';
+import {Icon} from '@rneui/themed';
+import {FlatList, ListRenderItem} from 'react-native';
+import {Swipeable} from 'react-native-gesture-handler';
+import {Reciter} from '@/data/reciterData';
+import {Surah} from '@/data/surahData';
+import {
+  useDownload,
+  DownloadedSurah,
+} from '@/services/player/store/downloadStore';
+import {useUnifiedPlayer} from '@/hooks/useUnifiedPlayer';
+import {QueueContext} from '@/services/queue/QueueContext';
+import {useRecentlyPlayedStore} from '@/services/player/store/recentlyPlayedStore';
+import {shuffleArray} from '@/utils/arrayUtils';
+import {State as TrackPlayerState} from 'react-native-track-player';
+import TrackPlayer from 'react-native-track-player';
+import {usePlayerStore} from '@/services/player/store/playerStore';
+import {useDownloadStore} from '@/services/player/store/downloadStore';
+import {ReciterDownloadsHeader} from '@/components/playlist-detail/ReciterDownloadsHeader';
+import {createDownloadedTrack} from '@/utils/track';
+
+interface DownloadTrackData {
+  download: DownloadedSurah;
+  reciter: Reciter | null;
+  surah: Surah | null;
+  rewayatName?: string;
+}
+
+interface ReciterDownloadsListProps {
+  reciterId: string;
+}
+
+export const ReciterDownloadsList: React.FC<ReciterDownloadsListProps> = ({
+  reciterId,
+}) => {
+  const {theme} = useTheme();
+  const {downloads, removeDownload} = useDownload();
+  const {pause, playback} = useUnifiedPlayer();
+  const queueContext = QueueContext.getInstance();
+  const {addRecentTrack} = useRecentlyPlayedStore();
+  const playerStore = usePlayerStore();
+
+  const [reciter, setReciter] = useState<Reciter | null>(null);
+  const [downloadData, setDownloadData] = useState<DownloadTrackData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Track current operation to prevent race conditions
+  const currentOperationRef = useRef<string | null>(null);
+
+  // Filter downloads for this reciter
+  const reciterDownloads = useMemo(() => {
+    return downloads.filter(d => d.reciterId === reciterId);
+  }, [downloads, reciterId]);
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    listContentContainer: {
+      flexGrow: 1,
+      paddingBottom: moderateScale(65),
+    },
+    emptyText: {
+      fontSize: moderateScale(16),
+      color: theme.colors.text,
+      textAlign: 'center',
+      marginTop: moderateScale(32),
+    },
+    listItem: {
+      marginVertical: moderateScale(2),
+    },
+    rightAction: {
+      flex: 1,
+      backgroundColor: '#ff4444',
+      justifyContent: 'center',
+      alignItems: 'flex-end',
+      paddingRight: moderateScale(20),
+    },
+    deleteButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: moderateScale(15),
+      paddingVertical: moderateScale(10),
+    },
+    deleteText: {
+      color: 'white',
+      fontSize: moderateScale(14),
+      fontWeight: '600',
+      marginLeft: moderateScale(8),
+    },
+  });
+
+  // Load reciter data
+  useEffect(() => {
+    if (!reciterId) return;
+
+    let mounted = true;
+    const loadReciter = async () => {
+      try {
+        const data = await getReciterById(reciterId);
+        if (mounted && data) {
+          setReciter(data);
+        }
+      } catch (error) {
+        console.error('Error loading reciter:', error);
+      }
+    };
+    loadReciter();
+    return () => {
+      mounted = false;
+    };
+  }, [reciterId]);
+
+  // Load download data
+  const loadDownloadData = useCallback(async () => {
+    if (!reciterId) return;
+
+    try {
+      setLoading(true);
+
+      // Enrich with surah data and rewayat name
+      const enrichedData = await Promise.all(
+        reciterDownloads.map(async download => {
+          const [loadedReciter, surah] = await Promise.all([
+            getReciterById(download.reciterId),
+            Promise.resolve(getSurahById(parseInt(download.surahId, 10))),
+          ]);
+
+          // Get rewayat name and style if rewayatId is available
+          let rewayatName: string | undefined;
+          if (loadedReciter && download.rewayatId) {
+            const rewayat = loadedReciter.rewayat.find(
+              r => r.id === download.rewayatId,
+            );
+            if (rewayat) {
+              // Capitalize style
+              const capitalizedStyle =
+                rewayat.style.charAt(0).toUpperCase() + rewayat.style.slice(1);
+              rewayatName = `${rewayat.name} • ${capitalizedStyle}`;
+            }
+          }
+
+          return {
+            download,
+            reciter: loadedReciter || null,
+            surah: surah || null,
+            rewayatName,
+          };
+        }),
+      );
+
+      // Sort by surah number
+      enrichedData.sort((a, b) => {
+        if (!a.surah || !b.surah) return 0;
+        return a.surah.id - b.surah.id;
+      });
+
+      setDownloadData(enrichedData);
+    } catch (error) {
+      console.error('Failed to load download data:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [reciterId, reciterDownloads]);
+
+  useEffect(() => {
+    loadDownloadData();
+  }, [loadDownloadData]);
+
+  // Handle track press to play
+  const handleTrackPress = useCallback(
+    async (download: DownloadedSurah, loadedReciter: Reciter, surah: Surah) => {
+      try {
+        if (downloadData.length === 0) {
+          console.warn('No download data loaded yet');
+          return;
+        }
+
+        // Find the index of the selected track
+        const selectedIndex = downloadData.findIndex(
+          item =>
+            item.download.reciterId === download.reciterId &&
+            item.download.surahId === download.surahId &&
+            (item.download.rewayatId || '') === (download.rewayatId || ''),
+        );
+
+        if (selectedIndex === -1) {
+          console.warn('Selected track not found');
+          return;
+        }
+
+        // Generate unique operation ID
+        const operationId = `${Date.now()}-${loadedReciter.id}-${surah.id}`;
+        currentOperationRef.current = operationId;
+
+        // Ensure download store is hydrated
+        useDownloadStore.getState();
+
+        // Create first track using downloaded file
+        const firstTrack = createDownloadedTrack(
+          loadedReciter,
+          surah,
+          download.filePath,
+          download.rewayatId,
+        );
+
+        // Reset and play immediately
+        await TrackPlayer.reset();
+        currentOperationRef.current = operationId;
+        await TrackPlayer.add(firstTrack);
+        await TrackPlayer.play();
+
+        // Update store immediately
+        if (currentOperationRef.current === operationId) {
+          const store = usePlayerStore.getState();
+          store.updateQueueState({
+            tracks: [firstTrack],
+            currentIndex: 0,
+            total: 1,
+            loading: false,
+            endReached: false,
+          });
+        }
+
+        // Get remaining items (reordered so selected is first)
+        const remainingItems = [
+          ...downloadData.slice(selectedIndex + 1),
+          ...downloadData.slice(0, selectedIndex),
+        ];
+
+        // Create remaining tracks in background
+        if (remainingItems.length > 0) {
+          const remainingTracks = remainingItems
+            .filter(
+              (
+                item,
+              ): item is DownloadTrackData & {reciter: Reciter; surah: Surah} =>
+                item.reciter !== null && item.surah !== null,
+            )
+            .map(item =>
+              createDownloadedTrack(
+                item.reciter,
+                item.surah,
+                item.download.filePath,
+                item.download.rewayatId,
+              ),
+            );
+
+          if (currentOperationRef.current === operationId) {
+            await TrackPlayer.add(remainingTracks);
+
+            if (currentOperationRef.current === operationId) {
+              const completeQueue = [firstTrack, ...remainingTracks];
+              const store = usePlayerStore.getState();
+              store.updateQueueState({
+                tracks: completeQueue,
+                total: completeQueue.length,
+              });
+            }
+          }
+        }
+
+        // Add to recently played
+        addRecentTrack(loadedReciter, surah, 0, 0, download.rewayatId);
+        queueContext.setCurrentReciter(loadedReciter);
+      } catch (error) {
+        console.error('Error playing track:', error);
+        currentOperationRef.current = null;
+      }
+    },
+    [downloadData, queueContext, addRecentTrack],
+  );
+
+  // Play all tracks
+  const handlePlayAll = useCallback(async () => {
+    if (downloadData.length === 0) return;
+
+    try {
+      // If currently playing, pause
+      if (playback.state === TrackPlayerState.Playing) {
+        await pause();
+        return;
+      }
+
+      const firstItem = downloadData.find(item => item.reciter && item.surah);
+      if (!firstItem?.reciter || !firstItem?.surah) return;
+
+      const operationId = `${Date.now()}-${firstItem.reciter.id}-play-all`;
+      currentOperationRef.current = operationId;
+
+      useDownloadStore.getState();
+
+      const firstTrack = createDownloadedTrack(
+        firstItem.reciter,
+        firstItem.surah,
+        firstItem.download.filePath,
+        firstItem.download.rewayatId,
+      );
+
+      try {
+        await TrackPlayer.reset();
+        currentOperationRef.current = operationId;
+        await TrackPlayer.add(firstTrack);
+        await TrackPlayer.play();
+
+        if (currentOperationRef.current === operationId) {
+          const store = usePlayerStore.getState();
+          store.updateQueueState({
+            tracks: [firstTrack],
+            currentIndex: 0,
+            total: 1,
+            loading: false,
+            endReached: false,
+          });
+        }
+      } catch (error) {
+        console.error('Error starting playback:', error);
+        currentOperationRef.current = null;
+        throw error;
+      }
+
+      // Create remaining tracks
+      const remainingItems = downloadData.slice(1);
+      if (remainingItems.length > 0) {
+        const remainingTracks = remainingItems
+          .filter(
+            (
+              item,
+            ): item is DownloadTrackData & {reciter: Reciter; surah: Surah} =>
+              item.reciter !== null && item.surah !== null,
+          )
+          .map(item =>
+            createDownloadedTrack(
+              item.reciter,
+              item.surah,
+              item.download.filePath,
+              item.download.rewayatId,
+            ),
+          );
+
+        if (currentOperationRef.current === operationId) {
+          await TrackPlayer.add(remainingTracks);
+
+          if (currentOperationRef.current === operationId) {
+            const completeQueue = [firstTrack, ...remainingTracks];
+            const store = usePlayerStore.getState();
+            store.updateQueueState({
+              tracks: completeQueue,
+              total: completeQueue.length,
+            });
+          }
+        }
+      }
+
+      addRecentTrack(
+        firstItem.reciter,
+        firstItem.surah,
+        0,
+        0,
+        firstItem.download.rewayatId,
+      );
+      queueContext.setCurrentReciter(firstItem.reciter);
+    } catch (error) {
+      console.error('Error playing all tracks:', error);
+      currentOperationRef.current = null;
+    }
+  }, [downloadData, pause, playback.state, queueContext, addRecentTrack]);
+
+  // Shuffle all tracks
+  const handleShuffle = useCallback(async () => {
+    if (downloadData.length === 0) return;
+
+    try {
+      const shuffledItems = shuffleArray([...downloadData]).filter(
+        (item): item is DownloadTrackData & {reciter: Reciter; surah: Surah} =>
+          item.reciter !== null && item.surah !== null,
+      );
+
+      if (shuffledItems.length === 0) return;
+
+      const firstItem = shuffledItems[0];
+
+      const operationId = `${Date.now()}-${firstItem.reciter.id}-shuffle-all`;
+      currentOperationRef.current = operationId;
+
+      useDownloadStore.getState();
+
+      const firstTrack = createDownloadedTrack(
+        firstItem.reciter,
+        firstItem.surah,
+        firstItem.download.filePath,
+        firstItem.download.rewayatId,
+      );
+
+      // Enable shuffle mode
+      if (!playerStore.settings.shuffle) {
+        playerStore.toggleShuffle();
+      }
+
+      try {
+        await TrackPlayer.reset();
+        currentOperationRef.current = operationId;
+        await TrackPlayer.add(firstTrack);
+        await TrackPlayer.play();
+
+        if (currentOperationRef.current === operationId) {
+          const store = usePlayerStore.getState();
+          store.updateQueueState({
+            tracks: [firstTrack],
+            currentIndex: 0,
+            total: 1,
+            loading: false,
+            endReached: false,
+          });
+        }
+      } catch (error) {
+        console.error('Error starting playback:', error);
+        currentOperationRef.current = null;
+        throw error;
+      }
+
+      // Create remaining tracks
+      const remainingItems = shuffledItems.slice(1);
+      if (remainingItems.length > 0) {
+        const remainingTracks = remainingItems
+          .filter(
+            (
+              item,
+            ): item is DownloadTrackData & {reciter: Reciter; surah: Surah} =>
+              item.reciter !== null && item.surah !== null,
+          )
+          .map(item =>
+            createDownloadedTrack(
+              item.reciter,
+              item.surah,
+              item.download.filePath,
+              item.download.rewayatId,
+            ),
+          );
+
+        if (currentOperationRef.current === operationId) {
+          await TrackPlayer.add(remainingTracks);
+
+          if (currentOperationRef.current === operationId) {
+            const completeQueue = [firstTrack, ...remainingTracks];
+            const store = usePlayerStore.getState();
+            store.updateQueueState({
+              tracks: completeQueue,
+              total: completeQueue.length,
+            });
+          }
+        }
+      }
+
+      addRecentTrack(
+        firstItem.reciter,
+        firstItem.surah,
+        0,
+        0,
+        firstItem.download.rewayatId,
+      );
+      queueContext.setCurrentReciter(firstItem.reciter);
+    } catch (error) {
+      console.error('Error shuffling tracks:', error);
+      currentOperationRef.current = null;
+    }
+  }, [downloadData, queueContext, addRecentTrack, playerStore]);
+
+  // Handle remove download
+  const handleRemoveDownload = useCallback(
+    async (download: DownloadedSurah) => {
+      try {
+        await removeDownload(
+          download.reciterId,
+          download.surahId,
+          download.rewayatId || undefined,
+        );
+      } catch (error) {
+        console.error('Error removing download:', error);
+      }
+    },
+    [removeDownload],
+  );
+
+  const ListHeaderComponent = useCallback(() => {
+    return (
+      <ReciterDownloadsHeader
+        reciterName={reciter?.name || 'Reciter'}
+        reciterImageUrl={reciter?.image_url || undefined}
+        subtitle={`${downloadData.length} ${downloadData.length === 1 ? 'surah' : 'surahs'} downloaded`}
+        onPlayPress={handlePlayAll}
+        onShufflePress={handleShuffle}
+        theme={theme}
+      />
+    );
+  }, [reciter, downloadData.length, handlePlayAll, handleShuffle, theme]);
+
+  const renderItem: ListRenderItem<DownloadTrackData> = ({item}) => {
+    const {download, reciter: itemReciter, surah, rewayatName} = item;
+
+    if (!itemReciter || !surah) {
+      return null;
+    }
+
+    const renderRightActions = () => (
+      <View style={styles.rightAction}>
+        <TouchableOpacity
+          style={styles.deleteButton}
+          onPress={() => handleRemoveDownload(download)}>
+          <Icon
+            name="trash-2"
+            type="feather"
+            size={moderateScale(20)}
+            color="white"
+          />
+          <Text style={styles.deleteText}>Remove</Text>
+        </TouchableOpacity>
+      </View>
+    );
+
+    return (
+      <Swipeable renderRightActions={renderRightActions}>
+        <View style={styles.listItem}>
+          <SurahItem
+            item={surah}
+            onPress={() => handleTrackPress(download, itemReciter, surah)}
+            reciterId={download.reciterId}
+            rewayatId={download.rewayatId}
+            rewayatName={rewayatName}
+          />
+        </View>
+      </Swipeable>
+    );
+  };
+
+  const getItemKey = (item: DownloadTrackData) =>
+    `${item.download.reciterId}:${item.download.surahId}:${item.download.rewayatId || ''}`;
+
+  if (loading) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.emptyText}>Loading...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={downloadData}
+        renderItem={renderItem}
+        keyExtractor={getItemKey}
+        ListHeaderComponent={ListHeaderComponent}
+        contentContainerStyle={styles.listContentContainer}
+        ListEmptyComponent={
+          <Text style={styles.emptyText}>No downloads for this reciter</Text>
+        }
+        bounces={false}
+      />
+    </View>
+  );
+};

--- a/services/player/store/downloadStore.ts
+++ b/services/player/store/downloadStore.ts
@@ -93,7 +93,11 @@ interface DownloadStoreState {
 
   // Actions
   addDownload: (download: DownloadedSurah) => void;
-  removeDownload: (reciterId: string, surahId: string) => void;
+  removeDownload: (
+    reciterId: string,
+    surahId: string,
+    rewayatId?: string,
+  ) => void;
   clearDownloads: () => void;
 
   // Queries (these are the missing pieces!)
@@ -119,7 +123,11 @@ interface DownloadStoreState {
   setDownloading: (id: string) => void;
   clearDownloading: (id: string) => void;
   setDownloadProgress: (id: string, progress: number) => void;
-  getDownloadProgress: (reciterId: string, surahId: string) => number;
+  getDownloadProgress: (
+    reciterId: string,
+    surahId: string,
+    rewayatId?: string,
+  ) => number;
   reorderDownloads: (fromIndex: number, toIndex: number) => void;
   setError: (error: Error | null) => void;
 
@@ -200,11 +208,12 @@ export const useDownloadStore = create<DownloadStoreState>()(
       // Actions
       addDownload: (download: DownloadedSurah) => {
         set(state => {
-          // Check if download already exists
+          // Check if download already exists (must match reciterId, surahId, AND rewayatId)
           const exists = state.downloads.some(
             d =>
               d.reciterId === download.reciterId &&
-              d.surahId === download.surahId,
+              d.surahId === download.surahId &&
+              (d.rewayatId || '') === (download.rewayatId || ''),
           );
 
           if (exists) {
@@ -217,11 +226,26 @@ export const useDownloadStore = create<DownloadStoreState>()(
           };
         });
       },
-      removeDownload: async (reciterId: string, surahId: string) => {
+      removeDownload: async (
+        reciterId: string,
+        surahId: string,
+        rewayatId?: string,
+      ) => {
         const {downloads} = get();
-        const download = downloads.find(
-          d => d.reciterId === reciterId && d.surahId === surahId,
-        );
+        const download = downloads.find(d => {
+          const reciterMatch = d.reciterId === reciterId;
+          const surahMatch = d.surahId === surahId;
+
+          // If rewayatId is provided, match it exactly
+          if (rewayatId) {
+            return reciterMatch && surahMatch && d.rewayatId === rewayatId;
+          }
+
+          // If rewayatId is not provided, only match downloads without rewayatId
+          return (
+            reciterMatch && surahMatch && (!d.rewayatId || d.rewayatId === '')
+          );
+        });
 
         try {
           if (download) {
@@ -230,9 +254,26 @@ export const useDownloadStore = create<DownloadStoreState>()(
 
           // Remove from store
           set(state => ({
-            downloads: state.downloads.filter(
-              d => !(d.reciterId === reciterId && d.surahId === surahId),
-            ),
+            downloads: state.downloads.filter(d => {
+              const reciterMatch = d.reciterId === reciterId;
+              const surahMatch = d.surahId === surahId;
+
+              // If rewayatId is provided, only remove that specific one
+              if (rewayatId) {
+                return !(
+                  reciterMatch &&
+                  surahMatch &&
+                  d.rewayatId === rewayatId
+                );
+              }
+
+              // If rewayatId is not provided, only remove downloads without rewayatId
+              return !(
+                reciterMatch &&
+                surahMatch &&
+                (!d.rewayatId || d.rewayatId === '')
+              );
+            }),
           }));
         } catch (error) {
           console.error('Error removing download:', error);
@@ -269,12 +310,14 @@ export const useDownloadStore = create<DownloadStoreState>()(
       },
 
       // Queries
+      // Only matches downloads without a specific rewayatId (empty string)
       isDownloaded: (reciterId: string, surahId: string) => {
         const {downloads} = get();
         return downloads.some(
           d =>
             d.reciterId === reciterId &&
             d.surahId === surahId &&
+            (!d.rewayatId || d.rewayatId === '') &&
             d.status === 'completed',
         );
       },
@@ -294,6 +337,7 @@ export const useDownloadStore = create<DownloadStoreState>()(
         );
       },
 
+      // Only checks for downloads without a specific rewayatId
       isDownloading: (reciterId: string, surahId: string) => {
         const {downloading} = get();
         const id = `${reciterId}-${surahId}`;
@@ -310,10 +354,14 @@ export const useDownloadStore = create<DownloadStoreState>()(
         return downloading.includes(id);
       },
 
+      // Only gets downloads without a specific rewayatId (empty string)
       getDownload: (reciterId: string, surahId: string) => {
         const {downloads} = get();
         return downloads.find(
-          d => d.reciterId === reciterId && d.surahId === surahId,
+          d =>
+            d.reciterId === reciterId &&
+            d.surahId === surahId &&
+            (!d.rewayatId || d.rewayatId === ''),
         );
       },
 
@@ -347,9 +395,15 @@ export const useDownloadStore = create<DownloadStoreState>()(
         throttledSetProgress(set, id, progress);
       },
 
-      getDownloadProgress: (reciterId: string, surahId: string) => {
+      getDownloadProgress: (
+        reciterId: string,
+        surahId: string,
+        rewayatId?: string,
+      ) => {
         const {downloadProgress} = get();
-        const id = `${reciterId}-${surahId}`;
+        const id = rewayatId
+          ? `${reciterId}-${surahId}-${rewayatId}`
+          : `${reciterId}-${surahId}`;
         return downloadProgress[id] || 0;
       },
 

--- a/types/reciter-profile.ts
+++ b/types/reciter-profile.ts
@@ -1,4 +1,10 @@
-import {Animated, ViewStyle, StyleProp} from 'react-native';
+import {
+  Animated,
+  ViewStyle,
+  StyleProp,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
+} from 'react-native';
 import {Reciter} from '@/data/reciterData';
 import {Surah} from '@/data/surahData';
 
@@ -87,7 +93,7 @@ export interface SurahListProps {
   /** Handler for surah options button press */
   onOptionsPress: (surah: Surah) => void;
   /** Scroll event handler */
-  onScroll: (event: any) => void;
+  onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   /** List header component */
   ListHeaderComponent: React.ReactElement;
   /** Style for the list container */


### PR DESCRIPTION
…mprovements

- Implement grouped downloads by reciter in collection screen
  - Show individual items for single downloads
  - Create dedicated reciter downloads screen for multiple downloads
  - Add ReciterDownloadsStackCard and ReciterDownloadsListItem components
  - Display downloads as rectangular cards in list view to distinguish from favorites

- Add comprehensive rewayat support across download system
  - Fix download duplicate checking to include rewayatId
  - Update isDownloaded, isDownloading, and getDownload to be rewayat-aware
  - Fix addDownload to properly check rewayatId when preventing duplicates
  - Update removeDownload to accept and handle rewayatId parameter
  - Allow downloading same surah by same reciter with different rewayat

- Create ReciterDownloadsList component for better code organization
  - Abstract download list logic from screen component
  - Implement proper type guards to eliminate non-null assertions
  - Add support for displaying rewayat name and style in surah items

- Enhance SurahItem component
  - Add optional rewayatName prop for displaying rewayat information
  - Show rewayat as plain text without borders in downloads screen
  - Preserve traditional bordered revelation place display for other screens
  - Improve visual consistency with DownloadCard subtitle style

- Improve TrackItem download state visibility
  - Increase download icon size from 12 to 13 points
  - Display download progress indicator during active downloads
  - Show download completion icon for downloaded tracks

- Fix TypeScript errors
  - Replace 'any' type with proper NativeSyntheticEvent<NativeScrollEvent> in reciter-profile types
  - Add necessary React Native imports

- Update download-related components
  - Fix SurahCard to check rewayatId when displaying download status
  - Update all download progress tracking to include rewayatId
  - Ensure consistent download state across SurahItem, TrackItem, TrackCard, and modals

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces reciter-grouped downloads and rewayat-aware download tracking across the app.
> 
> - Collection: Group downloads by `reciterId`; show single items as `track` or stacked `reciter-downloads` cards; add `ReciterDownloadsListItem` and grid `ReciterDownloadsStackCard`; navigate to `collection/reciter-downloads/[reciterId]`.
> - New screen/components: `ReciterDownloadsList` with `ReciterDownloadsHeader` for per-reciter downloads (play, shuffle, remove, rewayat name display).
> - Download store: Make `addDownload`, `removeDownload`, `isDownloaded*`, `isDownloading*`, `getDownloadProgress`, and `getDownload` rewayat-aware (keys include `rewayatId`); allow same surah downloaded per rewayat.
> - UI updates: `SurahItem`, `TrackItem`, `TrackCard`, `SurahCard`, and modals (`SurahOptionsModal`, `PlayerOptionsModal`) now pass `rewayatId`, show rewayat text, and display accurate download progress/icons.
> - Misc: Minor UI tweaks (icon sizes, pressed state formatting) and type fix in `types/reciter-profile` (`onScroll` uses `NativeSyntheticEvent<NativeScrollEvent>`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aca42beab2b24b1595b7438275052ac93a51c50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->