### PR TITLE
feat: add Juz-based grouping for surahs in reciter and browse screens

### DIFF
--- a/components/JuzSectionHeader.tsx
+++ b/components/JuzSectionHeader.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import {View, Text} from 'react-native';
+import {ScaledSheet, moderateScale} from 'react-native-size-matters';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import Color from 'color';
+
+interface JuzSectionHeaderProps {
+  juzNumber: number;
+  juzName: string;
+  juzArabicName: string;
+  surahCount?: number;
+}
+
+export const JuzSectionHeader: React.FC<JuzSectionHeaderProps> = React.memo(
+  ({juzNumber, juzName, juzArabicName, surahCount}) => {
+    const {theme} = useTheme();
+    const styles = createStyles(theme);
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.leftContent}>
+          <View style={styles.juzBadge}>
+            <Text style={styles.juzNumber}>{juzNumber}</Text>
+          </View>
+          <View style={styles.textContainer}>
+            <Text style={styles.juzName} numberOfLines={1}>
+              Juz {juzNumber} - {juzName}
+            </Text>
+            {surahCount !== undefined && (
+              <Text style={styles.surahCount}>
+                {surahCount} {surahCount === 1 ? 'Surah' : 'Surahs'}
+              </Text>
+            )}
+          </View>
+        </View>
+        <Text style={styles.arabicName}>{juzArabicName}</Text>
+      </View>
+    );
+  },
+);
+
+JuzSectionHeader.displayName = 'JuzSectionHeader';
+
+const createStyles = (theme: Theme) =>
+  ScaledSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingVertical: moderateScale(12),
+      paddingHorizontal: moderateScale(16),
+      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
+      borderBottomWidth: 1,
+      borderTopWidth: 1,
+      borderColor: Color(theme.colors.border).alpha(0.1).toString(),
+      marginBottom: moderateScale(8),
+    },
+    leftContent: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flex: 1,
+    },
+    juzBadge: {
+      width: moderateScale(32),
+      height: moderateScale(32),
+      borderRadius: moderateScale(16),
+      backgroundColor: Color(theme.colors.primary).alpha(0.15).toString(),
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginRight: moderateScale(12),
+    },
+    juzNumber: {
+      fontSize: moderateScale(14),
+      fontFamily: 'Manrope-Bold',
+      color: theme.colors.primary,
+    },
+    textContainer: {
+      flex: 1,
+    },
+    juzName: {
+      fontSize: moderateScale(14),
+      fontFamily: 'Manrope-SemiBold',
+      color: theme.colors.text,
+    },
+    surahCount: {
+      fontSize: moderateScale(11),
+      fontFamily: 'Manrope-Medium',
+      color: theme.colors.textSecondary,
+      marginTop: moderateScale(2),
+    },
+    arabicName: {
+      fontSize: moderateScale(18),
+      fontFamily: 'ScheherazadeNew',
+      color: theme.colors.text,
+      marginLeft: moderateScale(8),
+    },
+  });

