### PR TITLE
Reciters view playlist route

### DIFF
--- a/app/(tabs)/(a.home)/_layout.tsx
+++ b/app/(tabs)/(a.home)/_layout.tsx
@@ -6,6 +6,7 @@ export default function HomeLayout() {
       <Stack.Screen name="index" options={{headerShown: false}} />
       <Stack.Screen name="reciter/[id]" options={{headerShown: false}} />
       <Stack.Screen name="reciter/browse" options={{headerShown: false}} />
+      <Stack.Screen name="playlist/[id]" options={{headerShown: false}} />
       <Stack.Screen name="settings/index" options={{headerShown: false}} />
       <Stack.Screen name="settings/storage" options={{headerShown: false}} />
       <Stack.Screen name="settings/about" options={{headerShown: false}} />

--- a/app/(tabs)/(a.home)/playlist/[id].tsx
+++ b/app/(tabs)/(a.home)/playlist/[id].tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {useLocalSearchParams} from 'expo-router';
+import PlaylistDetail from '@/components/playlist-detail/PlaylistDetail';
+
+const HomePlaylistDetail: React.FC = () => {
+  const {id} = useLocalSearchParams<{id: string}>();
+
+  if (!id) {
+    return null; // Handle the absence of id appropriately
+  }
+
+  return <PlaylistDetail id={id} />;
+};
+
+export default HomePlaylistDetail;

--- a/components/RecitersView.tsx
+++ b/components/RecitersView.tsx
@@ -413,7 +413,7 @@ function RecitersView({onReciterPress}: RecitersViewProps) {
   // Handler for playlist card press
   const handlePlaylistPress = (playlist: UserPlaylist) => {
     router.push({
-      pathname: '/(tabs)/(c.collection)/playlist/[id]',
+      pathname: '/(tabs)/(a.home)/playlist/[id]',
       params: {id: playlist.id},
     });
   };


### PR DESCRIPTION
Add a direct route to the playlist detail screen within the home tab to prevent unnecessary tab switching.

---
<a href="https://cursor.com/background-agent?bcId=bc-032f6791-3985-43ca-9483-7316aa426848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-032f6791-3985-43ca-9483-7316aa426848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

