### PR TITLE
fix: optimize ExploreView performance and eliminate navigation lag

### DIFF
--- a/app/(tabs)/(b.search)/_layout.tsx
+++ b/app/(tabs)/(b.search)/_layout.tsx
@@ -6,6 +6,7 @@ export default function SearchLayout() {
     <Stack
       screenOptions={{
         headerShown: false,
+        freezeOnBlur: true,
       }}>
       <Stack.Screen name="index" />
       <Stack.Screen name="browse-all" />

--- a/app/(tabs)/(b.search)/index.tsx
+++ b/app/(tabs)/(b.search)/index.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import {View, StyleSheet} from 'react-native';
 import {SearchView} from '@/components/search/SearchView';
 import {useTheme} from '@/hooks/useTheme';
-import {useIsFocused} from '@react-navigation/native';
 
 export default function SearchScreen() {
   const {theme} = useTheme();
-  const isFocused = useIsFocused();
 
   const handleClose = () => {
     // Close functionality can be added here if needed in the future
@@ -16,7 +14,7 @@ export default function SearchScreen() {
   return (
     <View
       style={[styles.container, {backgroundColor: theme.colors.background}]}>
-      <SearchView visible={isFocused} onClose={handleClose} />
+      <SearchView visible={true} onClose={handleClose} />
     </View>
   );
 }

--- a/components/search/ExploreView.tsx
+++ b/components/search/ExploreView.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useMemo, useCallback} from 'react';
 import {
   View,
   StyleSheet,
@@ -182,15 +182,20 @@ const BentoTileComponent = React.memo(
 
 BentoTileComponent.displayName = 'BentoTileComponent';
 
-export function ExploreView({onSearchPress}: ExploreViewProps) {
+export const ExploreView = React.memo(function ExploreView({
+  onSearchPress,
+}: ExploreViewProps) {
   const router = useRouter();
   const {theme} = useTheme();
   const insets = useSafeAreaInsets();
   const {width} = useWindowDimensions();
 
-  const handleCategoryPress = (route: string) => {
-    router.push(route);
-  };
+  const handleCategoryPress = useCallback(
+    (route: string) => {
+      router.push(route);
+    },
+    [router],
+  );
 
   // Calculate tile dimensions based on screen width - strict two-column grid
   const tileDimensions = useMemo(() => {
@@ -213,26 +218,35 @@ export function ExploreView({onSearchPress}: ExploreViewProps) {
   // Create balanced layout
   const layout = useMemo(() => createExplicitLayout(), []);
 
-  // Render a column of tiles
-  const renderColumn = (tiles: BentoTile[], columnKey: string) => {
-    return (
-      <View key={columnKey} style={styles.column}>
-        {tiles.map(tile => (
-          <BentoTileComponent
-            key={tile.id}
-            tile={tile}
-            dimensions={{
-              width: tileDimensions.columnWidth,
-              height: tileDimensions.baseHeight * tile.heightMultiplier,
-            }}
-            onPress={() => handleCategoryPress(tile.route)}
-          />
-        ))}
-      </View>
-    );
-  };
+  // Memoize theme-dependent styles
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
-  const styles = createStyles(theme);
+  // Render a column of tiles - memoized with useCallback
+  const renderColumn = useCallback(
+    (tiles: BentoTile[], columnKey: string) => {
+      return (
+        <View key={columnKey} style={styles.column}>
+          {tiles.map(tile => (
+            <BentoTileComponent
+              key={tile.id}
+              tile={tile}
+              dimensions={{
+                width: tileDimensions.columnWidth,
+                height: tileDimensions.baseHeight * tile.heightMultiplier,
+              }}
+              onPress={() => handleCategoryPress(tile.route)}
+            />
+          ))}
+        </View>
+      );
+    },
+    [
+      styles.column,
+      tileDimensions.columnWidth,
+      tileDimensions.baseHeight,
+      handleCategoryPress,
+    ],
+  );
 
   return (
     <View style={styles.content}>
@@ -285,7 +299,7 @@ export function ExploreView({onSearchPress}: ExploreViewProps) {
       </ScrollView>
     </View>
   );
-}
+});
 
 const createStyles = (theme: ReturnType<typeof useTheme>['theme']) =>
   StyleSheet.create({


### PR DESCRIPTION
- Remove useIsFocused that was causing full component remount on navigation
- Add freezeOnBlur to Stack navigator to prevent unnecessary re-renders
- Memoize ExploreView component with React.memo
- Optimize callbacks with useCallback to prevent recreations
- Memoize styles to avoid recreation on every render

This fixes the 1-second dark screen lag when swiping back to ExploreView and eliminates double re-rendering issues.