### PR TITLE
Add Juz section separators to surah lists

### DIFF
--- a/components/SurahsView.tsx
+++ b/components/SurahsView.tsx
@@ -14,9 +14,11 @@ import {SURAHS, Surah} from '@/data/surahData';
 import Color from 'color';
 import {SurahsHero} from '@/components/hero/SurahsHero';
 import {GRADIENT_COLORS} from '@/utils/gradientColors';
+import {LinearGradient} from 'expo-linear-gradient';
 import {Icon} from '@rneui/themed';
 import {useSettings} from '@/hooks/useSettings';
 import {TOTAL_BOTTOM_PADDING} from '@/utils/constants';
+import {getJuzForSurah, getJuzName} from '@/data/juzData';
 
 interface SurahsViewProps {
   onSurahPress: (surah: Surah) => void;
@@ -24,6 +26,11 @@ interface SurahsViewProps {
 
 type ViewMode = 'card' | 'list';
 type SortOption = 'asc' | 'desc' | 'revelation';
+
+// Type for list items - can be either a Juz header or surah row
+type ListItem =
+  | {type: 'juz-header'; juzNumber: number; juzName: string}
+  | {type: 'surah-row'; surahs: Surah[]};
 
 function getSurahOfTheDay(): Surah {
   const today = new Date();
@@ -94,19 +101,53 @@ export default function SurahsView({onSurahPress}: SurahsViewProps) {
 
   // Prepare section data based on view mode
   const sections = useMemo(() => {
+    // Only show Juz headers in list view with asc/desc sort (not revelation)
+    const shouldShowJuzHeaders =
+      viewMode === 'list' && (sortOption === 'asc' || sortOption === 'desc');
+
     if (viewMode === 'card') {
+      // Card view: pairs of surahs, no Juz headers
       const pairs = groupSurahsIntoPairs(displaySurahs);
-      return [{title: 'surahs', data: pairs, viewMode: 'card' as const}];
+      const data: ListItem[] = pairs.map(pair => ({
+        type: 'surah-row' as const,
+        surahs: pair,
+      }));
+      return [{title: 'surahs', data, viewMode: 'card' as const}];
+    } else if (shouldShowJuzHeaders) {
+      // List view with Juz grouping
+      const data: ListItem[] = [];
+      let currentJuz: number | null = null;
+
+      displaySurahs.forEach(surah => {
+        const surahJuz = getJuzForSurah(surah.id);
+
+        // Add Juz header when we encounter a new Juz
+        if (surahJuz !== currentJuz) {
+          currentJuz = surahJuz;
+          data.push({
+            type: 'juz-header',
+            juzNumber: surahJuz,
+            juzName: getJuzName(surahJuz),
+          });
+        }
+
+        // Add the surah
+        data.push({
+          type: 'surah-row',
+          surahs: [surah],
+        });
+      });
+
+      return [{title: 'surahs', data, viewMode: 'list' as const}];
     } else {
-      return [
-        {
-          title: 'surahs',
-          data: displaySurahs.map(s => [s]),
-          viewMode: 'list' as const,
-        },
-      ];
+      // List view without Juz grouping (revelation order)
+      const data: ListItem[] = displaySurahs.map(s => ({
+        type: 'surah-row' as const,
+        surahs: [s],
+      }));
+      return [{title: 'surahs', data, viewMode: 'list' as const}];
     }
-  }, [displaySurahs, viewMode]);
+  }, [displaySurahs, viewMode, sortOption]);
 
   // Function to generate a consistent color for each surah
   const getColorForSurah = useCallback((id: number): string => {
@@ -129,11 +170,52 @@ export default function SurahsView({onSurahPress}: SurahsViewProps) {
 
   // Render item for SectionList
   const renderItem = useCallback(
-    ({item, section}: {item: Surah[]; section: {viewMode: ViewMode}}) => {
+    ({item, section}: {item: ListItem; section: {viewMode: ViewMode}}) => {
+      // Handle Juz header
+      if (item.type === 'juz-header') {
+        return (
+          <View style={styles.juzHeader}>
+            <LinearGradient
+              colors={['transparent', theme.colors.border]}
+              locations={[0, 0.5]}
+              start={{x: 0, y: 0.5}}
+              end={{x: 1, y: 0.5}}
+              style={styles.juzHeaderLine}
+            />
+            <View
+              style={[
+                styles.juzHeaderPill,
+                {
+                  backgroundColor: Color(theme.colors.text)
+                    .alpha(0.05)
+                    .toString(),
+                },
+              ]}>
+              <Text
+                style={[
+                  styles.juzHeaderText,
+                  {color: theme.colors.textSecondary},
+                ]}>
+                {item.juzName}
+              </Text>
+            </View>
+            <LinearGradient
+              colors={[theme.colors.border, 'transparent']}
+              locations={[0.5, 1]}
+              start={{x: 0, y: 0.5}}
+              end={{x: 1, y: 0.5}}
+              style={styles.juzHeaderLine}
+            />
+          </View>
+        );
+      }
+
+      // Handle surah row
+      const surahs = item.surahs;
       if (section.viewMode === 'card') {
         return (
           <View style={styles.cardRow}>
-            {item.map(surah => (
+            {surahs.map(surah => (
               <SurahCard
                 key={surah.id}
                 id={surah.id}
@@ -146,14 +228,20 @@ export default function SurahsView({onSurahPress}: SurahsViewProps) {
                 style={styles.surahCard}
               />
             ))}
-            {item.length === 1 && <View style={styles.surahCard} />}
+            {surahs.length === 1 && <View style={styles.surahCard} />}
           </View>
         );
       } else {
-        return <SurahItem item={item[0]} onPress={onSurahPress} />;
+        return <SurahItem item={surahs[0]} onPress={onSurahPress} />;
       }
     },
-    [getColorForSurah, onSurahPress],
+    [
+      getColorForSurah,
+      onSurahPress,
+      theme.colors.textSecondary,
+      theme.colors.border,
+      theme.colors.text,
+    ],
   );
 
   // Render section header (sticky sort options)
@@ -301,11 +389,12 @@ export default function SurahsView({onSurahPress}: SurahsViewProps) {
     [surahOfTheDay, onSurahPress],
   );
 
-  const keyExtractor = useCallback(
-    (item: Surah[], index: number) =>
-      `row-${index}-${item.map(s => s.id).join('-')}`,
-    [],
-  );
+  const keyExtractor = useCallback((item: ListItem, index: number) => {
+    if (item.type === 'juz-header') {
+      return `juz-${item.juzNumber}`;
+    }
+    return `row-${index}-${item.surahs.map(s => s.id).join('-')}`;
+  }, []);
 
   return (
     <View style={styles.container}>
@@ -378,5 +467,28 @@ const styles = StyleSheet.create({
   },
   itemSeparator: {
     height: moderateScale(12),
+  },
+  juzHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: moderateScale(16),
+    marginTop: moderateScale(8),
+    marginBottom: moderateScale(-4),
+  },
+  juzHeaderLine: {
+    flex: 1,
+    height: 1,
+  },
+  juzHeaderPill: {
+    paddingHorizontal: moderateScale(12),
+    paddingVertical: moderateScale(5),
+    borderRadius: moderateScale(12),
+    marginHorizontal: moderateScale(8),
+  },
+  juzHeaderText: {
+    fontSize: moderateScale(10),
+    fontFamily: 'Manrope-SemiBold',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
   },
 });

--- a/components/reciter-profile/components/SurahList/index.tsx
+++ b/components/reciter-profile/components/SurahList/index.tsx
@@ -8,10 +8,18 @@ import {SurahListProps} from '@/components/reciter-profile/types';
 import {SurahItem} from '@/components/SurahItem';
 import {SurahCard} from '@/components/cards/SurahCard';
 import {Surah} from '@/data/surahData';
+import {getJuzForSurah, getJuzName} from '@/data/juzData';
+import Color from 'color';
+import {LinearGradient} from 'expo-linear-gradient';
 
 // Define types matching useSettings and ReciterProfile
 type ReciterProfileViewMode = 'card' | 'list';
 type ReciterProfileSortOption = 'asc' | 'desc' | 'revelation'; // Include revelation order
+
+// Type for list items - can be either a Juz header or surah
+type ListItem =
+  | {type: 'juz-header'; juzNumber: number; juzName: string}
+  | {type: 'surah'; surah: Surah};
 
 // Update props interface (consider moving this to types/reciter-profile.ts)
 interface UpdatedSurahListProps extends SurahListProps {
@@ -51,12 +59,47 @@ export const SurahList = React.forwardRef<
       contentContainerStyle,
       viewMode,
       getColorForSurah,
+      sortOption,
       rewayatId,
     },
     ref,
   ) => {
     const {theme} = useTheme();
     const styles = createStyles(theme);
+
+    // Prepare list data with Juz headers when in list view with asc/desc sort
+    const listData = React.useMemo(() => {
+      const shouldShowJuzHeaders =
+        viewMode === 'list' && (sortOption === 'asc' || sortOption === 'desc');
+
+      if (!shouldShowJuzHeaders) {
+        // No Juz headers - just return surahs wrapped in ListItem type
+        return surahs.map(surah => ({type: 'surah' as const, surah}));
+      }
+
+      // Add Juz headers
+      const data: ListItem[] = [];
+      let currentJuz: number | null = null;
+
+      surahs.forEach(surah => {
+        const surahJuz = getJuzForSurah(surah.id);
+
+        // Add Juz header when we encounter a new Juz
+        if (surahJuz !== currentJuz) {
+          currentJuz = surahJuz;
+          data.push({
+            type: 'juz-header',
+            juzNumber: surahJuz,
+            juzName: getJuzName(surahJuz),
+          });
+        }
+
+        // Add the surah
+        data.push({type: 'surah', surah});
+      });
+
+      return data;
+    }, [surahs, viewMode, sortOption]);
 
     // Render a card item
     const renderCardItem = React.useCallback(
@@ -89,19 +132,61 @@ export const SurahList = React.forwardRef<
       ],
     );
 
-    // Render a list item using SurahItem
+    // Render a list item (surah or Juz header)
     const renderListItem = React.useCallback(
-      ({item}: {item: Surah}) => (
-        <SurahItem
-          item={item}
-          onPress={onSurahPress}
-          reciterId={reciterId}
-          isLoved={isLoved(reciterId, item.id.toString())}
-          isDownloaded={isDownloaded(reciterId, item.id.toString())}
-          onOptionsPress={onOptionsPress}
-          rewayatId={rewayatId}
-        />
-      ),
+      ({item}: {item: ListItem}) => {
+        // Handle Juz header
+        if (item.type === 'juz-header') {
+          return (
+            <View style={styles.juzHeader}>
+              <LinearGradient
+                colors={['transparent', theme.colors.border]}
+                locations={[0, 0.5]}
+                start={{x: 0, y: 0.5}}
+                end={{x: 1, y: 0.5}}
+                style={styles.juzHeaderLine}
+              />
+              <View
+                style={[
+                  styles.juzHeaderPill,
+                  {
+                    backgroundColor: Color(theme.colors.text)
+                      .alpha(0.05)
+                      .toString(),
+                  },
+                ]}>
+                <Text
+                  style={[
+                    styles.juzHeaderText,
+                    {color: theme.colors.textSecondary},
+                  ]}>
+                  {item.juzName}
+                </Text>
+              </View>
+              <LinearGradient
+                colors={[theme.colors.border, 'transparent']}
+                locations={[0.5, 1]}
+                start={{x: 0, y: 0.5}}
+                end={{x: 1, y: 0.5}}
+                style={styles.juzHeaderLine}
+              />
+            </View>
+          );
+        }
+
+        // Handle surah
+        return (
+          <SurahItem
+            item={item.surah}
+            onPress={onSurahPress}
+            reciterId={reciterId}
+            isLoved={isLoved(reciterId, item.surah.id.toString())}
+            isDownloaded={isDownloaded(reciterId, item.surah.id.toString())}
+            onOptionsPress={onOptionsPress}
+            rewayatId={rewayatId}
+          />
+        );
+      },
       [
         onSurahPress,
         reciterId,
@@ -109,8 +194,23 @@ export const SurahList = React.forwardRef<
         isDownloaded,
         onOptionsPress,
         rewayatId,
+        styles.juzHeader,
+        styles.juzHeaderLine,
+        styles.juzHeaderPill,
+        styles.juzHeaderText,
+        theme.colors.textSecondary,
+        theme.colors.border,
+        theme.colors.text,
       ],
     );
+
+    // Key extractor for list items
+    const listKeyExtractor = React.useCallback((item: ListItem) => {
+      if (item.type === 'juz-header') {
+        return `juz-${item.juzNumber}`;
+      }
+      return `list-${item.surah.id}`;
+    }, []);
 
     // Shared ListHeader to avoid re-rendering issues
     const HeaderMemo = React.useMemo(
@@ -166,9 +266,9 @@ export const SurahList = React.forwardRef<
             ref={viewMode === 'list' ? ref : undefined}
             bounces={true}
             showsVerticalScrollIndicator={false}
-            data={surahs}
+            data={listData}
             renderItem={renderListItem}
-            keyExtractor={item => `list-${item.id}`}
+            keyExtractor={listKeyExtractor}
             ListHeaderComponent={HeaderMemo}
             onScroll={viewMode === 'list' ? onScroll : undefined}
             scrollEventThrottle={1}
@@ -224,5 +324,28 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.textSecondary,
       textAlign: 'center',
       marginTop: moderateScale(20),
+    },
+    juzHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: moderateScale(16),
+      marginTop: moderateScale(8),
+      marginBottom: moderateScale(-4),
+    },
+    juzHeaderLine: {
+      flex: 1,
+      height: 1,
+    },
+    juzHeaderPill: {
+      paddingHorizontal: moderateScale(12),
+      paddingVertical: moderateScale(5),
+      borderRadius: moderateScale(12),
+      marginHorizontal: moderateScale(8),
+    },
+    juzHeaderText: {
+      fontSize: moderateScale(10),
+      fontFamily: 'Manrope-SemiBold',
+      textTransform: 'uppercase',
+      letterSpacing: 0.8,
     },
   });

--- a/data/juzData.ts
+++ b/data/juzData.ts
@@ -1,0 +1,204 @@
+/**
+ * Juz (Part) Data for the Quran
+ *
+ * The Quran is divided into 30 Juz (parts) for easier reading.
+ * This file maps each surah to the Juz where it STARTS.
+ *
+ * Note: Some surahs span multiple Juz, but we only track where they begin.
+ */
+
+/**
+ * Mapping of surah ID (1-114) to its starting Juz number (1-30)
+ */
+export const SURAH_TO_JUZ: Record<number, number> = {
+  // Juz 1: Surahs 1-2
+  1: 1, // Al-Fatiha
+  2: 1, // Al-Baqara
+
+  // Juz 3: Surah 3
+  3: 3, // Al-Imran
+
+  // Juz 4: Surah 4
+  4: 4, // An-Nisa
+
+  // Juz 6: Surah 5
+  5: 6, // Al-Ma'ida
+
+  // Juz 7: Surah 6
+  6: 7, // Al-An'am
+
+  // Juz 8: Surah 7
+  7: 8, // Al-A'raf
+
+  // Juz 9: Surah 8
+  8: 9, // Al-Anfal
+
+  // Juz 10: Surah 9
+  9: 10, // At-Tawba
+
+  // Juz 11: Surahs 10-11
+  10: 11, // Yunus
+  11: 11, // Hud
+
+  // Juz 12: Surah 12
+  12: 12, // Yusuf
+
+  // Juz 13: Surahs 13-14
+  13: 13, // Ar-Ra'd
+  14: 13, // Ibrahim
+
+  // Juz 14: Surahs 15-16
+  15: 14, // Al-Hijr
+  16: 14, // An-Nahl
+
+  // Juz 15: Surahs 17-18
+  17: 15, // Al-Isra
+  18: 15, // Al-Kahf
+
+  // Juz 16: Surahs 19-20
+  19: 16, // Maryam
+  20: 16, // Ta-Ha
+
+  // Juz 17: Surahs 21-22
+  21: 17, // Al-Anbiya
+  22: 17, // Al-Hajj
+
+  // Juz 18: Surahs 23-25
+  23: 18, // Al-Mu'minun
+  24: 18, // An-Nur
+  25: 18, // Al-Furqan
+
+  // Juz 19: Surahs 26-27
+  26: 19, // Ash-Shu'ara
+  27: 19, // An-Naml
+
+  // Juz 20: Surahs 28-29
+  28: 20, // Al-Qasas
+  29: 20, // Al-Ankabut
+
+  // Juz 21: Surahs 30-33
+  30: 21, // Ar-Rum
+  31: 21, // Luqman
+  32: 21, // As-Sajda
+  33: 21, // Al-Ahzab
+
+  // Juz 22: Surahs 34-36
+  34: 22, // Saba
+  35: 22, // Fatir
+  36: 22, // Ya-Sin
+
+  // Juz 23: Surahs 37-39
+  37: 23, // As-Saffat
+  38: 23, // Sad
+  39: 23, // Az-Zumar
+
+  // Juz 24: Surahs 40-41
+  40: 24, // Ghafir
+  41: 24, // Fussilat
+
+  // Juz 25: Surahs 42-45
+  42: 25, // Ash-Shura
+  43: 25, // Az-Zukhruf
+  44: 25, // Ad-Dukhan
+  45: 25, // Al-Jathiya
+
+  // Juz 26: Surahs 46-51
+  46: 26, // Al-Ahqaf
+  47: 26, // Muhammad
+  48: 26, // Al-Fath
+  49: 26, // Al-Hujurat
+  50: 26, // Qaf
+  51: 26, // Adh-Dhariyat
+
+  // Juz 27: Surahs 52-57
+  52: 27, // At-Tur
+  53: 27, // An-Najm
+  54: 27, // Al-Qamar
+  55: 27, // Ar-Rahman
+  56: 27, // Al-Waqi'a
+  57: 27, // Al-Hadid
+
+  // Juz 28: Surahs 58-66
+  58: 28, // Al-Mujadila
+  59: 28, // Al-Hashr
+  60: 28, // Al-Mumtahina
+  61: 28, // As-Saff
+  62: 28, // Al-Jumu'a
+  63: 28, // Al-Munafiqun
+  64: 28, // At-Taghabun
+  65: 28, // At-Talaq
+  66: 28, // At-Tahrim
+
+  // Juz 29: Surahs 67-77
+  67: 29, // Al-Mulk
+  68: 29, // Al-Qalam
+  69: 29, // Al-Haaqqa
+  70: 29, // Al-Ma'arij
+  71: 29, // Nuh
+  72: 29, // Al-Jinn
+  73: 29, // Al-Muzzammil
+  74: 29, // Al-Muddaththir
+  75: 29, // Al-Qiyama
+  76: 29, // Al-Insan
+  77: 29, // Al-Mursalat
+
+  // Juz 30 (Juz 'Amma): Surahs 78-114
+  78: 30, // An-Naba
+  79: 30, // An-Nazi'at
+  80: 30, // 'Abasa
+  81: 30, // At-Takwir
+  82: 30, // Al-Infitar
+  83: 30, // Al-Mutaffifin
+  84: 30, // Al-Inshiqaq
+  85: 30, // Al-Buruj
+  86: 30, // At-Tariq
+  87: 30, // Al-A'la
+  88: 30, // Al-Ghashiya
+  89: 30, // Al-Fajr
+  90: 30, // Al-Balad
+  91: 30, // Ash-Shams
+  92: 30, // Al-Layl
+  93: 30, // Ad-Duha
+  94: 30, // Ash-Sharh
+  95: 30, // At-Tin
+  96: 30, // Al-'Alaq
+  97: 30, // Al-Qadr
+  98: 30, // Al-Bayyina
+  99: 30, // Az-Zalzala
+  100: 30, // Al-'Adiyat
+  101: 30, // Al-Qari'a
+  102: 30, // At-Takathur
+  103: 30, // Al-'Asr
+  104: 30, // Al-Humaza
+  105: 30, // Al-Fil
+  106: 30, // Quraysh
+  107: 30, // Al-Ma'un
+  108: 30, // Al-Kawthar
+  109: 30, // Al-Kafirun
+  110: 30, // An-Nasr
+  111: 30, // Al-Masad
+  112: 30, // Al-Ikhlas
+  113: 30, // Al-Falaq
+  114: 30, // An-Nas
+};
+
+/**
+ * Get the Juz number for a given surah
+ * @param surahId - The surah ID (1-114)
+ * @returns The Juz number (1-30) where the surah starts
+ */
+export function getJuzForSurah(surahId: number): number {
+  return SURAH_TO_JUZ[surahId] || 1;
+}
+
+/**
+ * Get the display name for a Juz
+ * @param juzNumber - The Juz number (1-30)
+ * @returns The formatted Juz name
+ */
+export function getJuzName(juzNumber: number): string {
+  if (juzNumber === 30) {
+    return "Juz' 'Amma";
+  }
+  return `Juz' ${juzNumber}`;
+}


### PR DESCRIPTION
## Summary
- Add Juz (part) section separators to surah lists in both SurahsView and ReciterProfile
- Headers display only in list view when sorting by ascending or descending order
- Elegant design with pill badge and gradient fade divider lines

## Changes
- **New file**: `data/juzData.ts` - Maps all 114 surahs to their starting Juz (1-30)
- **Modified**: `components/SurahsView.tsx` - Added Juz headers with refined styling
- **Modified**: `components/reciter-profile/components/SurahList/index.tsx` - Added matching Juz headers

## Test plan
- [ ] Open Surahs tab and switch to list view
- [ ] Verify Juz headers appear with ascending sort
- [ ] Verify Juz headers appear with descending sort (Juz 30 first)
- [ ] Verify Juz headers do NOT appear with revelation sort
- [ ] Verify Juz headers do NOT appear in card/grid view
- [ ] Open a reciter profile and verify same behavior
- [ ] Test in both light and dark modes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)