### PR TITLE
Playlist reciter detail link

### DIFF
--- a/components/playlist-detail/ReciterDownloadsHeader.tsx
+++ b/components/playlist-detail/ReciterDownloadsHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, TouchableOpacity} from 'react-native';
+import {View, Text, TouchableOpacity, Pressable} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {LinearGradient} from 'expo-linear-gradient';
@@ -20,6 +20,7 @@ const AnimatedTouchableOpacity =
   Animated.createAnimatedComponent(TouchableOpacity);
 
 interface ReciterDownloadsHeaderProps {
+  reciterId: string;
   reciterName: string;
   reciterImageUrl?: string;
   subtitle: string;
@@ -29,6 +30,7 @@ interface ReciterDownloadsHeaderProps {
 }
 
 export const ReciterDownloadsHeader: React.FC<ReciterDownloadsHeaderProps> = ({
+  reciterId,
   reciterName,
   reciterImageUrl,
   subtitle,
@@ -39,6 +41,10 @@ export const ReciterDownloadsHeader: React.FC<ReciterDownloadsHeaderProps> = ({
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const styles = createStyles(theme, insets);
+
+  const handleReciterPress = () => {
+    router.push(`/reciter/${reciterId}`);
+  };
 
   // Animation values for button press feedback
   const shuffleScale = useSharedValue(1);
@@ -88,17 +94,21 @@ export const ReciterDownloadsHeader: React.FC<ReciterDownloadsHeaderProps> = ({
 
         {/* Header Content */}
         <View style={styles.contentContainer}>
-          {/* Reciter Image */}
-          <View style={styles.reciterImageContainer}>
-            <ReciterImage
-              reciterName={reciterName}
-              imageUrl={reciterImageUrl}
-              style={styles.reciterImage}
-            />
-          </View>
+          {/* Reciter Image - Tappable to navigate to reciter profile */}
+          <Pressable onPress={handleReciterPress}>
+            <View style={styles.reciterImageContainer}>
+              <ReciterImage
+                reciterName={reciterName}
+                imageUrl={reciterImageUrl}
+                style={styles.reciterImage}
+              />
+            </View>
+          </Pressable>
 
-          {/* Title and Subtitle */}
-          <Text style={styles.title}>{reciterName}</Text>
+          {/* Title and Subtitle - Title tappable to navigate to reciter profile */}
+          <Pressable onPress={handleReciterPress}>
+            <Text style={styles.title}>{reciterName}</Text>
+          </Pressable>
           <Text style={styles.subtitle}>{subtitle}</Text>
         </View>
       </LinearGradient>

--- a/components/reciter-downloads/ReciterDownloadsList.tsx
+++ b/components/reciter-downloads/ReciterDownloadsList.tsx
@@ -484,6 +484,7 @@ export const ReciterDownloadsList: React.FC<ReciterDownloadsListProps> = ({
   const ListHeaderComponent = useCallback(() => {
     return (
       <ReciterDownloadsHeader
+        reciterId={reciterId}
         reciterName={reciter?.name || 'Reciter'}
         reciterImageUrl={reciter?.image_url || undefined}
         subtitle={`${downloadData.length} ${downloadData.length === 1 ? 'surah' : 'surahs'} downloaded`}
@@ -492,7 +493,7 @@ export const ReciterDownloadsList: React.FC<ReciterDownloadsListProps> = ({
         theme={theme}
       />
     );
-  }, [reciter, downloadData.length, handlePlayAll, handleShuffle, theme]);
+  }, [reciterId, reciter, downloadData.length, handlePlayAll, handleShuffle, theme]);
 
   const renderItem: ListRenderItem<DownloadTrackData> = ({item}) => {
     const {download, reciter: itemReciter, surah, rewayatName} = item;


### PR DESCRIPTION
Enable navigation to the reciter detail screen by tapping the reciter image or name in the downloads playlist header.

The interaction uses `Pressable` components to avoid any visual tap feedback, fulfilling the requirement for no explicit tap interactions on these elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd8863bc-6659-4d5d-bd38-44ca99cc7c1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd8863bc-6659-4d5d-bd38-44ca99cc7c1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

