### PR TITLE
Fix download corruption after iOS app updates

### DIFF
--- a/services/downloadService.ts
+++ b/services/downloadService.ts
@@ -3,8 +3,37 @@ import {fetchAudioUrl} from './dataService';
 import {DownloadedSurah} from './player/store/downloadStore';
 
 interface DownloadResult {
-  filePath: string;
+  filePath: string; // This is now a RELATIVE path (just the filename)
   fileSize: number;
+}
+
+/**
+ * Resolves a relative file path (filename) to an absolute path.
+ * This is necessary because iOS changes the app container UUID on updates,
+ * so we store only the filename and reconstruct the full path at runtime.
+ * @param relativePath - The filename or relative path
+ * @returns The full absolute path using the current documentDirectory
+ */
+export function resolveFilePath(relativePath: string): string {
+  // If it's already an absolute path (legacy data), extract just the filename
+  if (relativePath.startsWith('file://') || relativePath.startsWith('/')) {
+    const filename = relativePath.split('/').pop() || relativePath;
+    return `${FileSystem.documentDirectory}${filename}`;
+  }
+  // Otherwise, it's already a relative path (just filename)
+  return `${FileSystem.documentDirectory}${relativePath}`;
+}
+
+/**
+ * Extracts just the filename from a path (for migration purposes)
+ * @param filePath - Full path or filename
+ * @returns Just the filename
+ */
+export function extractFilename(filePath: string): string {
+  if (filePath.startsWith('file://') || filePath.startsWith('/')) {
+    return filePath.split('/').pop() || filePath;
+  }
+  return filePath;
 }
 
 /**
@@ -50,8 +79,9 @@ export async function downloadSurah(
     const fileInfo = await FileSystem.getInfoAsync(localPath);
     if (fileInfo.exists) {
       console.log('File already exists:', localPath);
+      // Return only the filename (relative path) for storage
       return {
-        filePath: localPath,
+        filePath: fileName,
         fileSize: fileInfo.size || 0,
       };
     }
@@ -85,8 +115,10 @@ export async function downloadSurah(
 
     console.log('Download complete:', localPath, `Size: ${fileSize} bytes`);
 
+    // Return only the filename (relative path) for storage
+    // This ensures paths remain valid after app updates on iOS
     return {
-      filePath: localPath,
+      filePath: fileName,
       fileSize,
     };
   } catch (error) {
@@ -105,10 +137,12 @@ export async function clearAllDownloads(
   // Delete all files in parallel for better performance
   const deletePromises = downloads.map(async download => {
     try {
-      const fileInfo = await FileSystem.getInfoAsync(download.filePath);
+      // Resolve the relative path to absolute path
+      const absolutePath = resolveFilePath(download.filePath);
+      const fileInfo = await FileSystem.getInfoAsync(absolutePath);
       if (fileInfo.exists) {
-        await FileSystem.deleteAsync(download.filePath);
-        console.log('Deleted file:', download.filePath);
+        await FileSystem.deleteAsync(absolutePath);
+        console.log('Deleted file:', absolutePath);
       }
     } catch (error) {
       const errorMessage =
@@ -132,10 +166,12 @@ export async function clearAllDownloads(
 
 export async function removeDownload(download: DownloadedSurah): Promise<void> {
   try {
-    const fileInfo = await FileSystem.getInfoAsync(download.filePath);
+    // Resolve the relative path to absolute path
+    const absolutePath = resolveFilePath(download.filePath);
+    const fileInfo = await FileSystem.getInfoAsync(absolutePath);
     if (fileInfo.exists) {
-      await FileSystem.deleteAsync(download.filePath);
-      console.log('Deleted file:', download.filePath);
+      await FileSystem.deleteAsync(absolutePath);
+      console.log('Deleted file:', absolutePath);
     }
   } catch (error) {
     console.error('Error deleting file:', download.filePath, error);

--- a/services/player/store/downloadStore.ts
+++ b/services/player/store/downloadStore.ts
@@ -1,8 +1,11 @@
 import {create} from 'zustand';
 import {persist, createJSONStorage} from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import {clearAllDownloads as clearAllDownloadsService} from '@/services/downloadService';
-import {removeDownload as removeDownloadService} from '@/services/downloadService';
+import {
+  clearAllDownloads as clearAllDownloadsService,
+  removeDownload as removeDownloadService,
+  extractFilename,
+} from '@/services/downloadService';
 
 // Throttle utility to prevent excessive state updates during downloads
 const throttleMap = new Map<
@@ -457,6 +460,32 @@ export const useDownloadStore = create<DownloadStoreState>()(
         downloads: state.downloads,
         playlists: state.playlists,
       }),
+      // Migration: Convert absolute paths to relative paths (filenames only)
+      // This fixes the issue where iOS changes the app container UUID on updates,
+      // which would make stored absolute paths invalid
+      onRehydrateStorage: () => state => {
+        if (state && state.downloads.length > 0) {
+          const needsMigration = state.downloads.some(
+            d => d.filePath.startsWith('file://') || d.filePath.startsWith('/'),
+          );
+
+          if (needsMigration) {
+            console.log(
+              '[DownloadStore] Migrating absolute paths to relative paths...',
+            );
+            const migratedDownloads = state.downloads.map(download => ({
+              ...download,
+              filePath: extractFilename(download.filePath),
+            }));
+
+            // Update the store with migrated paths
+            useDownloadStore.setState({downloads: migratedDownloads});
+            console.log(
+              `[DownloadStore] Migrated ${migratedDownloads.length} downloads`,
+            );
+          }
+        }
+      },
     },
   ),
 );

--- a/utils/audioUtils.ts
+++ b/utils/audioUtils.ts
@@ -1,5 +1,6 @@
 import {Reciter} from '@/data/reciterData';
 import {useDownloadStore} from '@/services/player/store/downloadStore';
+import {resolveFilePath} from '@/services/downloadService';
 
 export function generateAudioUrl(
   reciter: Reciter,
@@ -54,10 +55,13 @@ export function generateSmartAudioUrl(
       download.status === 'completed' &&
       (!rewayatId || download.rewayatId === rewayatId)
     ) {
+      // Resolve the relative path to absolute path at runtime
+      // This ensures paths remain valid after iOS app updates
+      const absolutePath = resolveFilePath(download.filePath);
       console.log(
-        `Using local file for ${reciter.name} - Surah ${surahId}${rewayatId ? ` (Rewayat: ${rewayatId})` : ''}: ${download.filePath}`,
+        `Using local file for ${reciter.name} - Surah ${surahId}${rewayatId ? ` (Rewayat: ${rewayatId})` : ''}: ${absolutePath}`,
       );
-      return download.filePath;
+      return absolutePath;
     }
   }
 

--- a/utils/track.ts
+++ b/utils/track.ts
@@ -3,6 +3,7 @@ import {Track} from '@/types/audio';
 import {Surah} from '@/data/surahData';
 import {generateSmartAudioUrl} from './audioUtils';
 import {getReciterArtwork} from '@/utils/artworkUtils';
+import {resolveFilePath} from '@/services/downloadService';
 
 /**
  * Filters and returns available surahs for a given rewayat
@@ -108,9 +109,9 @@ export async function createTracksForRange(
  * Creates a Track object for a downloaded file using local file path
  * @param reciter - Reciter object
  * @param surah - Surah object
- * @param filePath - Local file path to the downloaded audio file
+ * @param filePath - Local file path (can be relative filename or absolute path)
  * @param rewayatId - Optional specific rewayat ID
- * @returns Track object with local file path
+ * @returns Track object with resolved absolute file path
  */
 export function createDownloadedTrack(
   reciter: Reciter,
@@ -118,9 +119,13 @@ export function createDownloadedTrack(
   filePath: string,
   rewayatId?: string,
 ): Track {
+  // Resolve the path to ensure it uses the current app container
+  // This is necessary because iOS changes the container UUID on app updates
+  const resolvedPath = resolveFilePath(filePath);
+
   return {
     id: `${reciter.id}-${surah.id}`,
-    url: filePath, // Use local file path instead of remote URL
+    url: resolvedPath, // Use resolved absolute path
     title: surah.name,
     artist: reciter.name,
     artwork: getReciterArtwork(reciter),


### PR DESCRIPTION
## Summary
- Fixes downloads becoming corrupt/inaccessible after TestFlight updates
- Stores relative file paths (filenames only) instead of absolute paths
- Adds automatic migration for existing downloads

## Problem
iOS changes the app container UUID on updates, which invalidates stored absolute paths like:
```
file:///var/mobile/Containers/Data/Application/ABC123-UUID/Documents/001_reciter.mp3
```

After an app update, the UUID changes but stored paths still reference the old one, making files appear "corrupt".

## Solution
- Store only filenames (e.g., `001_reciter.mp3`) instead of full paths
- Resolve to absolute paths at runtime using `FileSystem.documentDirectory`
- Automatically migrate existing absolute paths on app startup

## Changes
- `services/downloadService.ts`: Added `resolveFilePath()` and `extractFilename()` helpers, updated download functions
- `services/player/store/downloadStore.ts`: Added migration in `onRehydrateStorage`
- `utils/audioUtils.ts`: Updated to resolve paths at runtime
- `utils/track.ts`: Updated `createDownloadedTrack()` to resolve paths

## Test plan
- [ ] Fresh install: Download a surah, verify playback works
- [ ] Update scenario: Install current version, download surahs, update to this version, verify downloads still work
- [ ] Migration: Check console logs for migration messages on app startup with existing downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)