### PR TITLE
Add iOS CLI archive script

### DIFF
--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>teamID</key>
+    <string>S4W5Q2L53W</string>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>compileBitcode</key>
+    <false/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "version:patch": "node scripts/version-bump.js patch",
     "version:minor": "node scripts/version-bump.js minor",
     "version:major": "node scripts/version-bump.js major",
-    "version:current": "node scripts/generate-version.js"
+    "version:current": "node scripts/generate-version.js",
+    "ios:archive": "./scripts/ios-archive.sh",
+    "ios:archive:upload": "./scripts/ios-archive.sh --upload"
   },
   "jest": {
     "preset": "jest-expo"

--- a/scripts/ios-archive.sh
+++ b/scripts/ios-archive.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# iOS Archive and Upload Script
+# Usage: ./scripts/ios-archive.sh [--upload]
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+WORKSPACE="ios/Bayaan.xcworkspace"
+SCHEME="Bayaan"
+CONFIGURATION="Release"
+ARCHIVE_PATH="build/Bayaan.xcarchive"
+EXPORT_PATH="build/export"
+EXPORT_OPTIONS="ios/ExportOptions.plist"
+
+# Parse arguments
+UPLOAD=false
+for arg in "$@"; do
+    case $arg in
+        --upload)
+            UPLOAD=true
+            shift
+            ;;
+    esac
+done
+
+echo -e "${YELLOW}🔧 iOS Archive Script${NC}"
+echo "========================"
+
+# Get version from package.json
+VERSION=$(node -p "require('./package.json').version")
+echo -e "Version: ${GREEN}$VERSION${NC}"
+
+# Clean build folder
+echo -e "\n${YELLOW}📁 Cleaning build folder...${NC}"
+rm -rf build/
+mkdir -p build/
+
+# Run pod install
+echo -e "\n${YELLOW}📦 Running pod install...${NC}"
+cd ios && pod install && cd ..
+
+# Archive
+echo -e "\n${YELLOW}📦 Archiving...${NC}"
+xcodebuild -workspace "$WORKSPACE" \
+    -scheme "$SCHEME" \
+    -configuration "$CONFIGURATION" \
+    -archivePath "$ARCHIVE_PATH" \
+    -destination "generic/platform=iOS" \
+    archive \
+    | xcpretty || xcodebuild -workspace "$WORKSPACE" \
+    -scheme "$SCHEME" \
+    -configuration "$CONFIGURATION" \
+    -archivePath "$ARCHIVE_PATH" \
+    -destination "generic/platform=iOS" \
+    archive
+
+if [ ! -d "$ARCHIVE_PATH" ]; then
+    echo -e "${RED}❌ Archive failed${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ Archive created at $ARCHIVE_PATH${NC}"
+
+# Export
+echo -e "\n${YELLOW}📤 Exporting IPA...${NC}"
+xcodebuild -exportArchive \
+    -archivePath "$ARCHIVE_PATH" \
+    -exportPath "$EXPORT_PATH" \
+    -exportOptionsPlist "$EXPORT_OPTIONS" \
+    | xcpretty || xcodebuild -exportArchive \
+    -archivePath "$ARCHIVE_PATH" \
+    -exportPath "$EXPORT_PATH" \
+    -exportOptionsPlist "$EXPORT_OPTIONS"
+
+if [ ! -f "$EXPORT_PATH/Bayaan.ipa" ]; then
+    echo -e "${RED}❌ Export failed${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ IPA exported to $EXPORT_PATH/Bayaan.ipa${NC}"
+
+# Upload to App Store Connect (optional)
+if [ "$UPLOAD" = true ]; then
+    echo -e "\n${YELLOW}🚀 Uploading to App Store Connect...${NC}"
+    xcrun altool --upload-app \
+        --type ios \
+        --file "$EXPORT_PATH/Bayaan.ipa" \
+        --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
+        --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID" \
+        2>/dev/null || \
+    xcrun notarytool submit "$EXPORT_PATH/Bayaan.ipa" \
+        --keychain-profile "AC_PASSWORD" \
+        --wait 2>/dev/null || \
+    echo -e "${YELLOW}⚠️  Auto-upload requires App Store Connect API key setup.${NC}"
+    echo -e "${YELLOW}   You can manually upload using Transporter app or:${NC}"
+    echo -e "${YELLOW}   xcrun altool --upload-app --type ios --file $EXPORT_PATH/Bayaan.ipa${NC}"
+fi
+
+echo -e "\n${GREEN}🎉 Done!${NC}"
+echo -e "Archive: $ARCHIVE_PATH"
+echo -e "IPA: $EXPORT_PATH/Bayaan.ipa"


### PR DESCRIPTION
## Summary
- Add `scripts/ios-archive.sh` for CLI-based iOS archiving
- Add `ios/ExportOptions.plist` for App Store export configuration
- Add npm scripts for easy access

## Usage
```bash
npm run ios:archive         # Build and export IPA
npm run ios:archive:upload  # Build, export, and upload to App Store Connect
```

## Test plan
- [ ] Run `npm run ios:archive` and verify IPA is created at `build/export/Bayaan.ipa`
- [ ] Test upload functionality (requires App Store Connect API key setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)