### PR TITLE
Fix downloaded track playback issues

### DIFF
--- a/services/player/events/playbackService.ts
+++ b/services/player/events/playbackService.ts
@@ -59,24 +59,28 @@ async function validateTrackState(): Promise<{
       };
     }
 
-    // Check if URL is accessible
-    try {
-      const response = await fetch(track.url, {method: 'HEAD'});
-      if (!response.ok) {
+    // Check if URL is accessible (only for remote URLs)
+    // Skip validation for local file:// URLs - fetch doesn't support them
+    // and TrackPlayer handles local file validation internally
+    if (!track.url.startsWith('file://')) {
+      try {
+        const response = await fetch(track.url, {method: 'HEAD'});
+        if (!response.ok) {
+          return {
+            isValid: false,
+            track,
+            duration: 0,
+            error: `Track URL not accessible: ${response.status}`,
+          };
+        }
+      } catch (error) {
         return {
           isValid: false,
           track,
           duration: 0,
-          error: `Track URL not accessible: ${response.status}`,
+          error: `Track URL error: ${(error as Error).message}`,
         };
       }
-    } catch (error) {
-      return {
-        isValid: false,
-        track,
-        duration: 0,
-        error: `Track URL error: ${(error as Error).message}`,
-      };
     }
 
     const duration = await TrackPlayer.getDuration();
@@ -196,9 +200,13 @@ async function recoverFromError(
       maxAttempts,
       'attempts',
     );
+    // Ensure loading states are cleared on failure
+    store.updateLoadingState({trackLoading: false});
     return false;
   } catch (error) {
     console.error('[PlaybackService] Recovery failed with error:', error);
+    // Ensure loading states are cleared on failure
+    store.updateLoadingState({trackLoading: false});
     return false;
   }
 }
@@ -619,6 +627,11 @@ export async function playbackService() {
               state: State.None,
               position: 0,
               duration: 0,
+            });
+            // Clear loading states to prevent stuck UI
+            store.updateLoadingState({
+              trackLoading: false,
+              queueLoading: false,
             });
           }
         }

--- a/services/player/store/downloadStore.ts
+++ b/services/player/store/downloadStore.ts
@@ -120,6 +120,11 @@ interface DownloadStoreState {
     reciterId: string,
     surahId: string,
   ) => DownloadedSurah | undefined;
+  getDownloadWithRewayat: (
+    reciterId: string,
+    surahId: string,
+    rewayatId: string,
+  ) => DownloadedSurah | undefined;
   setDownloads: (downloads: DownloadedSurah[]) => void;
   clearAllDownloads: () => Promise<void>;
   // Status management
@@ -365,6 +370,22 @@ export const useDownloadStore = create<DownloadStoreState>()(
             d.reciterId === reciterId &&
             d.surahId === surahId &&
             (!d.rewayatId || d.rewayatId === ''),
+        );
+      },
+
+      // Gets a download with a specific rewayatId
+      getDownloadWithRewayat: (
+        reciterId: string,
+        surahId: string,
+        rewayatId: string,
+      ) => {
+        const {downloads} = get();
+        return downloads.find(
+          d =>
+            d.reciterId === reciterId &&
+            d.surahId === surahId &&
+            d.rewayatId === rewayatId &&
+            d.status === 'completed',
         );
       },
 

--- a/utils/audioUtils.ts
+++ b/utils/audioUtils.ts
@@ -39,29 +39,31 @@ export function generateSmartAudioUrl(
   surahId: string,
   rewayatId?: string,
 ): string {
-  // Check if the surah is downloaded (with rewayat if provided)
   const downloadStore = useDownloadStore.getState();
 
-  // Use isDownloadedWithRewayat if rewayatId is provided, otherwise use isDownloaded
-  const isDownloaded = rewayatId
-    ? downloadStore.isDownloadedWithRewayat(reciter.id, surahId, rewayatId)
-    : downloadStore.isDownloaded(reciter.id, surahId);
-
-  if (isDownloaded) {
-    const download = downloadStore.getDownload(reciter.id, surahId);
-    // Double-check that the download matches the rewayat (if specified)
-    if (
-      download &&
-      download.status === 'completed' &&
-      (!rewayatId || download.rewayatId === rewayatId)
-    ) {
+  // Check if downloaded with specific rewayat
+  if (rewayatId) {
+    const download = downloadStore.getDownloadWithRewayat(
+      reciter.id,
+      surahId,
+      rewayatId,
+    );
+    if (download) {
       // Resolve the relative path to absolute path at runtime
       // This ensures paths remain valid after iOS app updates
       const absolutePath = resolveFilePath(download.filePath);
       console.log(
-        `Using local file for ${reciter.name} - Surah ${surahId}${
-          rewayatId ? ` (Rewayat: ${rewayatId})` : ''
-        }: ${absolutePath}`,
+        `Using local file for ${reciter.name} - Surah ${surahId} (Rewayat: ${rewayatId}): ${absolutePath}`,
+      );
+      return absolutePath;
+    }
+  } else {
+    // Check without rewayat (legacy downloads without rewayatId)
+    const download = downloadStore.getDownload(reciter.id, surahId);
+    if (download && download.status === 'completed') {
+      const absolutePath = resolveFilePath(download.filePath);
+      console.log(
+        `Using local file for ${reciter.name} - Surah ${surahId}: ${absolutePath}`,
       );
       return absolutePath;
     }


### PR DESCRIPTION
## Summary
- Add `getDownloadWithRewayat()` method to downloadStore for retrieving downloads with specific rewayatId
- Fix `generateSmartAudioUrl()` to use correct getter when rewayatId is provided (was always using `getDownload()` which only matches empty rewayatId)
- Skip URL validation for local `file://` URLs in `validateTrackState()` (fetch doesn't support file:// protocol)
- Add loading state cleanup in error recovery paths to prevent stuck UI

## Fixes
1. Downloaded tracks not picked up from ReciterDetailScreen
2. Playback corruption when trying to play offline

## Test plan
- [x] Tested on TestFlight - fix confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)