### PR TITLE
Improve What's New modal with semver and aggregated changelogs

### DIFF
--- a/components/modals/WhatsNewModal.tsx
+++ b/components/modals/WhatsNewModal.tsx
@@ -19,7 +19,13 @@ import {useTheme} from '@/hooks/useTheme';
 import {Icon} from '@rneui/base';
 import {ChangelogEntry} from '@/types/changelog';
 import changelogData from '@/data/changelog.json';
-import {hasVersionChanged, markVersionAsSeen} from '@/utils/versionUtils';
+import {
+  hasVersionChanged,
+  markVersionAsSeen,
+  getMissedChangelogs,
+  getLastSeenVersion,
+  getCurrentVersion,
+} from '@/utils/versionUtils';
 import Animated, {FadeIn, ZoomIn} from 'react-native-reanimated';
 
 const {width} = Dimensions.get('window');
@@ -31,16 +37,16 @@ export interface WhatsNewModalRef {
 export const WhatsNewModal = forwardRef<WhatsNewModalRef>((props, ref) => {
   const {theme} = useTheme();
   const [visible, setVisible] = useState(false);
-  const [currentChangelog, setCurrentChangelog] =
-    useState<ChangelogEntry | null>(null);
+  const [changelogs, setChangelogs] = useState<ChangelogEntry[]>([]);
   const [pressedButton, setPressedButton] = useState(false);
 
   // Expose show method to parent components
   useImperativeHandle(ref, () => ({
     show: () => {
       if (changelogData.length > 0) {
+        // When manually shown, just show the latest
         const latestChangelog = changelogData[0] as ChangelogEntry;
-        setCurrentChangelog(latestChangelog);
+        setChangelogs([latestChangelog]);
         setVisible(true);
       }
     },
@@ -55,17 +61,30 @@ export const WhatsNewModal = forwardRef<WhatsNewModalRef>((props, ref) => {
         console.log('[WhatsNewModal] Changelog entries:', changelogData.length);
 
         if (versionChanged && changelogData.length > 0) {
-          const latestChangelog = changelogData[0] as ChangelogEntry;
-          setCurrentChangelog(latestChangelog);
-          console.log(
-            '[WhatsNewModal] Will show modal for version:',
-            latestChangelog.version,
+          const lastSeen = await getLastSeenVersion();
+          const current = getCurrentVersion();
+
+          // Get all missed changelogs between last seen and current
+          const missed = getMissedChangelogs(
+            changelogData as ChangelogEntry[],
+            lastSeen,
+            current,
           );
 
-          setTimeout(() => {
-            console.log('[WhatsNewModal] Opening modal...');
-            setVisible(true);
-          }, 800);
+          console.log('[WhatsNewModal] Missed changelogs:', missed.length);
+
+          if (missed.length > 0) {
+            setChangelogs(missed);
+            console.log(
+              '[WhatsNewModal] Will show modal for versions:',
+              missed.map(c => c.version).join(', '),
+            );
+
+            setTimeout(() => {
+              console.log('[WhatsNewModal] Opening modal...');
+              setVisible(true);
+            }, 800);
+          }
         } else {
           console.log('[WhatsNewModal] Not showing modal');
         }
@@ -82,9 +101,13 @@ export const WhatsNewModal = forwardRef<WhatsNewModalRef>((props, ref) => {
     markVersionAsSeen();
   }
 
-  if (!currentChangelog) {
+  if (changelogs.length === 0) {
     return null;
   }
+
+  // For display, show the latest version number in the header
+  const latestVersion = changelogs[0]?.version;
+  const hasMultipleVersions = changelogs.length > 1;
 
   return (
     <Modal
@@ -116,41 +139,75 @@ export const WhatsNewModal = forwardRef<WhatsNewModalRef>((props, ref) => {
             </Text>
 
             <Text style={[styles.version, {color: theme.colors.textSecondary}]}>
-              Version {currentChangelog.version}
+              {hasMultipleVersions
+                ? `Versions ${changelogs[changelogs.length - 1]?.version} - ${latestVersion}`
+                : `Version ${latestVersion}`}
             </Text>
 
             <ScrollView
               style={styles.scrollView}
               showsVerticalScrollIndicator={false}
               contentContainerStyle={styles.scrollContent}>
-              <View style={styles.highlightsContainer}>
-                {currentChangelog.highlights.map((highlight, index) => (
-                  <View key={index} style={styles.highlightCard}>
-                    <Icon
-                      name={highlight.icon}
-                      type="ionicon"
-                      size={moderateScale(26)}
-                      color={theme.colors.text}
-                    />
-                    <View style={styles.highlightTextContainer}>
+              {changelogs.map((changelog, changelogIndex) => (
+                <View key={changelog.version}>
+                  {hasMultipleVersions && (
+                    <View style={styles.versionDivider}>
+                      <View
+                        style={[
+                          styles.dividerLine,
+                          {backgroundColor: theme.colors.textSecondary},
+                        ]}
+                      />
                       <Text
                         style={[
-                          styles.highlightTitle,
-                          {color: theme.colors.text},
-                        ]}>
-                        {highlight.title}
-                      </Text>
-                      <Text
-                        style={[
-                          styles.highlightDescription,
+                          styles.versionLabel,
                           {color: theme.colors.textSecondary},
                         ]}>
-                        {highlight.description}
+                        v{changelog.version}
                       </Text>
+                      <View
+                        style={[
+                          styles.dividerLine,
+                          {backgroundColor: theme.colors.textSecondary},
+                        ]}
+                      />
                     </View>
+                  )}
+
+                  <View style={styles.highlightsContainer}>
+                    {changelog.highlights.map((highlight, index) => (
+                      <View key={index} style={styles.highlightCard}>
+                        <Icon
+                          name={highlight.icon}
+                          type="ionicon"
+                          size={moderateScale(26)}
+                          color={theme.colors.text}
+                        />
+                        <View style={styles.highlightTextContainer}>
+                          <Text
+                            style={[
+                              styles.highlightTitle,
+                              {color: theme.colors.text},
+                            ]}>
+                            {highlight.title}
+                          </Text>
+                          <Text
+                            style={[
+                              styles.highlightDescription,
+                              {color: theme.colors.textSecondary},
+                            ]}>
+                            {highlight.description}
+                          </Text>
+                        </View>
+                      </View>
+                    ))}
                   </View>
-                ))}
-              </View>
+
+                  {changelogIndex < changelogs.length - 1 && (
+                    <View style={styles.sectionSpacer} />
+                  )}
+                </View>
+              ))}
             </ScrollView>
 
             <TouchableOpacity
@@ -230,6 +287,23 @@ const styles = StyleSheet.create({
   scrollContent: {
     paddingBottom: moderateScale(8),
   },
+  versionDivider: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: moderateScale(12),
+    marginTop: moderateScale(4),
+  },
+  dividerLine: {
+    flex: 1,
+    height: 1,
+    opacity: 0.2,
+  },
+  versionLabel: {
+    fontSize: moderateScale(12),
+    fontFamily: 'Manrope-SemiBold',
+    paddingHorizontal: moderateScale(12),
+    opacity: 0.6,
+  },
   highlightsContainer: {
     width: '100%',
     gap: moderateScale(16),
@@ -253,6 +327,9 @@ const styles = StyleSheet.create({
     fontFamily: 'Manrope-Regular',
     lineHeight: moderateScale(18),
     opacity: 0.7,
+  },
+  sectionSpacer: {
+    height: moderateScale(8),
   },
   button: {
     paddingVertical: moderateScale(14),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bayaan",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bayaan",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@babel/runtime": "^7.20.6",
         "@expo/react-native-read-more-text": "^1.1.0",
@@ -63,7 +63,6 @@
         "react-native-image-colors": "^1.5.2",
         "react-native-indicators": "^0.17.0",
         "react-native-modalize": "^2.1.1",
-        "react-native-pager-view": "6.5.1",
         "react-native-reanimated": "~3.16.1",
         "react-native-reanimated-carousel": "^3.5.1",
         "react-native-render-html": "^6.3.4",
@@ -77,6 +76,7 @@
         "react-native-track-player": "^4.1.1",
         "react-native-web": "~0.19.13",
         "rn-sliding-up-panel": "^2.4.6",
+        "semver": "^7.7.3",
         "zustand": "^4.5.5"
       },
       "devDependencies": {
@@ -90,6 +90,7 @@
         "@types/react": "~18.3.12",
         "@types/react-native-indicators": "^0.16.6",
         "@types/react-test-renderer": "^18.0.7",
+        "@types/semver": "^7.7.1",
         "ajv": "^8.12.0",
         "ajv-keywords": "^5.1.0",
         "eslint": "^8.57.0",
@@ -261,6 +262,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/eslint-parser": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.27.0.tgz",
@@ -278,6 +288,16 @@
       "peerDependencies": {
         "@babel/core": "^7.11.0",
         "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
@@ -324,6 +344,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
@@ -345,6 +374,15 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.0.tgz",
@@ -360,6 +398,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -2036,6 +2083,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
@@ -2275,6 +2331,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/preset-flow": {
@@ -2756,18 +2821,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/@expo/cli/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.5.tgz",
@@ -2821,18 +2874,6 @@
         "xml2js": "0.6.0"
       }
     },
-    "node_modules/@expo/config-plugins/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/config-types": {
       "version": "52.0.5",
       "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-52.0.5.tgz",
@@ -2846,18 +2887,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/@expo/config/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@expo/devcert": {
@@ -2914,18 +2943,6 @@
         "fingerprint": "bin/cli.js"
       }
     },
-    "node_modules/@expo/fingerprint/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/image-utils": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.6.5.tgz",
@@ -2978,18 +2995,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@expo/image-utils/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@expo/image-utils/node_modules/universalify": {
@@ -3225,18 +3230,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/universalify": {
@@ -4799,18 +4792,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -5246,18 +5227,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/signal-exit": {
@@ -6632,9 +6601,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6714,19 +6683,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -6845,19 +6801,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
@@ -6883,19 +6826,6 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -7766,6 +7696,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
@@ -7793,6 +7732,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
@@ -10504,19 +10452,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/eslint-config-universe/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -10713,6 +10648,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/eslint-plugin-jest": {
       "version": "26.9.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.9.0.tgz",
@@ -10778,6 +10723,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-node/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -10888,6 +10843,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-scope": {
@@ -12024,19 +11989,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/expo-module-scripts/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/expo-module-scripts/node_modules/source-map": {
       "version": "0.5.7",
@@ -14530,19 +14482,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -14572,19 +14511,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-source-maps": {
@@ -15408,19 +15334,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jest-util": {
@@ -17397,18 +17310,6 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm-package-arg/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -19075,16 +18976,6 @@
         "react-native-gesture-handler": "> 1.0.0"
       }
     },
-    "node_modules/react-native-pager-view": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.5.1.tgz",
-      "integrity": "sha512-YdX7bP+rPYvATMU7HzlMq9JaG3ui/+cVRbFZFGW+QshDULANFg9ECR1BA7H7JTIcO/ZgWCwF+1aVmYG5yBA9Og==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-ratings": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-8.1.0.tgz",
@@ -19466,18 +19357,6 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/react-native/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/ws": {
@@ -20172,12 +20051,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -20513,18 +20395,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -21913,19 +21783,6 @@
         "esbuild": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "react-native-track-player": "^4.1.1",
     "react-native-web": "~0.19.13",
     "rn-sliding-up-panel": "^2.4.6",
+    "semver": "^7.7.3",
     "zustand": "^4.5.5"
   },
   "devDependencies": {
@@ -109,6 +110,7 @@
     "@types/react": "~18.3.12",
     "@types/react-native-indicators": "^0.16.6",
     "@types/react-test-renderer": "^18.0.7",
+    "@types/semver": "^7.7.1",
     "ajv": "^8.12.0",
     "ajv-keywords": "^5.1.0",
     "eslint": "^8.57.0",

--- a/utils/versionUtils.ts
+++ b/utils/versionUtils.ts
@@ -1,8 +1,26 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants from 'expo-constants';
+import * as semver from 'semver';
+import {ChangelogEntry} from '@/types/changelog';
 
 const LAST_SEEN_VERSION_KEY = '@bayaan_last_seen_version';
 const FIRST_INSTALL_KEY = '@bayaan_first_install';
+
+/**
+ * Normalize version string to valid semver format
+ * Handles cases like "1.3" -> "1.3.0"
+ */
+function normalizeVersion(version: string): string {
+  const cleaned = semver.clean(version);
+  if (cleaned) return cleaned;
+
+  // Handle versions like "1.3" by adding .0
+  const parts = version.split('.');
+  while (parts.length < 3) {
+    parts.push('0');
+  }
+  return parts.join('.');
+}
 
 /**
  * Get the current app version from Expo config
@@ -42,14 +60,47 @@ export async function isFirstInstall(): Promise<boolean> {
 }
 
 /**
+ * Check if this is a minor or major version bump (not a patch)
+ * Examples:
+ * - 1.2.0 -> 1.2.1 = patch (returns false)
+ * - 1.2.0 -> 1.3.0 = minor (returns true)
+ * - 1.2.0 -> 2.0.0 = major (returns true)
+ */
+export function isMinorOrMajorUpdate(
+  lastVersion: string,
+  currentVersion: string,
+): boolean {
+  const lastNorm = normalizeVersion(lastVersion);
+  const currentNorm = normalizeVersion(currentVersion);
+
+  const lastParsed = semver.parse(lastNorm);
+  const currentParsed = semver.parse(currentNorm);
+
+  if (!lastParsed || !currentParsed) {
+    // Fallback to simple comparison if parsing fails
+    return lastVersion !== currentVersion;
+  }
+
+  // Check if major or minor version increased
+  return (
+    currentParsed.major > lastParsed.major ||
+    currentParsed.minor > lastParsed.minor
+  );
+}
+
+/**
  * Check if the app version has changed since the last launch
- * Returns false on first install, true on updates
+ * Only returns true for minor/major updates, not patches
  */
 export async function hasVersionChanged(): Promise<boolean> {
   try {
     const currentVersion = getCurrentVersion();
     const lastSeenVersion = await getLastSeenVersion();
     const firstInstall = await isFirstInstall();
+
+    console.log('[VersionUtils] Current version:', currentVersion);
+    console.log('[VersionUtils] Last seen version:', lastSeenVersion);
+    console.log('[VersionUtils] First install:', firstInstall);
 
     // Don't show on first install
     if (firstInstall) {
@@ -62,12 +113,65 @@ export async function hasVersionChanged(): Promise<boolean> {
       return true;
     }
 
-    // Compare versions
-    return currentVersion !== lastSeenVersion;
+    const currentNorm = normalizeVersion(currentVersion);
+    const lastNorm = normalizeVersion(lastSeenVersion);
+
+    // Check if current is actually newer (not a downgrade)
+    if (!semver.gt(currentNorm, lastNorm)) {
+      console.log('[VersionUtils] Not an upgrade, skipping modal');
+      return false;
+    }
+
+    // Only show for minor/major updates
+    const shouldShow = isMinorOrMajorUpdate(lastSeenVersion, currentVersion);
+    console.log('[VersionUtils] Is minor/major update:', shouldShow);
+
+    // If it's just a patch, mark as seen silently
+    if (!shouldShow) {
+      await markVersionAsSeen();
+    }
+
+    return shouldShow;
   } catch (error) {
     console.error('[VersionUtils] Failed to check version change:', error);
     return false;
   }
+}
+
+/**
+ * Get all changelog entries between lastSeenVersion and currentVersion
+ * Returns entries where: lastSeenVersion < entry.version <= currentVersion
+ * Only includes entries that represent minor/major updates from the last seen version
+ */
+export function getMissedChangelogs(
+  changelogData: ChangelogEntry[],
+  lastSeenVersion: string | null,
+  currentVersion: string,
+): ChangelogEntry[] {
+  const currentNorm = normalizeVersion(currentVersion);
+
+  // If no last seen version, return all entries up to current
+  if (!lastSeenVersion) {
+    return changelogData.filter(entry => {
+      const entryNorm = normalizeVersion(entry.version);
+      return semver.lte(entryNorm, currentNorm);
+    });
+  }
+
+  const lastNorm = normalizeVersion(lastSeenVersion);
+
+  // Filter entries: lastSeen < entry <= current
+  const missed = changelogData.filter(entry => {
+    const entryNorm = normalizeVersion(entry.version);
+    return semver.gt(entryNorm, lastNorm) && semver.lte(entryNorm, currentNorm);
+  });
+
+  // Sort by version descending (newest first)
+  return missed.sort((a, b) => {
+    const aNorm = normalizeVersion(a.version);
+    const bNorm = normalizeVersion(b.version);
+    return semver.rcompare(aNorm, bNorm);
+  });
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,10 +3412,10 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/semver@^7.3.12", "@types/semver@^7.5.0":
-  version "7.7.0"
-  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz"
-  integrity sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==
+"@types/semver@^7.3.12", "@types/semver@^7.5.0", "@types/semver@^7.7.1":
+  version "7.7.1"
+  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz"
+  integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
@@ -10163,11 +10163,6 @@ react-native-modalize@^2.1.1:
   resolved "https://registry.npmjs.org/react-native-modalize/-/react-native-modalize-2.1.1.tgz"
   integrity sha512-4/7EZWsrUqAAkkAVEnOsSdpAPQaEBewX7TvwFuzgvGDzxKpq3O58I9SnSeU8QtG/r91XYHJNaU5dAuDrcLjUaQ==
 
-react-native-pager-view@6.5.1:
-  version "6.5.1"
-  resolved "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.5.1.tgz"
-  integrity sha512-YdX7bP+rPYvATMU7HzlMq9JaG3ui/+cVRbFZFGW+QshDULANFg9ECR1BA7H7JTIcO/ZgWCwF+1aVmYG5yBA9Og==
-
 react-native-ratings@^8.1.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-8.1.0.tgz"
@@ -10792,50 +10787,30 @@ semver@^5.6.0:
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@^6.1.0, semver@^6.3.0, semver@^6.3.1:
+semver@^6.1.0:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.1.3:
-  version "7.7.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+semver@^6.3.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5:
-  version "7.7.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.7:
-  version "7.7.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
-
-semver@^7.5.3:
-  version "7.7.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
-
-semver@^7.5.4, semver@^7.6.0:
-  version "7.7.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
-
-semver@^7.6.3:
-  version "7.7.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+semver@^7.1.3, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3, semver@^7.7.3, semver@7.x:
+  version "7.7.3"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz"
+  integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
 
 semver@~7.6.3:
   version "7.6.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
-
-semver@7.x:
-  version "7.7.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 send@^0.19.0:
   version "0.19.1"


### PR DESCRIPTION
## Summary
- Add `semver` library for proper semantic version comparison
- Only show modal for minor/major updates (skip patch updates like 1.3.0 → 1.3.1)
- Show all missed changelogs when users skip versions (e.g., 1.1 → 1.4 shows 1.2, 1.3, 1.4)
- Handle version normalization (e.g., "1.3" equals "1.3.0")
- Ignore downgrades (no modal shown)

## Test plan
- [ ] Verify patch updates (1.3.0 → 1.3.1) do NOT show modal
- [ ] Verify minor updates (1.2.0 → 1.3.0) show modal
- [ ] Verify major updates (1.x → 2.x) show modal
- [ ] Verify skipped versions show aggregated changelogs with version dividers
- [ ] Verify downgrades do NOT show modal
- [ ] Test via Dev Menu → "Test What's New Modal" → restart app

🤖 Generated with [Claude Code](https://claude.com/claude-code)