--- a/components/browse/BrowseSurahs.tsx
+++ b/components/browse/BrowseSurahs.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useMemo, useCallback} from 'react';
-import {View, FlatList, TouchableOpacity, Text} from 'react-native';
+import {View, FlatList, SectionList, TouchableOpacity, Text} from 'react-native';
 import {useRouter} from 'expo-router';
 import {
   moderateScale,
@@ -9,6 +9,7 @@ import {
 import {SURAHS, Surah} from '@/data/surahData';
 import {SurahCard} from '@/components/cards/SurahCard';
 import {SurahItem} from '@/components/SurahItem';
+import {JuzSectionHeader} from '@/components/JuzSectionHeader';
 import Header from '@/components/Header';
 import {Icon} from '@rneui/themed';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -20,16 +21,51 @@ import {useModal} from '@/components/providers/ModalProvider';
 import {GRADIENT_COLORS} from '@/utils/gradientColors';
 import {useReciterSelection} from '@/hooks/useReciterSelection';
 import {Theme} from '@/utils/themeUtils';
+import {groupSurahsByJuz, JuzSection} from '@/data/juzData';
 
 // Define types for clarity, matching the ones in useSettings
 type ViewMode = 'card' | 'list';
-type SortOption = 'asc' | 'desc' | 'revelation';
+type SortOption = 'asc' | 'desc' | 'revelation' | 'juz';
 
 const ItemSeparator = React.memo(() => {
   const styles = useStyles();
   return <View style={styles.listSeparator} />;
 });
 ItemSeparator.displayName = 'ItemSeparator';
+
+// Card row component for card grid in section list
+const CardRow = React.memo(
+  ({
+    surahs,
+    onPress,
+    getColorForSurah,
+    styles,
+  }: {
+    surahs: Surah[];
+    onPress: (surah: Surah) => void;
+    getColorForSurah: (id: number) => string;
+    styles: ReturnType<typeof useStyles>;
+  }) => (
+    <View style={styles.cardRow}>
+      {surahs.map(surah => (
+        <SurahCard
+          key={surah.id}
+          id={surah.id}
+          name={surah.name}
+          translatedName={surah.translated_name_english}
+          versesCount={surah.verses_count}
+          revelationPlace={surah.revelation_place}
+          color={getColorForSurah(surah.id)}
+          onPress={() => onPress(surah)}
+          style={styles.surahCard}
+        />
+      ))}
+      {/* Add placeholder if odd number of cards */}
+      {surahs.length === 1 && <View style={styles.surahCard} />}
+    </View>
+  ),
+);
+CardRow.displayName = 'CardRow';
 
 const useStyles = () => {
   return ScaledSheet.create({
@@ -41,7 +77,7 @@ const useStyles = () => {
     },
     scrollView: {
       flex: 1,
-      marginTop: moderateScale(4), // Reduced from 10 to 4
+      marginTop: moderateScale(4),
     },
     scrollContent: {
       paddingBottom: verticalScale(100),
@@ -54,11 +90,11 @@ const useStyles = () => {
       paddingHorizontal: moderateScale(16),
       marginHorizontal: moderateScale(16),
       borderRadius: moderateScale(8),
-      marginBottom: moderateScale(2), // Reduced from 5 to 2
+      marginBottom: moderateScale(2),
     },
     surahsContainer: {
       flex: 1,
-      paddingTop: 0, // Removed padding at top of container
+      paddingTop: 0,
     },
     sortOptions: {
       flexDirection: 'row',
@@ -84,23 +120,30 @@ const useStyles = () => {
     },
     listContent: {
       paddingHorizontal: moderateScale(16),
-      paddingTop: 0, // Removed padding to bring content closer to options row
+      paddingTop: 0,
     },
     listViewContent: {
-      paddingHorizontal: 0, // Remove horizontal padding for list view to match SurahItem styling
+      paddingHorizontal: 0,
     },
     columnWrapper: {
       justifyContent: 'space-between',
-      marginBottom: moderateScale(16), // Space between rows in card view
+      marginBottom: moderateScale(16),
+    },
+    cardRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      paddingHorizontal: moderateScale(16),
+      marginBottom: moderateScale(16),
     },
     surahCard: {
-      width: '48%', // Allow some space between cards
+      width: '48%',
     },
     listSeparator: {
       height: moderateScale(4),
     },
     viewContainer: {
       width: '100%',
+      flex: 1,
     },
     hiddenView: {
       display: 'none',
@@ -154,6 +197,11 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
       : [...SURAHS];
 
     // Then sort based on selected option
+    if (sortOption === 'juz') {
+      // For juz, sort by ID ascending (grouping is handled separately)
+      return result.sort((a, b) => a.id - b.id);
+    }
+
     switch (sortOption) {
       case 'asc':
         return result.sort((a, b) => a.id - b.id);
@@ -165,6 +213,29 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
         return result;
     }
   }, [searchQuery, sortOption]);
+
+  // Group surahs by Juz for juz sort option
+  const juzSections = useMemo(() => {
+    if (sortOption !== 'juz') return [];
+    return groupSurahsByJuz(displaySurahs);
+  }, [displaySurahs, sortOption]);
+
+  // Prepare card rows for Juz sections (2 cards per row)
+  const juzCardSections = useMemo(() => {
+    if (sortOption !== 'juz' || viewMode !== 'card') return [];
+
+    return juzSections.map(section => {
+      // Group surahs into rows of 2
+      const rows: Surah[][] = [];
+      for (let i = 0; i < section.data.length; i += 2) {
+        rows.push(section.data.slice(i, i + 2));
+      }
+      return {
+        ...section,
+        data: rows,
+      };
+    });
+  }, [juzSections, viewMode, sortOption]);
 
   // Function to generate a consistent color for each surah
   const getColorForSurah = useCallback((id: number): string => {
@@ -228,15 +299,15 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
   const toggleViewMode = () => {
     const newMode = viewMode === 'card' ? 'list' : 'card';
     setViewMode(newMode);
-    setBrowseViewModeSetting(newMode); // Persist the change
+    setBrowseViewModeSetting(newMode);
   };
 
   const changeSortOption = (option: SortOption) => {
     setSortOption(option);
-    setBrowseSortOptionSetting(option); // Persist the change
+    setBrowseSortOptionSetting(option);
   };
 
-  // Render a card item
+  // Render a card item for FlatList
   const renderCardItem = useCallback(
     ({item}: {item: Surah}) => (
       <SurahCard
@@ -259,6 +330,36 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
       <SurahItem item={item} onPress={handleSurahPress} />
     ),
     [handleSurahPress],
+  );
+
+  // Render section header for Juz
+  const renderSectionHeader = useCallback(
+    ({section}: {section: JuzSection<Surah> | JuzSection<Surah[]>}) => (
+      <JuzSectionHeader
+        juzNumber={section.juzNumber}
+        juzName={section.juzName}
+        juzArabicName={section.juzArabicName}
+        surahCount={
+          Array.isArray(section.data[0])
+            ? (section.data as Surah[][]).reduce((acc, row) => acc + row.length, 0)
+            : section.data.length
+        }
+      />
+    ),
+    [],
+  );
+
+  // Render card row for SectionList
+  const renderCardRow = useCallback(
+    ({item}: {item: Surah[]}) => (
+      <CardRow
+        surahs={item}
+        onPress={handleSurahPress}
+        getColorForSurah={getColorForSurah}
+        styles={styles}
+      />
+    ),
+    [handleSurahPress, getColorForSurah, styles],
   );
 
   // Sort and view options row
@@ -370,6 +471,41 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
             Rev
           </Text>
         </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[
+            styles.sortButton,
+            sortOption === 'juz' && {
+              backgroundColor: Color(theme.colors.primary)
+                .alpha(0.1)
+                .toString(),
+            },
+          ]}
+          activeOpacity={1}
+          onPress={() => changeSortOption('juz')}>
+          <Icon
+            name="layers"
+            type="feather"
+            size={moderateScale(14)}
+            color={
+              sortOption === 'juz'
+                ? theme.colors.primary
+                : theme.colors.textSecondary
+            }
+          />
+          <Text
+            style={[
+              styles.sortButtonText,
+              {
+                color:
+                  sortOption === 'juz'
+                    ? theme.colors.primary
+                    : theme.colors.textSecondary,
+              },
+            ]}>
+            Juz
+          </Text>
+        </TouchableOpacity>
       </View>
 
       {/* View mode toggle */}
@@ -387,6 +523,124 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
     </Animated.View>
   );
 
+  // Render content based on sort option
+  const renderContent = () => {
+    // For Juz view, use SectionList
+    if (sortOption === 'juz') {
+      return (
+        <Animated.View
+          entering={FadeIn.delay(200)}
+          style={styles.surahsContainer}>
+          {/* Card View with Juz sections */}
+          <View
+            style={[
+              styles.viewContainer,
+              viewMode !== 'card' && styles.hiddenView,
+            ]}>
+            <SectionList
+              sections={juzCardSections}
+              renderItem={renderCardRow}
+              renderSectionHeader={renderSectionHeader}
+              keyExtractor={(item, index) =>
+                `juz-card-row-${item.map(s => s.id).join('-')}-${index}`
+              }
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={[styles.listContent, styles.scrollContent]}
+              stickySectionHeadersEnabled={false}
+              initialNumToRender={10}
+              maxToRenderPerBatch={10}
+              windowSize={5}
+              removeClippedSubviews={true}
+              ItemSeparatorComponent={ItemSeparator}
+            />
+          </View>
+
+          {/* List View with Juz sections */}
+          <View
+            style={[
+              styles.viewContainer,
+              viewMode !== 'list' && styles.hiddenView,
+            ]}>
+            <SectionList
+              sections={juzSections}
+              renderItem={renderListItem}
+              renderSectionHeader={renderSectionHeader}
+              keyExtractor={item => `juz-list-${item.id}`}
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={[
+                styles.listContent,
+                styles.listViewContent,
+                styles.scrollContent,
+              ]}
+              stickySectionHeadersEnabled={false}
+              initialNumToRender={15}
+              maxToRenderPerBatch={10}
+              windowSize={5}
+              removeClippedSubviews={true}
+              ItemSeparatorComponent={ItemSeparator}
+            />
+          </View>
+        </Animated.View>
+      );
+    }
+
+    // For other views, use FlatList
+    return (
+      <Animated.View
+        entering={FadeIn.delay(200)}
+        style={styles.surahsContainer}>
+        {/* Card View */}
+        <View
+          style={[
+            styles.viewContainer,
+            viewMode !== 'card' && styles.hiddenView,
+          ]}>
+          <FlatList
+            data={displaySurahs}
+            renderItem={renderCardItem}
+            keyExtractor={item => `card-${item.id}`}
+            showsVerticalScrollIndicator={false}
+            scrollEnabled={true}
+            contentContainerStyle={[styles.listContent, styles.scrollContent]}
+            numColumns={2}
+            columnWrapperStyle={styles.columnWrapper}
+            initialNumToRender={25}
+            maxToRenderPerBatch={10}
+            windowSize={5}
+            removeClippedSubviews={true}
+            ItemSeparatorComponent={ItemSeparator}
+          />
+        </View>
+
+        {/* List View */}
+        <View
+          style={[
+            styles.viewContainer,
+            viewMode !== 'list' && styles.hiddenView,
+          ]}>
+          <FlatList
+            data={displaySurahs}
+            renderItem={renderListItem}
+            keyExtractor={item => `list-${item.id}`}
+            showsVerticalScrollIndicator={false}
+            scrollEnabled={true}
+            contentContainerStyle={[
+              styles.listContent,
+              styles.listViewContent,
+              styles.scrollContent,
+            ]}
+            numColumns={1}
+            initialNumToRender={25}
+            maxToRenderPerBatch={10}
+            windowSize={5}
+            removeClippedSubviews={true}
+            ItemSeparatorComponent={ItemSeparator}
+          />
+        </View>
+      </Animated.View>
+    );
+  };
+
   return (
     <View
       style={[styles.container, {backgroundColor: theme.colors.background}]}>
@@ -395,59 +649,7 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
       <View
         style={[styles.content, {marginTop: insets.top + moderateScale(56)}]}>
         {renderOptionsRow()}
-
-        <Animated.View
-          entering={FadeIn.delay(200)}
-          style={styles.surahsContainer}>
-          {/* Card View */}
-          <View
-            style={[
-              styles.viewContainer,
-              viewMode !== 'card' && styles.hiddenView,
-            ]}>
-            <FlatList
-              data={displaySurahs}
-              renderItem={renderCardItem}
-              keyExtractor={item => `card-${item.id}`}
-              showsVerticalScrollIndicator={false}
-              scrollEnabled={true}
-              contentContainerStyle={[styles.listContent, styles.scrollContent]}
-              numColumns={2}
-              columnWrapperStyle={styles.columnWrapper}
-              initialNumToRender={25}
-              maxToRenderPerBatch={10}
-              windowSize={5}
-              removeClippedSubviews={true}
-              ItemSeparatorComponent={ItemSeparator}
-            />
-          </View>
-
-          {/* List View */}
-          <View
-            style={[
-              styles.viewContainer,
-              viewMode !== 'list' && styles.hiddenView,
-            ]}>
-            <FlatList
-              data={displaySurahs}
-              renderItem={renderListItem}
-              keyExtractor={item => `list-${item.id}`}
-              showsVerticalScrollIndicator={false}
-              scrollEnabled={true}
-              contentContainerStyle={[
-                styles.listContent,
-                styles.listViewContent,
-                styles.scrollContent,
-              ]}
-              numColumns={1}
-              initialNumToRender={25}
-              maxToRenderPerBatch={10}
-              windowSize={5}
-              removeClippedSubviews={true}
-              ItemSeparatorComponent={ItemSeparator}
-            />
-          </View>
-        </Animated.View>
+        {renderContent()}
       </View>
     </View>
   );

--- a/components/reciter-profile/ReciterProfile.tsx
+++ b/components/reciter-profile/ReciterProfile.tsx
@@ -58,7 +58,7 @@ interface ReciterProfileProps {
 
 // Define types matching useSettings
 type ReciterProfileViewMode = 'card' | 'list';
-type ReciterProfileSortOption = 'asc' | 'desc' | 'revelation';
+type ReciterProfileSortOption = 'asc' | 'desc' | 'revelation' | 'juz';
 
 // Create a proper memoized wrapper for SurahList
 const MemoizedSurahList = React.memo(SurahList);
@@ -157,7 +157,8 @@ const ReciterProfile: React.FC<ReciterProfileProps> = ({
 
     // Sort based on sortOption
     return [...filtered].sort((a, b) => {
-      if (sortOption === 'asc') {
+      if (sortOption === 'asc' || sortOption === 'juz') {
+        // For 'juz', sort by ID ascending (grouping is handled in SurahList)
         return a.id - b.id;
       } else if (sortOption === 'desc') {
         return b.id - a.id;
@@ -1034,6 +1035,32 @@ const ReciterProfile: React.FC<ReciterProfileProps> = ({
                               styles.activeOptionText,
                           ]}>
                           Rev
+                        </Text>
+                      </TouchableOpacity>
+
+                      <TouchableOpacity
+                        style={[
+                          styles.optionButton,
+                          sortOption === 'juz' && styles.activeOptionButton,
+                        ]}
+                        activeOpacity={1}
+                        onPress={() => changeSortOption('juz')}>
+                        <Icon
+                          name="layers"
+                          type="feather"
+                          size={moderateScale(14)}
+                          color={
+                            sortOption === 'juz'
+                              ? theme.colors.primary
+                              : theme.colors.textSecondary
+                          }
+                        />
+                        <Text
+                          style={[
+                            styles.optionButtonText,
+                            sortOption === 'juz' && styles.activeOptionText,
+                          ]}>
+                          Juz
                         </Text>
                       </TouchableOpacity>
                     </View>

--- a/components/reciter-profile/components/SurahList/index.tsx
+++ b/components/reciter-profile/components/SurahList/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import {Text, Animated, View} from 'react-native';
+import React, {useMemo} from 'react';
+import {Text, Animated, View, SectionList} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {Theme} from '@/utils/themeUtils';
@@ -7,18 +7,20 @@ import {useTheme} from '@/hooks/useTheme';
 import {SurahListProps} from '@/components/reciter-profile/types';
 import {SurahItem} from '@/components/SurahItem';
 import {SurahCard} from '@/components/cards/SurahCard';
+import {JuzSectionHeader} from '@/components/JuzSectionHeader';
 import {Surah} from '@/data/surahData';
+import {groupSurahsByJuz, JuzSection} from '@/data/juzData';
 
 // Define types matching useSettings and ReciterProfile
 type ReciterProfileViewMode = 'card' | 'list';
-type ReciterProfileSortOption = 'asc' | 'desc' | 'revelation'; // Include revelation order
+type ReciterProfileSortOption = 'asc' | 'desc' | 'revelation' | 'juz';
 
-// Update props interface (consider moving this to types/reciter-profile.ts)
+// Update props interface
 interface UpdatedSurahListProps extends SurahListProps {
   viewMode: ReciterProfileViewMode;
   getColorForSurah: (id: number) => string;
   sortOption: ReciterProfileSortOption;
-  rewayatId?: string; // Add rewayatId prop
+  rewayatId?: string;
 }
 
 // Shared ItemSeparator component
@@ -29,10 +31,60 @@ const ItemSeparator = React.memo(() => {
 });
 ItemSeparator.displayName = 'ItemSeparator';
 
+// Card row component for card grid in section list
+const CardRow = React.memo(
+  ({
+    surahs,
+    onSurahPress,
+    reciterId,
+    isLoved,
+    isDownloaded,
+    onOptionsPress,
+    getColorForSurah,
+    rewayatId,
+    styles,
+  }: {
+    surahs: Surah[];
+    onSurahPress: (surah: Surah) => void;
+    reciterId: string;
+    isLoved: (id: string, surahId: string | number) => boolean;
+    isDownloaded: (id: string, surahId: string | number) => boolean;
+    onOptionsPress?: (surah: Surah) => void;
+    getColorForSurah: (id: number) => string;
+    rewayatId?: string;
+    styles: ReturnType<typeof createStyles>;
+  }) => (
+    <View style={styles.cardRow}>
+      {surahs.map(surah => (
+        <SurahCard
+          key={surah.id}
+          id={surah.id}
+          name={surah.name}
+          translatedName={surah.translated_name_english}
+          versesCount={surah.verses_count}
+          revelationPlace={surah.revelation_place}
+          color={getColorForSurah(surah.id)}
+          onPress={() => onSurahPress(surah)}
+          style={styles.surahCard}
+          isLoved={isLoved(reciterId, surah.id.toString())}
+          isDownloaded={isDownloaded(reciterId, surah.id.toString())}
+          onOptionsPress={onOptionsPress ? () => onOptionsPress(surah) : undefined}
+          reciterId={reciterId}
+          rewayatId={rewayatId}
+        />
+      ))}
+      {/* Add placeholder if odd number of cards */}
+      {surahs.length === 1 && <View style={styles.surahCard} />}
+    </View>
+  ),
+);
+CardRow.displayName = 'CardRow';
+
 /**
  * SurahList component for the ReciterProfile
  *
  * Displays surahs in either a list or grid view.
+ * Supports grouping by Juz when sortOption is 'juz'.
  */
 export const SurahList = React.forwardRef<
   Animated.FlatList,
@@ -50,6 +102,7 @@ export const SurahList = React.forwardRef<
       ListHeaderComponent,
       contentContainerStyle,
       viewMode,
+      sortOption,
       getColorForSurah,
       rewayatId,
     },
@@ -58,7 +111,30 @@ export const SurahList = React.forwardRef<
     const {theme} = useTheme();
     const styles = createStyles(theme);
 
-    // Render a card item
+    // Group surahs by Juz for juz sort option
+    const juzSections = useMemo(() => {
+      if (sortOption !== 'juz') return [];
+      return groupSurahsByJuz(surahs);
+    }, [surahs, sortOption]);
+
+    // Prepare card rows for Juz sections (2 cards per row)
+    const juzCardSections = useMemo(() => {
+      if (sortOption !== 'juz' || viewMode !== 'card') return [];
+
+      return juzSections.map(section => {
+        // Group surahs into rows of 2
+        const rows: Surah[][] = [];
+        for (let i = 0; i < section.data.length; i += 2) {
+          rows.push(section.data.slice(i, i + 2));
+        }
+        return {
+          ...section,
+          data: rows,
+        };
+      });
+    }, [juzSections, viewMode, sortOption]);
+
+    // Render a card item for FlatList
     const renderCardItem = React.useCallback(
       ({item}: {item: Surah}) => (
         <SurahCard
@@ -72,7 +148,7 @@ export const SurahList = React.forwardRef<
           style={styles.surahCard}
           isLoved={isLoved(reciterId, item.id.toString())}
           isDownloaded={isDownloaded(reciterId, item.id.toString())}
-          onOptionsPress={() => onOptionsPress && onOptionsPress(item)}
+          onOptionsPress={onOptionsPress ? () => onOptionsPress(item) : undefined}
           reciterId={reciterId}
           rewayatId={rewayatId}
         />
@@ -102,14 +178,42 @@ export const SurahList = React.forwardRef<
           rewayatId={rewayatId}
         />
       ),
-      [
-        onSurahPress,
-        reciterId,
-        isLoved,
-        isDownloaded,
-        onOptionsPress,
-        rewayatId,
-      ],
+      [onSurahPress, reciterId, isLoved, isDownloaded, onOptionsPress, rewayatId],
+    );
+
+    // Render section header for Juz
+    const renderSectionHeader = React.useCallback(
+      ({section}: {section: JuzSection<Surah> | JuzSection<Surah[]>}) => (
+        <JuzSectionHeader
+          juzNumber={section.juzNumber}
+          juzName={section.juzName}
+          juzArabicName={section.juzArabicName}
+          surahCount={
+            Array.isArray(section.data[0])
+              ? (section.data as Surah[][]).reduce((acc, row) => acc + row.length, 0)
+              : section.data.length
+          }
+        />
+      ),
+      [],
+    );
+
+    // Render card row for SectionList
+    const renderCardRow = React.useCallback(
+      ({item}: {item: Surah[]}) => (
+        <CardRow
+          surahs={item}
+          onSurahPress={onSurahPress}
+          reciterId={reciterId}
+          isLoved={isLoved}
+          isDownloaded={isDownloaded}
+          onOptionsPress={onOptionsPress}
+          getColorForSurah={getColorForSurah}
+          rewayatId={rewayatId}
+          styles={styles}
+        />
+      ),
+      [onSurahPress, reciterId, isLoved, isDownloaded, onOptionsPress, getColorForSurah, rewayatId, styles],
     );
 
     // Shared ListHeader to avoid re-rendering issues
@@ -118,12 +222,78 @@ export const SurahList = React.forwardRef<
       [ListHeaderComponent],
     );
 
-    // Important: We use the same exact contentContainerStyle for both views
+    // Shared content container style
     const sharedContentContainerStyle = React.useMemo(
       () => [styles.listContentContainer, contentContainerStyle],
       [styles.listContentContainer, contentContainerStyle],
     );
 
+    // If sortOption is 'juz', use SectionList
+    if (sortOption === 'juz') {
+      return (
+        <View style={styles.surahsContainer}>
+          {/* Card View with Juz sections */}
+          <View
+            style={[
+              styles.viewContainer,
+              viewMode !== 'card' && styles.hiddenView,
+            ]}>
+            <SectionList
+              sections={juzCardSections}
+              renderItem={renderCardRow}
+              renderSectionHeader={renderSectionHeader}
+              keyExtractor={(item, index) =>
+                `juz-card-row-${item.map(s => s.id).join('-')}-${index}`
+              }
+              ListHeaderComponent={HeaderMemo}
+              onScroll={viewMode === 'card' ? onScroll : undefined}
+              scrollEventThrottle={16}
+              contentContainerStyle={sharedContentContainerStyle}
+              stickySectionHeadersEnabled={false}
+              showsVerticalScrollIndicator={false}
+              ListEmptyComponent={
+                <Text style={styles.emptyText}>No surahs available</Text>
+              }
+              initialNumToRender={10}
+              maxToRenderPerBatch={10}
+              windowSize={5}
+              removeClippedSubviews={true}
+              ItemSeparatorComponent={ItemSeparator}
+            />
+          </View>
+
+          {/* List View with Juz sections */}
+          <View
+            style={[
+              styles.viewContainer,
+              viewMode !== 'list' && styles.hiddenView,
+            ]}>
+            <SectionList
+              sections={juzSections}
+              renderItem={renderListItem}
+              renderSectionHeader={renderSectionHeader}
+              keyExtractor={item => `juz-list-${item.id}`}
+              ListHeaderComponent={HeaderMemo}
+              onScroll={viewMode === 'list' ? onScroll : undefined}
+              scrollEventThrottle={16}
+              contentContainerStyle={sharedContentContainerStyle}
+              stickySectionHeadersEnabled={false}
+              showsVerticalScrollIndicator={false}
+              ListEmptyComponent={
+                <Text style={styles.emptyText}>No surahs available</Text>
+              }
+              initialNumToRender={15}
+              maxToRenderPerBatch={10}
+              windowSize={5}
+              removeClippedSubviews={true}
+              ItemSeparatorComponent={ItemSeparator}
+            />
+          </View>
+        </View>
+      );
+    }
+
+    // For other sort options, use FlatList
     return (
       <View style={styles.surahsContainer}>
         {/* Card View */}
@@ -211,6 +381,12 @@ const createStyles = (theme: Theme) =>
       justifyContent: 'space-between',
       marginBottom: moderateScale(16),
       paddingHorizontal: moderateScale(16),
+    },
+    cardRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      paddingHorizontal: moderateScale(16),
+      marginBottom: moderateScale(16),
     },
     surahCard: {
       width: '47%',

--- a/data/juzData.ts
+++ b/data/juzData.ts
@@ -1,0 +1,177 @@
+/**
+ * Juz Data - Maps each of the 30 Juz (parts) of the Quran to their Surahs
+ *
+ * Each Juz contains specific Surahs. Some Surahs span multiple Juz.
+ * This mapping assigns each Surah to its primary Juz (where it starts).
+ */
+
+export interface JuzInfo {
+  id: number;
+  name: string;
+  arabicName: string;
+  startSurah: number;
+  endSurah: number;
+  // Array of all surah IDs that have verses in this Juz
+  surahs: number[];
+}
+
+/**
+ * Complete mapping of all 30 Juz with their surah ranges
+ * Based on the traditional division of the Quran
+ */
+export const JUZ_DATA: JuzInfo[] = [
+  {id: 1, name: 'Alif Lam Meem', arabicName: 'الٓمٓ', startSurah: 1, endSurah: 2, surahs: [1, 2]},
+  {id: 2, name: 'Sayaqool', arabicName: 'سَيَقُولُ', startSurah: 2, endSurah: 2, surahs: [2]},
+  {id: 3, name: 'Tilkal Rusul', arabicName: 'تِلْكَ الرُّسُلُ', startSurah: 2, endSurah: 3, surahs: [2, 3]},
+  {id: 4, name: 'Lan Tanaloo', arabicName: 'لَن تَنَالُوا', startSurah: 3, endSurah: 4, surahs: [3, 4]},
+  {id: 5, name: 'Wal Mohsanat', arabicName: 'وَالْمُحْصَنَاتُ', startSurah: 4, endSurah: 4, surahs: [4]},
+  {id: 6, name: 'La Yuhibbullah', arabicName: 'لَا يُحِبُّ اللَّهُ', startSurah: 4, endSurah: 5, surahs: [4, 5]},
+  {id: 7, name: 'Wa Iza Samiu', arabicName: 'وَإِذَا سَمِعُوا', startSurah: 5, endSurah: 6, surahs: [5, 6]},
+  {id: 8, name: 'Wa Lau Annana', arabicName: 'وَلَوْ أَنَّنَا', startSurah: 6, endSurah: 7, surahs: [6, 7]},
+  {id: 9, name: 'Qalal Malao', arabicName: 'قَالَ الْمَلَأُ', startSurah: 7, endSurah: 8, surahs: [7, 8]},
+  {id: 10, name: 'Wa Alamu', arabicName: 'وَاعْلَمُوا', startSurah: 8, endSurah: 9, surahs: [8, 9]},
+  {id: 11, name: 'Yatazeroon', arabicName: 'يَعْتَذِرُونَ', startSurah: 9, endSurah: 11, surahs: [9, 10, 11]},
+  {id: 12, name: 'Wa Mamin Daabbah', arabicName: 'وَمَا مِن دَابَّةٍ', startSurah: 11, endSurah: 12, surahs: [11, 12]},
+  {id: 13, name: 'Wa Ma Ubrioo', arabicName: 'وَمَا أُبَرِّئُ', startSurah: 12, endSurah: 14, surahs: [12, 13, 14]},
+  {id: 14, name: 'Rubama', arabicName: 'رُبَمَا', startSurah: 15, endSurah: 16, surahs: [15, 16]},
+  {id: 15, name: 'Subhanallazi', arabicName: 'سُبْحَانَ الَّذِي', startSurah: 17, endSurah: 18, surahs: [17, 18]},
+  {id: 16, name: 'Qal Alam', arabicName: 'قَالَ أَلَمْ', startSurah: 18, endSurah: 20, surahs: [18, 19, 20]},
+  {id: 17, name: 'Iqtaraba', arabicName: 'اقْتَرَبَ', startSurah: 21, endSurah: 22, surahs: [21, 22]},
+  {id: 18, name: 'Qad Aflaha', arabicName: 'قَدْ أَفْلَحَ', startSurah: 23, endSurah: 25, surahs: [23, 24, 25]},
+  {id: 19, name: 'Wa Qalallazina', arabicName: 'وَقَالَ الَّذِينَ', startSurah: 25, endSurah: 27, surahs: [25, 26, 27]},
+  {id: 20, name: 'Amman Khalaq', arabicName: 'أَمَّنْ خَلَقَ', startSurah: 27, endSurah: 29, surahs: [27, 28, 29]},
+  {id: 21, name: 'Otlu Ma Oohi', arabicName: 'اتْلُ مَا أُوحِيَ', startSurah: 29, endSurah: 33, surahs: [29, 30, 31, 32, 33]},
+  {id: 22, name: 'Wa Manyaqnut', arabicName: 'وَمَن يَقْنُتْ', startSurah: 33, endSurah: 36, surahs: [33, 34, 35, 36]},
+  {id: 23, name: 'Wa Mali', arabicName: 'وَمَا لِيَ', startSurah: 36, endSurah: 39, surahs: [36, 37, 38, 39]},
+  {id: 24, name: 'Faman Azlam', arabicName: 'فَمَنْ أَظْلَمُ', startSurah: 39, endSurah: 41, surahs: [39, 40, 41]},
+  {id: 25, name: 'Ilayhi Yurad', arabicName: 'إِلَيْهِ يُرَدُّ', startSurah: 41, endSurah: 45, surahs: [41, 42, 43, 44, 45]},
+  {id: 26, name: 'Ha Meem', arabicName: 'حم', startSurah: 46, endSurah: 51, surahs: [46, 47, 48, 49, 50, 51]},
+  {id: 27, name: 'Qala Fama Khatbukum', arabicName: 'قَالَ فَمَا خَطْبُكُمْ', startSurah: 51, endSurah: 57, surahs: [51, 52, 53, 54, 55, 56, 57]},
+  {id: 28, name: 'Qad Sami Allah', arabicName: 'قَدْ سَمِعَ اللَّهُ', startSurah: 58, endSurah: 66, surahs: [58, 59, 60, 61, 62, 63, 64, 65, 66]},
+  {id: 29, name: 'Tabarakallazi', arabicName: 'تَبَارَكَ الَّذِي', startSurah: 67, endSurah: 77, surahs: [67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77]},
+  {id: 30, name: 'Amma', arabicName: 'عَمَّ', startSurah: 78, endSurah: 114, surahs: [78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114]},
+];
+
+/**
+ * Map of surah ID to its primary Juz number
+ * A surah is assigned to the Juz where most of its verses appear
+ */
+export const SURAH_TO_JUZ: Record<number, number> = {
+  1: 1, 2: 1, 3: 3, 4: 4, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10,
+  10: 11, 11: 11, 12: 12, 13: 13, 14: 13, 15: 14, 16: 14,
+  17: 15, 18: 15, 19: 16, 20: 16, 21: 17, 22: 17, 23: 18,
+  24: 18, 25: 18, 26: 19, 27: 19, 28: 20, 29: 20, 30: 21,
+  31: 21, 32: 21, 33: 21, 34: 22, 35: 22, 36: 22, 37: 23,
+  38: 23, 39: 23, 40: 24, 41: 24, 42: 25, 43: 25, 44: 25,
+  45: 25, 46: 26, 47: 26, 48: 26, 49: 26, 50: 26, 51: 26,
+  52: 27, 53: 27, 54: 27, 55: 27, 56: 27, 57: 27, 58: 28,
+  59: 28, 60: 28, 61: 28, 62: 28, 63: 28, 64: 28, 65: 28,
+  66: 28, 67: 29, 68: 29, 69: 29, 70: 29, 71: 29, 72: 29,
+  73: 29, 74: 29, 75: 29, 76: 29, 77: 29, 78: 30, 79: 30,
+  80: 30, 81: 30, 82: 30, 83: 30, 84: 30, 85: 30, 86: 30,
+  87: 30, 88: 30, 89: 30, 90: 30, 91: 30, 92: 30, 93: 30,
+  94: 30, 95: 30, 96: 30, 97: 30, 98: 30, 99: 30, 100: 30,
+  101: 30, 102: 30, 103: 30, 104: 30, 105: 30, 106: 30,
+  107: 30, 108: 30, 109: 30, 110: 30, 111: 30, 112: 30,
+  113: 30, 114: 30,
+};
+
+/**
+ * Get the Juz number for a given surah
+ * @param surahId The surah ID (1-114)
+ * @returns The Juz number (1-30)
+ */
+export const getJuzForSurah = (surahId: number): number => {
+  return SURAH_TO_JUZ[surahId] || 1;
+};
+
+/**
+ * Get Juz info by Juz number
+ * @param juzNumber The Juz number (1-30)
+ * @returns JuzInfo object or undefined
+ */
+export const getJuzInfo = (juzNumber: number): JuzInfo | undefined => {
+  return JUZ_DATA.find(juz => juz.id === juzNumber);
+};
+
+/**
+ * Get all surahs in a specific Juz
+ * @param juzNumber The Juz number (1-30)
+ * @returns Array of surah IDs in that Juz
+ */
+export const getSurahsInJuz = (juzNumber: number): number[] => {
+  const juz = JUZ_DATA.find(j => j.id === juzNumber);
+  return juz?.surahs || [];
+};
+
+/**
+ * Interface for grouped surahs by Juz (for SectionList)
+ */
+export interface JuzSection<T> {
+  juzNumber: number;
+  juzName: string;
+  juzArabicName: string;
+  data: T[];
+}
+
+/**
+ * Group surahs by their Juz number
+ * Handles cases where not all surahs are present
+ * @param surahs Array of surahs to group
+ * @returns Array of JuzSection objects for use with SectionList
+ */
+export const groupSurahsByJuz = <T extends {id: number}>(
+  surahs: T[],
+): JuzSection<T>[] => {
+  // Create a map to group surahs by Juz
+  const juzMap = new Map<number, T[]>();
+
+  // Group surahs by their Juz
+  surahs.forEach(surah => {
+    const juzNumber = getJuzForSurah(surah.id);
+    if (!juzMap.has(juzNumber)) {
+      juzMap.set(juzNumber, []);
+    }
+    juzMap.get(juzNumber)!.push(surah);
+  });
+
+  // Convert map to array of sections, sorted by Juz number
+  const sections: JuzSection<T>[] = [];
+
+  // Sort the Juz numbers to ensure proper order
+  const sortedJuzNumbers = Array.from(juzMap.keys()).sort((a, b) => a - b);
+
+  sortedJuzNumbers.forEach(juzNumber => {
+    const juzInfo = getJuzInfo(juzNumber);
+    if (juzInfo) {
+      const surahsInJuz = juzMap.get(juzNumber) || [];
+      // Sort surahs within each Juz by their ID
+      surahsInJuz.sort((a, b) => a.id - b.id);
+
+      sections.push({
+        juzNumber,
+        juzName: juzInfo.name,
+        juzArabicName: juzInfo.arabicName,
+        data: surahsInJuz,
+      });
+    }
+  });
+
+  return sections;
+};
+
+/**
+ * Group surahs by Juz in descending order (for desc sort)
+ * @param surahs Array of surahs to group
+ * @returns Array of JuzSection objects sorted by Juz descending
+ */
+export const groupSurahsByJuzDesc = <T extends {id: number}>(
+  surahs: T[],
+): JuzSection<T>[] => {
+  const sections = groupSurahsByJuz(surahs);
+  // Reverse Juz order and reverse surahs within each Juz
+  return sections.reverse().map(section => ({
+    ...section,
+    data: [...section.data].reverse(),
+  }));
+};

--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -3,10 +3,10 @@ import {persist, createJSONStorage} from 'zustand/middleware';
 import {storage} from '@/utils/storage';
 
 type BrowseViewMode = 'card' | 'list';
-type BrowseSortOption = 'asc' | 'desc' | 'revelation';
+type BrowseSortOption = 'asc' | 'desc' | 'revelation' | 'juz';
 
 type ReciterProfileViewMode = 'card' | 'list';
-type ReciterProfileSortOption = 'asc' | 'desc' | 'revelation'; // Add revelation option
+type ReciterProfileSortOption = 'asc' | 'desc' | 'revelation' | 'juz';
 
 type CollectionViewMode = 'grid' | 'list';
 


### PR DESCRIPTION
- Add comprehensive Juz data utility (juzData.ts) with all 30 Juz mappings
- Create JuzSectionHeader component for section headers
- Update SurahList to use SectionList for Juz grouping with proper card/list views
- Update ReciterProfile with Juz sort option button
- Update browse-all-surahs screen with Juz grouping support
- Add 'juz' sort option to useSettings for persistence
- Handle partial surah lists (when reciter doesn't have all surahs)
- Optimize performance with memoization and virtualization