### PR TITLE
Fix edit playlist modal not opening

### DIFF
--- a/components/sheets/PlaylistContextSheet.tsx
+++ b/components/sheets/PlaylistContextSheet.tsx
@@ -105,10 +105,13 @@ export const PlaylistContextSheet = (props: SheetProps<'playlist-context'>) => {
   }, []);
 
   const handleEdit = useCallback(() => {
-    if (onEdit) {
-      onEdit();
-    }
     handleClose();
+    // Wait for context sheet to close before showing edit sheet
+    setTimeout(() => {
+      if (onEdit) {
+        onEdit();
+      }
+    }, 300);
   }, [onEdit, handleClose]);
 
   const handleDelete = useCallback(() => {


### PR DESCRIPTION
## Summary
- Fixes the edit playlist button in the playlist context menu not opening the edit modal
- Root cause: race condition where both sheets were transitioning simultaneously
- Fix: Close the context sheet first, wait 300ms for animation, then show the edit sheet

## Test plan
- [ ] Open a playlist
- [ ] Tap the options button (three dots)
- [ ] Tap "Edit Playlist"
- [ ] Verify the edit modal opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)