### PR TITLE
refactor: replace RNEUI Icon with @expo/vector-icons

### DIFF
--- a/app/(tabs)/(a.home)/adhkar/[superId]/[dhikrId].tsx
+++ b/app/(tabs)/(a.home)/adhkar/[superId]/[dhikrId].tsx
@@ -10,7 +10,7 @@ import {
 import {useLocalSearchParams, useRouter} from 'expo-router';
 import {SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useAdhkar} from '@/hooks/useAdhkar';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -244,9 +244,8 @@ const DhikrReaderScreen: React.FC = () => {
           onPress={handleBack}
           activeOpacity={1}
           hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(24)}
             color={theme.colors.text}
           />

--- a/app/(tabs)/(a.home)/adhkar/[superId]/index.tsx
+++ b/app/(tabs)/(a.home)/adhkar/[superId]/index.tsx
@@ -9,7 +9,7 @@ import {
 import {useLocalSearchParams, useRouter} from 'expo-router';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useAdhkar} from '@/hooks/useAdhkar';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -257,9 +257,8 @@ const SuperCategoryListScreen: React.FC = () => {
             onPress={handleBack}
             activeOpacity={1}
             hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
-            <Icon
+            <Feather
               name="arrow-left"
-              type="feather"
               size={moderateScale(24)}
               color={theme.colors.text}
             />

--- a/app/(tabs)/(a.home)/adhkar/saved/[dhikrId].tsx
+++ b/app/(tabs)/(a.home)/adhkar/saved/[dhikrId].tsx
@@ -10,7 +10,7 @@ import {
 import {useLocalSearchParams, useRouter} from 'expo-router';
 import {SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useAdhkar} from '@/hooks/useAdhkar';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -224,9 +224,8 @@ const SavedDhikrReaderScreen: React.FC = () => {
           onPress={handleBack}
           activeOpacity={1}
           hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(24)}
             color={theme.colors.text}
           />

--- a/app/(tabs)/(a.home)/adhkar/saved/index.tsx
+++ b/app/(tabs)/(a.home)/adhkar/saved/index.tsx
@@ -3,7 +3,7 @@ import {View, Text, FlatList, TouchableOpacity} from 'react-native';
 import {useRouter} from 'expo-router';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather, Ionicons} from '@expo/vector-icons';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
 import {LoadingIndicator} from '@/components/LoadingIndicator';
@@ -121,9 +121,8 @@ const SavedAdhkarScreen: React.FC = () => {
           onPress={handleBack}
           activeOpacity={1}
           hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(24)}
             color={theme.colors.text}
           />
@@ -157,9 +156,8 @@ const SavedAdhkarScreen: React.FC = () => {
       <View style={styles.container}>
         {Header}
         <View style={styles.emptyContainer}>
-          <Icon
+          <Ionicons
             name="bookmark-outline"
-            type="ionicon"
             size={moderateScale(48)}
             color={theme.colors.textSecondary}
           />

--- a/app/(tabs)/(a.home)/index.tsx
+++ b/app/(tabs)/(a.home)/index.tsx
@@ -6,7 +6,7 @@ import {
   StyleSheet,
   Platform,
 } from 'react-native';
-import {Icon} from '@rneui/themed';
+import {AntDesign} from '@expo/vector-icons';
 import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {createStyles} from './_styles';
@@ -143,8 +143,7 @@ const Header = React.memo(
             activeOpacity={0.7}
             style={headerStyles.settingsButton}
             onPress={handleSettingsPress}>
-            <Icon
-              type="antdesign"
+            <AntDesign
               name="setting"
               size={moderateScale(20)}
               color={theme.colors.textSecondary}

--- a/app/(tabs)/(a.home)/settings/credits.tsx
+++ b/app/(tabs)/(a.home)/settings/credits.tsx
@@ -3,7 +3,7 @@ import {View, Text, ScrollView, TouchableOpacity, Linking} from 'react-native';
 import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/base';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {Theme} from '@/utils/themeUtils';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -182,9 +182,8 @@ export default function CreditsScreen() {
                       </Text>
                     </View>
                     {item.link && (
-                      <Icon
+                      <Feather
                         name="external-link"
-                        type="feather"
                         size={moderateScale(16)}
                         color={theme.colors.textSecondary}
                       />

--- a/app/(tabs)/(a.home)/settings/index.tsx
+++ b/app/(tabs)/(a.home)/settings/index.tsx
@@ -4,7 +4,7 @@ import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {Theme, ThemeMode, PrimaryColor} from '@/utils/themeUtils';
-import {Icon} from '@rneui/base';
+import {Feather, Ionicons, MaterialIcons} from '@expo/vector-icons';
 import {primaryColors} from '@/styles/colorSchemes';
 import {clearPlayerCache} from '@/services/player/utils/storage';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -255,12 +255,19 @@ export default function SettingsScreen() {
                 onPressOut={() => setPressedOption(null)}>
                 <View style={styles.themeContent}>
                   <View style={[styles.iconContainer]}>
-                    <Icon
-                      name={option.icon}
-                      type={option.iconType}
-                      size={moderateScale(20)}
-                      color={theme.colors.text}
-                    />
+                    {option.iconType === 'ionicon' ? (
+                      <Ionicons
+                        name={option.icon as any}
+                        size={moderateScale(20)}
+                        color={theme.colors.text}
+                      />
+                    ) : (
+                      <Feather
+                        name={option.icon as any}
+                        size={moderateScale(20)}
+                        color={theme.colors.text}
+                      />
+                    )}
                   </View>
                   <Text
                     style={[
@@ -368,10 +375,15 @@ export default function SettingsScreen() {
                           size={moderateScale(24)}
                           color={theme.colors.textSecondary}
                         />
+                      ) : item.iconType === 'material' ? (
+                        <MaterialIcons
+                          name={item.icon as any}
+                          size={moderateScale(20)}
+                          color={theme.colors.textSecondary}
+                        />
                       ) : (
-                        <Icon
-                          name={item.icon}
-                          type={item.iconType}
+                        <Feather
+                          name={item.icon as any}
                           size={moderateScale(20)}
                           color={theme.colors.textSecondary}
                         />
@@ -393,17 +405,17 @@ export default function SettingsScreen() {
                         {item.description}
                       </Text>
                     </View>
-                    <Icon
-                      name={
-                        isExternalLink(item.type)
-                          ? 'external-link'
-                          : 'arrow-right'
-                      }
-                      type="feather"
-                      size={moderateScale(20)}
-                      color={theme.colors.textSecondary}
-                      containerStyle={{opacity: 0.6}}
-                    />
+                    <View style={{opacity: 0.6}}>
+                      <Feather
+                        name={
+                          isExternalLink(item.type)
+                            ? 'external-link'
+                            : 'arrow-right'
+                        }
+                        size={moderateScale(20)}
+                        color={theme.colors.textSecondary}
+                      />
+                    </View>
                   </View>
                 </TouchableOpacity>
               ))}

--- a/app/(tabs)/(a.home)/settings/reciter-choice.tsx
+++ b/app/(tabs)/(a.home)/settings/reciter-choice.tsx
@@ -4,7 +4,7 @@ import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {Theme} from '@/utils/themeUtils';
-import {Icon} from '@rneui/base';
+import {AntDesign, Feather} from '@expo/vector-icons';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import Header from '@/components/Header';
 import Color from 'color';
@@ -128,12 +128,19 @@ export default function ReciterChoiceScreen() {
                                     .toString(),
                           },
                         ]}>
-                        <Icon
-                          name={option.icon}
-                          type={option.iconType}
-                          size={moderateScale(20)}
-                          color={theme.colors.text}
-                        />
+                        {option.iconType === 'antdesign' ? (
+                          <AntDesign
+                            name={option.icon as any}
+                            size={moderateScale(20)}
+                            color={theme.colors.text}
+                          />
+                        ) : (
+                          <Feather
+                            name={option.icon as any}
+                            size={moderateScale(20)}
+                            color={theme.colors.text}
+                          />
+                        )}
                       </View>
                       <View style={styles.optionTextContainer}>
                         <Text
@@ -158,9 +165,8 @@ export default function ReciterChoiceScreen() {
                         </Text>
                       </View>
                       {defaultReciterSelection === option.action && (
-                        <Icon
+                        <Feather
                           name="check-circle"
-                          type="feather"
                           size={24}
                           color={Color(theme.colors.text).alpha(0.8).toString()}
                         />

--- a/app/(tabs)/(a.home)/settings/storage.tsx
+++ b/app/(tabs)/(a.home)/settings/storage.tsx
@@ -10,7 +10,7 @@ import Header from '@/components/Header';
 import {useStorageBreakdown} from '@/hooks/useStorageBreakdown';
 import {useDownloadStore} from '@/services/player/store/downloadStore';
 import {clearPlayerCache} from '@/services/player/utils/storage';
-import {Icon} from '@rneui/base';
+import {Feather} from '@expo/vector-icons';
 
 interface StorageCategoryProps {
   color: string;
@@ -214,9 +214,8 @@ export default function StorageScreen() {
           </View>
         ) : error ? (
           <View style={styles.errorContainer}>
-            <Icon
+            <Feather
               name="alert-circle"
-              type="feather"
               size={moderateScale(48)}
               color={theme.colors.error}
             />

--- a/app/(tabs)/(c.collection)/collection/downloads.tsx
+++ b/app/(tabs)/(c.collection)/collection/downloads.tsx
@@ -23,7 +23,7 @@ import {usePlayerActions} from '@/hooks/usePlayerActions';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {createDownloadedTrack} from '@/utils/track';
 import {moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {DownloadCollectionActionButtons} from '@/components/DownloadCollectionActionButtons';
 import {CollectionCard} from '@/components/CollectionCard';
 import {DownloadIcon} from '@/components/Icons';
@@ -221,9 +221,8 @@ export default function DownloadsScreen() {
             style={styles.backButton}
             onPress={() => router.back()}
             hitSlop={8}>
-            <Icon
+            <Feather
               name="arrow-left"
-              type="feather"
               size={moderateScale(24)}
               color={theme.colors.text}
             />

--- a/app/(tabs)/(c.collection)/collection/favorite-reciters.tsx
+++ b/app/(tabs)/(c.collection)/collection/favorite-reciters.tsx
@@ -17,7 +17,7 @@ import {CircularReciterCard} from '@/components/cards/CircularReciterCard';
 import {useFavoriteReciters} from '@/hooks/useFavoriteReciters';
 import {useRouter} from 'expo-router';
 import {moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {LinearGradient} from 'expo-linear-gradient';
 import {StatusBar} from 'expo-status-bar';
 import {CollectionCard} from '@/components/CollectionCard';
@@ -245,21 +245,15 @@ export default function FavoriteRecitersScreen() {
                 outputRange: [1, 0],
               }),
             }}>
-            <Icon
-              name="arrow-left"
-              type="feather"
-              size={moderateScale(24)}
-              color="white"
-            />
+            <Feather name="arrow-left" size={moderateScale(24)} color="white" />
           </Animated.View>
           <Animated.View
             style={{
               position: 'absolute',
               opacity: headerOpacity,
             }}>
-            <Icon
+            <Feather
               name="arrow-left"
-              type="feather"
               size={moderateScale(24)}
               color={theme.colors.text}
             />
@@ -289,21 +283,15 @@ export default function FavoriteRecitersScreen() {
                 outputRange: [1, 0],
               }),
             }}>
-            <Icon
-              name="search"
-              type="feather"
-              size={moderateScale(20)}
-              color="white"
-            />
+            <Feather name="search" size={moderateScale(20)} color="white" />
           </Animated.View>
           <Animated.View
             style={{
               position: 'absolute',
               opacity: headerOpacity,
             }}>
-            <Icon
+            <Feather
               name="search"
-              type="feather"
               size={moderateScale(20)}
               color={theme.colors.text}
             />

--- a/app/(tabs)/(c.collection)/collection/playlists.tsx
+++ b/app/(tabs)/(c.collection)/collection/playlists.tsx
@@ -5,7 +5,7 @@ import {createStyles} from './_styles';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {PlaylistCard} from '@/components/cards/PlaylistCard';
 import {useRouter} from 'expo-router';
-import {Icon} from '@rneui/themed';
+import {Ionicons} from '@expo/vector-icons';
 import {moderateScale} from 'react-native-size-matters';
 import {usePlaylists} from '@/hooks/usePlaylists';
 
@@ -52,9 +52,8 @@ export default function PlaylistsScreen() {
             onPress={() => {
               /* Handle create playlist */
             }}>
-            <Icon
+            <Ionicons
               name="add"
-              type="ionicon"
               size={moderateScale(24)}
               color={theme.colors.primary}
             />

--- a/app/(tabs)/(c.collection)/collection/uploads.tsx
+++ b/app/(tabs)/(c.collection)/collection/uploads.tsx
@@ -12,7 +12,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {MicrophoneIcon, PlayIcon, ShuffleIcon} from '@/components/Icons';
 import {SheetManager} from 'react-native-actions-sheet';
 import {useUploadsStore, getCustomReciterName} from '@/store/uploadsStore';
@@ -204,9 +204,8 @@ export default function UploadsScreen() {
             onPress={() => handlePlayRecitation(item, index)}
             onLongPress={() => handleShowOptions(item, index)}>
             <View style={styles.itemIconContainer}>
-              <Icon
+              <Feather
                 name="music"
-                type="feather"
                 size={moderateScale(18)}
                 color={theme.colors.textSecondary}
               />
@@ -238,9 +237,8 @@ export default function UploadsScreen() {
           <Pressable
             style={styles.itemOptionsZone}
             onPress={() => handleShowOptions(item, index)}>
-            <Icon
+            <Feather
               name="more-horizontal"
-              type="feather"
               size={moderateScale(18)}
               color={theme.colors.text}
             />
@@ -272,9 +270,8 @@ export default function UploadsScreen() {
             style={[styles.backButton, {top: insets.top + moderateScale(10)}]}
             onPress={() => router.back()}
             hitSlop={8}>
-            <Icon
+            <Feather
               name="arrow-left"
-              type="feather"
               size={moderateScale(24)}
               color={theme.colors.text}
             />
@@ -359,9 +356,8 @@ export default function UploadsScreen() {
               color={theme.colors.textSecondary}
             />
           ) : (
-            <Icon
+            <Feather
               name="plus"
-              type="feather"
               size={moderateScale(16)}
               color={theme.colors.textSecondary}
             />

--- a/app/(tabs)/(c.collection)/index.tsx
+++ b/app/(tabs)/(c.collection)/index.tsx
@@ -4,7 +4,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {moderateScale, ScaledSheet} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useFavoriteReciters} from '@/hooks/useFavoriteReciters';
 import {useLoved} from '@/hooks/useLoved';
 import {useSettings} from '@/hooks/useSettings';
@@ -570,9 +570,8 @@ export default function CollectionScreen() {
 
         {/* Add to Collection Bar */}
         <Pressable style={styles.addBar} onPress={handleAddPress}>
-          <Icon
+          <Feather
             name="plus"
-            type="feather"
             size={moderateScale(16)}
             color={theme.colors.textSecondary}
           />

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {TouchableOpacity, ViewStyle, StyleProp} from 'react-native';
-import {Icon} from '@rneui/themed';
+import {Pressable, ViewStyle, StyleProp} from 'react-native';
+import {Feather} from '@expo/vector-icons';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {useNavigation} from '@react-navigation/native';
@@ -30,17 +30,15 @@ export const BackButton: React.FC<BackButtonProps> = ({
   };
 
   return (
-    <TouchableOpacity
-      activeOpacity={0.99}
+    <Pressable
       style={[styles.backButton, style, {marginLeft: insets.left}]}
       onPress={handlePress}>
-      <Icon
+      <Feather
         name="arrow-left"
-        type="feather"
         color={theme.colors.text}
         size={moderateScale(iconSize)}
       />
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {View, Text, TouchableOpacity, ViewStyle, Platform} from 'react-native';
-import {Icon} from '@rneui/base';
+import {View, Text, Pressable, ViewStyle, Platform} from 'react-native';
+import {Feather} from '@expo/vector-icons';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -65,17 +65,15 @@ export const Header: React.FC<HeaderProps> = ({
           </View>
         ))}
       <View style={styles.headerContent}>
-        <TouchableOpacity
+        <Pressable
           style={[styles.backButton, backButtonStyle]}
-          activeOpacity={0.7}
           onPress={onBack}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(24)}
             color={theme.colors.text}
           />
-        </TouchableOpacity>
+        </Pressable>
         <Text style={[styles.headerTitle, titleStyle]}>{title}</Text>
       </View>
     </View>

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -9,7 +9,7 @@ import {
   TextStyle,
 } from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useTheme} from '@/hooks/useTheme';
 import Color from 'color';
 
@@ -17,7 +17,6 @@ interface InputProps extends TextInputProps {
   label?: string;
   showIcon?: boolean;
   iconName?: string;
-  iconType?: string;
   error?: string;
   helperText?: string;
   showCharacterCount?: boolean;
@@ -30,7 +29,6 @@ export const Input: React.FC<InputProps> = ({
   label,
   showIcon = false,
   iconName = 'edit-3',
-  iconType = 'feather',
   error,
   helperText,
   showCharacterCount = false,
@@ -49,9 +47,8 @@ export const Input: React.FC<InputProps> = ({
       {label && (
         <View style={styles.labelRow}>
           {showIcon && (
-            <Icon
-              name={iconName}
-              type={iconType}
+            <Feather
+              name={iconName as any}
               size={moderateScale(16)}
               color={theme.colors.textSecondary}
             />

--- a/components/MushafSettingsContent.tsx
+++ b/components/MushafSettingsContent.tsx
@@ -4,7 +4,7 @@ import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
 import Color from 'color';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useTajweedStore} from '@/store/tajweedStore';
 import FormattedTextRenderer from '@/components/utils/FormattedText';
 import {LinearGradient} from 'expo-linear-gradient';
@@ -224,9 +224,8 @@ const FontSizeControl: React.FC<FontSizeControlProps> = ({
             onPress={handleDecrement}
             hitSlop={10}
             disabled={currentDisplayValue <= DISPLAY_MIN}>
-            <Icon
+            <Feather
               name="minus"
-              type="feather"
               size={moderateScale(18)}
               color={
                 currentDisplayValue <= DISPLAY_MIN
@@ -240,9 +239,8 @@ const FontSizeControl: React.FC<FontSizeControlProps> = ({
             onPress={handleIncrement}
             hitSlop={10}
             disabled={currentDisplayValue >= DISPLAY_MAX}>
-            <Icon
+            <Feather
               name="plus"
-              type="feather"
               size={moderateScale(18)}
               color={
                 currentDisplayValue >= DISPLAY_MAX

--- a/components/PlaylistItem.tsx
+++ b/components/PlaylistItem.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import {View, Text, TouchableOpacity} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
-import {Icon} from '@rneui/themed';
+import {MaterialIcons} from '@expo/vector-icons';
 import {PlaylistIcon} from '@/components/Icons';
 import Color from 'color';
 
@@ -32,8 +32,7 @@ export const PlaylistItem: React.FC<PlaylistItemProps> = React.memo(
     const borderColor = Color(playlistColor).alpha(0.3).toString();
 
     return (
-      <TouchableOpacity
-        activeOpacity={0.99}
+      <Pressable
         style={[styles.playlistItem, isSelected && styles.selectedPlaylistItem]}
         onPress={handlePress}
         onLongPress={handleLongPress}>
@@ -53,15 +52,14 @@ export const PlaylistItem: React.FC<PlaylistItemProps> = React.memo(
         </View>
         {isSelected && (
           <View style={styles.checkmarkContainer}>
-            <Icon
+            <MaterialIcons
               name="check"
-              type="material"
               size={moderateScale(24)}
               color={theme.colors.primary}
             />
           </View>
         )}
-      </TouchableOpacity>
+      </Pressable>
     );
   },
 );

--- a/components/ReciterBrowse.tsx
+++ b/components/ReciterBrowse.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useCallback, useEffect, useMemo} from 'react';
-import {View, Text, TouchableOpacity, FlatList} from 'react-native';
+import {View, Text, Pressable, FlatList} from 'react-native';
 import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {
@@ -7,7 +7,7 @@ import {
   moderateScale,
   verticalScale,
 } from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import SearchBar from '@/components/SearchBar';
 import {RECITERS, Reciter} from '@/data/reciterData';
 import {ReciterItem} from '@/components/ReciterItem';
@@ -152,17 +152,15 @@ const ReciterBrowse = ({surahId, initialView = 'all'}: ReciterBrowseProps) => {
         },
       ]}>
       <View style={createStyles(theme).header}>
-        <TouchableOpacity
-          activeOpacity={0.99}
+        <Pressable
           onPress={() => router.back()}
           style={createStyles(theme).backButton}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(24)}
             color={theme.colors.text}
           />
-        </TouchableOpacity>
+        </Pressable>
         <Text
           style={[createStyles(theme).headerTitle, {color: theme.colors.text}]}>
           Browse Reciters
@@ -180,8 +178,7 @@ const ReciterBrowse = ({surahId, initialView = 'all'}: ReciterBrowseProps) => {
         />
       </View>
       <View style={createStyles(theme).toggleContainer}>
-        <TouchableOpacity
-          activeOpacity={0.99}
+        <Pressable
           style={[
             createStyles(theme).toggleButton,
             activeView === 'all' && createStyles(theme).activeToggleButton,
@@ -195,9 +192,8 @@ const ReciterBrowse = ({surahId, initialView = 'all'}: ReciterBrowseProps) => {
             ]}>
             All Reciters
           </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          activeOpacity={0.99}
+        </Pressable>
+        <Pressable
           style={[
             createStyles(theme).toggleButton,
             activeView === 'favorites' &&
@@ -212,7 +208,7 @@ const ReciterBrowse = ({surahId, initialView = 'all'}: ReciterBrowseProps) => {
             ]}>
             Favorites
           </Text>
-        </TouchableOpacity>
+        </Pressable>
       </View>
       <FlatList
         data={filteredReciters}

--- a/components/ReciterItem.tsx
+++ b/components/ReciterItem.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import {View, Text, TouchableOpacity} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
-import {Icon} from '@rneui/themed';
+import {MaterialIcons} from '@expo/vector-icons';
 import {Reciter} from '@/data/reciterData';
 import {ReciterImage} from '@/components/ReciterImage';
 
@@ -21,8 +21,7 @@ export const ReciterItem: React.FC<ReciterItemProps> = React.memo(
     const handlePress = React.useCallback(() => onPress(item), [item, onPress]);
 
     return (
-      <TouchableOpacity
-        activeOpacity={0.99}
+      <Pressable
         style={[styles.reciterItem, isSelected && styles.selectedReciterItem]}
         onPress={handlePress}>
         <View
@@ -48,15 +47,14 @@ export const ReciterItem: React.FC<ReciterItemProps> = React.memo(
         </View>
         {isSelected && (
           <View style={styles.checkmarkContainer}>
-            <Icon
+            <MaterialIcons
               name="check"
-              type="material"
               size={moderateScale(24)}
               color={theme.colors.primary}
             />
           </View>
         )}
-      </TouchableOpacity>
+      </Pressable>
     );
   },
 );

--- a/components/ScreenHeader.tsx
+++ b/components/ScreenHeader.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import {View, Text, TouchableOpacity} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {
   ScaledSheet,
   moderateScale,
   verticalScale,
 } from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
 import {useRouter} from 'expo-router';
@@ -21,17 +21,13 @@ export const ScreenHeader: React.FC<ScreenHeaderProps> = ({title}) => {
 
   return (
     <View style={styles.header}>
-      <TouchableOpacity
-        activeOpacity={0.99}
-        onPress={() => router.back()}
-        style={styles.backButton}>
-        <Icon
+      <Pressable onPress={() => router.back()} style={styles.backButton}>
+        <Feather
           name="arrow-left"
-          type="feather"
           size={moderateScale(24)}
           color={theme.colors.text}
         />
-      </TouchableOpacity>
+      </Pressable>
       <Text style={styles.headerTitle}>{title}</Text>
     </View>
   );

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useImperativeHandle, forwardRef, useRef} from 'react';
-import {TouchableOpacity, Text, TextInput, Animated} from 'react-native';
-import {Icon} from '@rneui/themed';
+import {Pressable, Text, TextInput, Animated, View} from 'react-native';
+import {Feather, AntDesign} from '@expo/vector-icons';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
@@ -101,13 +101,15 @@ const SearchBar = forwardRef<SearchBarRef, SearchBarProps>(
                 transform: [{rotate: spin}],
               },
             ]}>
-            <Icon
-              name="search"
-              type="feather"
-              size={moderateScale(20)}
-              color={isFocused ? theme.colors.text : theme.colors.textSecondary}
-              onPress={() => inputRef.current?.focus()}
-            />
+            <Pressable onPress={() => inputRef.current?.focus()}>
+              <Feather
+                name="search"
+                size={moderateScale(20)}
+                color={
+                  isFocused ? theme.colors.text : theme.colors.textSecondary
+                }
+              />
+            </Pressable>
           </Animated.View>
           <TextInput
             ref={inputRef}
@@ -137,17 +139,15 @@ const SearchBar = forwardRef<SearchBarRef, SearchBarProps>(
               from={{opacity: 0, scale: 0}}
               animate={{opacity: 1, scale: 1}}
               exit={{opacity: 0, scale: 0}}>
-              <TouchableOpacity
-                activeOpacity={0.99}
-                onPress={() => onChangeText('')}>
-                <Icon
-                  name="close"
-                  type="antdesign"
-                  size={moderateScale(20)}
-                  color={theme.colors.text}
-                  containerStyle={styles.clearIcon}
-                />
-              </TouchableOpacity>
+              <Pressable onPress={() => onChangeText('')}>
+                <View style={styles.clearIcon}>
+                  <AntDesign
+                    name="close"
+                    size={moderateScale(20)}
+                    color={theme.colors.text}
+                  />
+                </View>
+              </Pressable>
             </MotiView>
           )}
         </MotiView>
@@ -155,12 +155,9 @@ const SearchBar = forwardRef<SearchBarRef, SearchBarProps>(
           <MotiView
             from={{opacity: 0, translateX: 20}}
             animate={{opacity: 1, translateX: 0}}>
-            <TouchableOpacity
-              activeOpacity={0.99}
-              style={styles.cancelButton}
-              onPress={handleCancel}>
+            <Pressable style={styles.cancelButton} onPress={handleCancel}>
               <Text style={styles.cancelButtonText}>Cancel</Text>
-            </TouchableOpacity>
+            </Pressable>
           </MotiView>
         )}
       </MotiView>

--- a/components/SearchInput.tsx
+++ b/components/SearchInput.tsx
@@ -11,7 +11,7 @@ import {
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 
 export interface SearchInputProps extends TextInputProps {
@@ -85,9 +85,8 @@ export const SearchInput = forwardRef<TextInput, SearchInputProps>(
             style,
           ]}>
           <View style={styles.searchIconContainer}>
-            <Icon
+            <Feather
               name="search"
-              type="feather"
               size={iconSize}
               color={iconColor}
               style={{opacity: iconOpacity}}
@@ -121,12 +120,7 @@ export const SearchInput = forwardRef<TextInput, SearchInputProps>(
             <Pressable
               onPress={() => onChangeText('')}
               style={styles.clearButton}>
-              <Icon
-                name="x"
-                type="feather"
-                size={moderateScale(16)}
-                color={iconColor}
-              />
+              <Feather name="x" size={moderateScale(16)} color={iconColor} />
             </Pressable>
           )}
         </View>
@@ -146,12 +140,7 @@ export const SearchInput = forwardRef<TextInput, SearchInputProps>(
         )}
         {onClose && (
           <Pressable onPress={onClose} style={styles.closeButton}>
-            <Icon
-              name="x"
-              type="feather"
-              size={moderateScale(24)}
-              color={iconColor}
-            />
+            <Feather name="x" size={moderateScale(24)} color={iconColor} />
           </Pressable>
         )}
       </View>

--- a/components/SurahItem.tsx
+++ b/components/SurahItem.tsx
@@ -6,8 +6,7 @@ import {Theme} from '@/utils/themeUtils';
 import {surahGlyphMap} from '@/utils/surahGlyphMap';
 import {Surah} from '@/data/surahData';
 import {HeartIcon} from '@/components/Icons';
-import {Icon} from '@rneui/themed';
-import {Ionicons} from '@expo/vector-icons';
+import {Feather, Ionicons} from '@expo/vector-icons';
 import Color from 'color';
 import {MakkahIcon, MadinahIcon} from '@/components/Icons';
 import * as Haptics from 'expo-haptics';
@@ -270,9 +269,8 @@ export const SurahItem: React.FC<SurahItemProps> = React.memo(
                 surahId={Number(item.id)}
               />
             ) : (
-              <Icon
+              <Feather
                 name="more-horizontal"
-                type="feather"
                 size={moderateScale(18)}
                 color={theme.colors.text}
               />

--- a/components/SurahsView.tsx
+++ b/components/SurahsView.tsx
@@ -15,7 +15,7 @@ import Color from 'color';
 import {SurahsHero} from '@/components/hero/SurahsHero';
 import {GRADIENT_COLORS} from '@/utils/gradientColors';
 import {LinearGradient} from 'expo-linear-gradient';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useSettings} from '@/hooks/useSettings';
 import {TOTAL_BOTTOM_PADDING} from '@/utils/constants';
 import {getJuzForSurah, getJuzName} from '@/data/juzData';
@@ -266,9 +266,8 @@ export default function SurahsView({onSurahPress}: SurahsViewProps) {
               ]}
               activeOpacity={1}
               onPress={() => changeSortOption('asc')}>
-              <Icon
+              <Feather
                 name="arrow-up"
-                type="feather"
                 size={moderateScale(14)}
                 color={
                   sortOption === 'asc'
@@ -301,9 +300,8 @@ export default function SurahsView({onSurahPress}: SurahsViewProps) {
               ]}
               activeOpacity={1}
               onPress={() => changeSortOption('desc')}>
-              <Icon
+              <Feather
                 name="arrow-down"
-                type="feather"
                 size={moderateScale(14)}
                 color={
                   sortOption === 'desc'
@@ -336,9 +334,8 @@ export default function SurahsView({onSurahPress}: SurahsViewProps) {
               ]}
               activeOpacity={1}
               onPress={() => changeSortOption('revelation')}>
-              <Icon
+              <Feather
                 name="calendar"
-                type="feather"
                 size={moderateScale(14)}
                 color={
                   sortOption === 'revelation'
@@ -366,9 +363,8 @@ export default function SurahsView({onSurahPress}: SurahsViewProps) {
             style={styles.viewModeButton}
             onPress={toggleViewMode}
             activeOpacity={1}>
-            <Icon
+            <Feather
               name={viewMode === 'card' ? 'list' : 'grid'}
-              type="feather"
               size={moderateScale(16)}
               color={theme.colors.text}
             />

--- a/components/TrackItem.tsx
+++ b/components/TrackItem.tsx
@@ -18,9 +18,8 @@ import {
   useIsDownloading,
 } from '@/services/player/store/downloadSelectors';
 import {CircularProgress} from '@/components/CircularProgress';
-import {Ionicons} from '@expo/vector-icons';
+import {Feather, Ionicons} from '@expo/vector-icons';
 import {GradientText} from '@/components/GradientText';
-import {Icon} from '@rneui/themed';
 
 interface TrackItemProps {
   reciterId: string;
@@ -202,9 +201,8 @@ export const TrackItem: React.FC<TrackItemProps> = React.memo(
                 gap={moderateScale(1.2)}
               />
             ) : (
-              <Icon
+              <Feather
                 name="more-horizontal"
-                type="feather"
                 size={moderateScale(18)}
                 color={theme.colors.text}
               />

--- a/components/adhkar/AdhkarAudioControls.tsx
+++ b/components/adhkar/AdhkarAudioControls.tsx
@@ -8,7 +8,7 @@
 
 import React, {useMemo} from 'react';
 import {View, TouchableOpacity} from 'react-native';
-import {Icon} from '@rneui/themed';
+import {Feather, Ionicons} from '@expo/vector-icons';
 import Slider from '@react-native-community/slider';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import Animated, {useAnimatedStyle, withSpring} from 'react-native-reanimated';
@@ -115,9 +115,8 @@ export const AdhkarAudioControls: React.FC<AdhkarAudioControlsProps> =
           <View style={styles.container}>
             <View style={styles.buttonsRow}>
               <View style={styles.noAudioPlaceholder}>
-                <Icon
+                <Feather
                   name="volume-x"
-                  type="feather"
                   size={moderateScale(18)}
                   color={theme.colors.textSecondary}
                 />
@@ -141,9 +140,8 @@ export const AdhkarAudioControls: React.FC<AdhkarAudioControlsProps> =
                   hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
                   accessibilityRole="button"
                   accessibilityLabel="Copy Arabic text">
-                  <Icon
+                  <Feather
                     name="copy"
-                    type="feather"
                     size={moderateScale(18)}
                     color={theme.colors.textSecondary}
                   />
@@ -158,9 +156,8 @@ export const AdhkarAudioControls: React.FC<AdhkarAudioControlsProps> =
                     isBookmarked ? 'Remove bookmark' : 'Add bookmark'
                   }
                   accessibilityState={{selected: isBookmarked}}>
-                  <Icon
+                  <Ionicons
                     name={isBookmarked ? 'bookmark' : 'bookmark-outline'}
-                    type="ionicon"
                     size={moderateScale(18)}
                     color={
                       isBookmarked
@@ -176,9 +173,8 @@ export const AdhkarAudioControls: React.FC<AdhkarAudioControlsProps> =
                   hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
                   accessibilityRole="button"
                   accessibilityLabel="Share dhikr">
-                  <Icon
+                  <Feather
                     name="share"
-                    type="feather"
                     size={moderateScale(18)}
                     color={theme.colors.textSecondary}
                   />
@@ -190,9 +186,8 @@ export const AdhkarAudioControls: React.FC<AdhkarAudioControlsProps> =
                   hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
                   accessibilityRole="button"
                   accessibilityLabel="Layout settings">
-                  <Icon
+                  <Feather
                     name="sliders"
-                    type="feather"
                     size={moderateScale(18)}
                     color={theme.colors.textSecondary}
                   />
@@ -273,9 +268,8 @@ export const AdhkarAudioControls: React.FC<AdhkarAudioControlsProps> =
                 hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
                 accessibilityRole="button"
                 accessibilityLabel="Copy Arabic text">
-                <Icon
+                <Feather
                   name="copy"
-                  type="feather"
                   size={moderateScale(18)}
                   color={theme.colors.textSecondary}
                 />
@@ -291,9 +285,8 @@ export const AdhkarAudioControls: React.FC<AdhkarAudioControlsProps> =
                   isBookmarked ? 'Remove bookmark' : 'Add bookmark'
                 }
                 accessibilityState={{selected: isBookmarked}}>
-                <Icon
+                <Ionicons
                   name={isBookmarked ? 'bookmark' : 'bookmark-outline'}
-                  type="ionicon"
                   size={moderateScale(18)}
                   color={
                     isBookmarked
@@ -310,9 +303,8 @@ export const AdhkarAudioControls: React.FC<AdhkarAudioControlsProps> =
                 hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
                 accessibilityRole="button"
                 accessibilityLabel="Share dhikr">
-                <Icon
+                <Feather
                   name="share"
-                  type="feather"
                   size={moderateScale(18)}
                   color={theme.colors.textSecondary}
                 />
@@ -325,9 +317,8 @@ export const AdhkarAudioControls: React.FC<AdhkarAudioControlsProps> =
                 hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
                 accessibilityRole="button"
                 accessibilityLabel="Layout settings">
-                <Icon
+                <Feather
                   name="sliders"
-                  type="feather"
                   size={moderateScale(18)}
                   color={theme.colors.textSecondary}
                 />

--- a/components/adhkar/DhikrReader.tsx
+++ b/components/adhkar/DhikrReader.tsx
@@ -10,7 +10,7 @@ import {
   UIManager,
 } from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {SheetManager} from 'react-native-actions-sheet';
 import {useTheme} from '@/hooks/useTheme';
@@ -169,9 +169,8 @@ export const DhikrReader: React.FC<DhikrReaderProps> = ({
                 showInstruction ? 'Hide instruction' : 'Show instruction'
               }>
               <View style={styles.instructionToggleContent}>
-                <Icon
+                <Feather
                   name="info"
-                  type="feather"
                   size={moderateScale(16)}
                   color={theme.colors.textSecondary}
                 />
@@ -179,9 +178,8 @@ export const DhikrReader: React.FC<DhikrReaderProps> = ({
                   {showInstruction ? 'Hide Info' : 'Show Info'}
                 </Text>
               </View>
-              <Icon
+              <Feather
                 name={showInstruction ? 'chevron-up' : 'chevron-down'}
-                type="feather"
                 size={moderateScale(18)}
                 color={theme.colors.textSecondary}
               />

--- a/components/adhkar/TasbeehCounter.tsx
+++ b/components/adhkar/TasbeehCounter.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback} from 'react';
 import {View, Text, TouchableOpacity, Animated} from 'react-native';
 import * as Haptics from 'expo-haptics';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import Color from 'color';
 import {useTheme} from '@/hooks/useTheme';
@@ -108,9 +108,8 @@ export const TasbeehCounter: React.FC<TasbeehCounterProps> = ({
               {/* Target reached indicator */}
               {targetReached ? (
                 <View style={styles.successBadge}>
-                  <Icon
+                  <Feather
                     name="check-circle"
-                    type="feather"
                     size={moderateScale(20)}
                     color={SUCCESS_COLOR}
                   />
@@ -137,9 +136,8 @@ export const TasbeehCounter: React.FC<TasbeehCounterProps> = ({
         accessibilityRole="button"
         accessibilityLabel="Reset counter"
         accessibilityHint="Resets the count to zero">
-        <Icon
+        <Feather
           name="refresh-cw"
-          type="feather"
           size={moderateScale(18)}
           color={theme.colors.textSecondary}
         />

--- a/components/browse/BrowseReciters.tsx
+++ b/components/browse/BrowseReciters.tsx
@@ -15,7 +15,7 @@ import Animated, {
   LinearTransition,
 } from 'react-native-reanimated';
 import {moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/base';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {RECITERS, Reciter, Rewayat} from '@/data/reciterData';
 import {Theme} from '@/utils/themeUtils';
@@ -655,9 +655,8 @@ export default function BrowseReciters({
               styles.searchButton,
               isSearchFocused && styles.searchButtonFocused,
             ]}>
-            <Icon
+            <Feather
               name="search"
-              type="feather"
               size={moderateScale(18)}
               color={theme.colors.textSecondary}
             />
@@ -681,9 +680,8 @@ export default function BrowseReciters({
                 onPress={handleClearSearch}
                 style={styles.clearSearchButton}
                 activeOpacity={0.7}>
-                <Icon
+                <Feather
                   name="x"
-                  type="feather"
                   size={moderateScale(16)}
                   color={theme.colors.textSecondary}
                 />
@@ -705,9 +703,8 @@ export default function BrowseReciters({
               style={styles.filterButton}
               activeOpacity={0.7}
               onPress={handleFilterModalPress}>
-              <Icon
+              <Feather
                 name="sliders"
-                type="feather"
                 size={moderateScale(18)}
                 color={theme.colors.textSecondary}
               />

--- a/components/browse/BrowseSurahs.tsx
+++ b/components/browse/BrowseSurahs.tsx
@@ -10,7 +10,7 @@ import {SURAHS, Surah} from '@/data/surahData';
 import {SurahCard} from '@/components/cards/SurahCard';
 import {SurahItem} from '@/components/SurahItem';
 import Header from '@/components/Header';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import Color from 'color';
 import Animated, {FadeIn} from 'react-native-reanimated';
@@ -388,9 +388,8 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
           ]}
           activeOpacity={1}
           onPress={() => changeSortOption('asc')}>
-          <Icon
+          <Feather
             name="arrow-up"
-            type="feather"
             size={moderateScale(14)}
             color={
               sortOption === 'asc'
@@ -423,9 +422,8 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
           ]}
           activeOpacity={1}
           onPress={() => changeSortOption('desc')}>
-          <Icon
+          <Feather
             name="arrow-down"
-            type="feather"
             size={moderateScale(14)}
             color={
               sortOption === 'desc'
@@ -458,9 +456,8 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
           ]}
           activeOpacity={1}
           onPress={() => changeSortOption('revelation')}>
-          <Icon
+          <Feather
             name="calendar"
-            type="feather"
             size={moderateScale(14)}
             color={
               sortOption === 'revelation'
@@ -488,9 +485,8 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
         style={styles.viewModeButton}
         onPress={toggleViewMode}
         activeOpacity={1}>
-        <Icon
+        <Feather
           name={viewMode === 'card' ? 'list' : 'grid'}
-          type="feather"
           size={moderateScale(16)}
           color={theme.colors.text}
         />

--- a/components/browse/CategoryScreen.tsx
+++ b/components/browse/CategoryScreen.tsx
@@ -4,7 +4,7 @@ import {useRouter} from 'expo-router';
 import {Category} from '@/data/categories';
 import {useTheme} from '@/hooks/useTheme';
 import {moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import Animated, {FadeInDown} from 'react-native-reanimated';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -72,9 +72,8 @@ export function CategoryScreen({
             </Text>
           )}
         </View>
-        <Icon
+        <Feather
           name="chevron-right"
-          type="feather"
           size={20}
           color={theme.colors.textSecondary}
         />
@@ -97,11 +96,11 @@ export function CategoryScreen({
           style={styles.backButton}
           activeOpacity={0.7}
           onPress={() => router.back()}>
-          <Icon name="arrow-left" type="feather" size={24} color={'#FFFFFF'} />
+          <Feather name="arrow-left" size={24} color={'#FFFFFF'} />
         </TouchableOpacity>
         <View style={styles.titleContainer}>
-          <Icon
-            {...icon}
+          <Feather
+            name={icon.name as any}
             size={24}
             color={'#FFFFFF'}
             style={styles.titleIcon}

--- a/components/browse/FilterModal.tsx
+++ b/components/browse/FilterModal.tsx
@@ -9,7 +9,7 @@ import {
   Platform,
 } from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/base';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {Theme} from '@/utils/themeUtils';
 import {RECITERS} from '@/data/reciterData';
@@ -283,9 +283,8 @@ export default function FilterModal({
                   style={styles.closeButton}
                   onPress={onClose}
                   activeOpacity={0.7}>
-                  <Icon
+                  <Feather
                     name="x"
-                    type="feather"
                     size={moderateScale(24)}
                     color={theme.colors.text}
                   />

--- a/components/cards/CircularReciterCard.tsx
+++ b/components/cards/CircularReciterCard.tsx
@@ -10,7 +10,7 @@ import {
 import {useTheme} from '@/hooks/useTheme';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {ReciterImage} from '@/components/ReciterImage';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -146,9 +146,8 @@ export const CircularReciterCard: React.FC<CircularReciterCardProps> = ({
             {isSelected && <View style={styles.selectedOverlay} />}
           </>
         ) : (
-          <Icon
+          <Feather
             name="plus"
-            type="feather"
             size={moderateScale(imageSize * 0.3)}
             color={theme.colors.textSecondary}
           />

--- a/components/cards/RewayatCard.tsx
+++ b/components/cards/RewayatCard.tsx
@@ -10,7 +10,7 @@ import Animated, {
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
-import {Icon} from '@rneui/base';
+import {Feather} from '@expo/vector-icons';
 
 interface RewayatCardProps {
   rewayat: RewayatInfo;
@@ -73,9 +73,8 @@ function RewayatCard({
       <View style={styles.content}>
         <View style={styles.header}>
           <View style={styles.iconWrapper}>
-            <Icon
+            <Feather
               name="chevron-right"
-              type="feather"
               size={moderateScale(14)}
               color={theme.colors.textSecondary}
             />

--- a/components/cards/SurahCard.tsx
+++ b/components/cards/SurahCard.tsx
@@ -14,8 +14,7 @@ import {surahGlyphMap} from '@/utils/surahGlyphMap';
 import {LinearGradient} from 'expo-linear-gradient';
 import Color from 'color';
 import {MakkahIcon, MadinahIcon, HeartIcon} from '@/components/Icons';
-import {Icon} from '@rneui/themed';
-import {Ionicons} from '@expo/vector-icons';
+import {Ionicons, Feather} from '@expo/vector-icons';
 import Animated, {
   useAnimatedStyle,
   withSpring,
@@ -406,9 +405,8 @@ export const SurahCard: React.FC<SurahCardProps> = ({
             style={styles.optionsButton}
             onPress={handleOptionsPressWrapper}
             activeOpacity={0.7}>
-            <Icon
+            <Feather
               name="more-horizontal"
-              type="feather"
               size={moderateScale(16)}
               color={theme.colors.textSecondary}
             />

--- a/components/changelog/ChangelogContent.tsx
+++ b/components/changelog/ChangelogContent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {View, Text, StyleSheet, ScrollView, Image} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
-import {Icon} from '@rneui/base';
+import {Ionicons} from '@expo/vector-icons';
 import Color from 'color';
 import {ChangelogEntry} from '@/types/changelog';
 
@@ -45,9 +45,8 @@ export function ChangelogContent({
       <View style={styles.highlightsContainer}>
         {changelog.highlights.map((highlight, index) => (
           <View key={index} style={styles.highlightCard}>
-            <Icon
-              name={highlight.icon}
-              type="ionicon"
+            <Ionicons
+              name={highlight.icon as any}
               size={moderateScale(26)}
               color={theme.colors.text}
             />

--- a/components/collection/CollectionSearchModal.tsx
+++ b/components/collection/CollectionSearchModal.tsx
@@ -23,7 +23,7 @@ import {
   StyleSheet,
 } from 'react-native';
 import {useRouter} from 'expo-router';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -590,9 +590,8 @@ export const CollectionSearchModal: React.FC<CollectionSearchModalProps> = ({
           styles.iconContainer,
           {backgroundColor: activeTheme.colors.card},
         ]}>
-        <Icon
-          name={getIconForType(item.type)}
-          type="feather"
+        <Feather
+          name={getIconForType(item.type) as any}
           size={moderateScale(20)}
           color={activeTheme.colors.text}
         />
@@ -704,9 +703,8 @@ export const CollectionSearchModal: React.FC<CollectionSearchModalProps> = ({
         {query.trim().length === 0 ? (
           /* Empty State - No search yet */
           <View style={styles.emptyState}>
-            <Icon
+            <Feather
               name="search"
-              type="feather"
               size={moderateScale(48)}
               color={activeTheme.colors.textSecondary}
             />
@@ -735,9 +733,8 @@ export const CollectionSearchModal: React.FC<CollectionSearchModalProps> = ({
             ListHeaderComponent={
               isSearching ? (
                 <View style={styles.loadingContainer}>
-                  <Icon
+                  <Feather
                     name="loader"
-                    type="feather"
                     size={moderateScale(24)}
                     color={activeTheme.colors.textSecondary}
                   />
@@ -751,9 +748,8 @@ export const CollectionSearchModal: React.FC<CollectionSearchModalProps> = ({
                 </View>
               ) : searchResults.length === 0 ? (
                 <View style={styles.noResultsContainer}>
-                  <Icon
+                  <Feather
                     name="inbox"
-                    type="feather"
                     size={moderateScale(48)}
                     color={activeTheme.colors.textSecondary}
                   />

--- a/components/collection/CollectionStickyHeader.tsx
+++ b/components/collection/CollectionStickyHeader.tsx
@@ -10,7 +10,7 @@ import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 
 interface CollectionStickyHeaderProps {
   title: string;
@@ -53,9 +53,8 @@ export const CollectionStickyHeader: React.FC<CollectionStickyHeaderProps> = ({
           style={styles.backButton}
           onPress={() => router.back()}
           hitSlop={8}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(22)}
             color={theme.colors.text}
           />

--- a/components/collection/PlaylistModal.tsx
+++ b/components/collection/PlaylistModal.tsx
@@ -9,7 +9,7 @@ import {
   Platform,
 } from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {Theme} from '@/utils/themeUtils';
 import {PlaylistIcon} from '@/components/Icons';
 import {Input} from '@/components/Input';
@@ -118,9 +118,8 @@ export const PlaylistModal: React.FC<PlaylistModalProps> = ({
         {/* Header */}
         <View style={styles.header}>
           <TouchableOpacity onPress={handleClose} style={styles.closeButton}>
-            <Icon
+            <Feather
               name="x"
-              type="feather"
               size={moderateScale(24)}
               color={theme.colors.text}
             />
@@ -196,7 +195,6 @@ export const PlaylistModal: React.FC<PlaylistModalProps> = ({
             label="Playlist Name"
             showIcon
             iconName="edit-3"
-            iconType="feather"
             placeholder="Name"
             value={playlistName}
             onChangeText={setPlaylistName}

--- a/components/collection/SectionHeader.tsx
+++ b/components/collection/SectionHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {View, TouchableOpacity, StyleSheet} from 'react-native';
+import {View, Pressable, StyleSheet} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {Theme} from '@/utils/themeUtils';
 
 interface SectionHeaderProps {
@@ -22,17 +22,13 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
       {/* <Text style={[styles.title, {color: theme.colors.textSecondary}]}>{title}</Text> */}
 
       {onViewToggle && (
-        <TouchableOpacity
-          style={styles.toggleButton}
-          onPress={onViewToggle}
-          activeOpacity={0.7}>
-          <Icon
+        <Pressable style={styles.toggleButton} onPress={onViewToggle}>
+          <Feather
             name={isGridView ? 'list' : 'grid'}
-            type="feather"
             size={moderateScale(20)}
             color={theme.colors.text}
           />
-        </TouchableOpacity>
+        </Pressable>
       )}
     </View>
   );

--- a/components/hero/SavedAdhkarHero.tsx
+++ b/components/hero/SavedAdhkarHero.tsx
@@ -13,7 +13,7 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 import {LinearGradient} from 'expo-linear-gradient';
-import {Icon} from '@rneui/themed';
+import {Ionicons} from '@expo/vector-icons';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
 import {getRandomColors} from '@/utils/gradientColors';
@@ -103,9 +103,8 @@ const SavedAdhkarCard = ({
               {savedCount === 1 ? 'SAVED DHIKR' : 'SAVED ADHKAR'}
             </Text>
             <View style={styles.iconContainer}>
-              <Icon
+              <Ionicons
                 name="bookmark"
-                type="ionicon"
                 size={moderateScale(20)}
                 color={theme.colors.text}
               />

--- a/components/hero/ScrollingReciters.tsx
+++ b/components/hero/ScrollingReciters.tsx
@@ -24,7 +24,7 @@ import {RECITERS, Reciter} from '@/data/reciterData';
 import {ReciterImage} from '@/components/ReciterImage';
 import {reciterImages} from '@/utils/reciterImages';
 import {Theme} from '@/utils/themeUtils';
-import {Icon} from '@rneui/base';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {useRouter} from 'expo-router';
 import {LinearGradient} from 'expo-linear-gradient';
@@ -168,9 +168,8 @@ const BrowseButton = React.memo(
         onPress={onPress}
         activeOpacity={0.8}>
         <Text style={styles.buttonText}>Browse All</Text>
-        <Icon
+        <Feather
           name="arrow-right"
-          type="feather"
           size={moderateScale(18)}
           color={theme.colors.text}
           style={styles.buttonIcon}
@@ -494,9 +493,8 @@ export const ScrollingHero = React.memo(
                 },
               ]}>
               <Text style={styles.buttonText}>Browse All</Text>
-              <Icon
+              <Feather
                 name="arrow-right"
-                type="feather"
                 size={moderateScale(16)}
                 color={theme.colors.text}
                 style={styles.buttonIcon}

--- a/components/modals/WhatsNewModal.tsx
+++ b/components/modals/WhatsNewModal.tsx
@@ -16,7 +16,7 @@ import {
 } from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
-import {Icon} from '@rneui/base';
+import {Ionicons} from '@expo/vector-icons';
 import {ChangelogEntry} from '@/types/changelog';
 import changelogData from '@/data/changelog.json';
 import {
@@ -140,7 +140,9 @@ export const WhatsNewModal = forwardRef<WhatsNewModalRef>((props, ref) => {
 
             <Text style={[styles.version, {color: theme.colors.textSecondary}]}>
               {hasMultipleVersions
-                ? `Versions ${changelogs[changelogs.length - 1]?.version} - ${latestVersion}`
+                ? `Versions ${
+                    changelogs[changelogs.length - 1]?.version
+                  } - ${latestVersion}`
                 : `Version ${latestVersion}`}
             </Text>
 
@@ -177,9 +179,8 @@ export const WhatsNewModal = forwardRef<WhatsNewModalRef>((props, ref) => {
                   <View style={styles.highlightsContainer}>
                     {changelog.highlights.map((highlight, index) => (
                       <View key={index} style={styles.highlightCard}>
-                        <Icon
-                          name={highlight.icon}
-                          type="ionicon"
+                        <Ionicons
+                          name={highlight.icon as any}
                           size={moderateScale(26)}
                           color={theme.colors.text}
                         />

--- a/components/player/v2/PlayerContent/Header.tsx
+++ b/components/player/v2/PlayerContent/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {View, Text, Pressable, StyleSheet} from 'react-native';
-import {Icon} from '@rneui/themed';
 import {moderateScale} from 'react-native-size-matters';
+import {Entypo, Feather} from '@expo/vector-icons';
 import {useTheme} from '@/hooks/useTheme';
 import {usePlayerActions} from '@/hooks/usePlayerActions';
 import {usePlayerStore} from '@/services/player/store/playerStore';
@@ -32,9 +32,8 @@ export const Header: React.FC<HeaderProps> = ({onOptionsPress}) => {
   return (
     <View style={styles.header}>
       <Pressable style={styles.closeButton} onPress={handleClose}>
-        <Icon
+        <Entypo
           name="chevron-thin-down"
-          type="entypo"
           size={moderateScale(22)}
           color={theme.colors.text}
         />
@@ -45,9 +44,8 @@ export const Header: React.FC<HeaderProps> = ({onOptionsPress}) => {
       </Text>
 
       <Pressable style={styles.optionsButton} onPress={onOptionsPress}>
-        <Icon
+        <Feather
           name="more-horizontal"
-          type="feather"
           size={moderateScale(22)}
           color={theme.colors.text}
         />

--- a/components/player/v2/PlayerContent/QueueList.tsx
+++ b/components/player/v2/PlayerContent/QueueList.tsx
@@ -10,7 +10,7 @@ import {
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {usePlayerStore} from '@/services/player/store/playerStore';
-import {Icon} from '@rneui/themed';
+import {MaterialCommunityIcons} from '@expo/vector-icons';
 import {TrackItem} from '@/components/TrackItem';
 
 interface QueueListProps {
@@ -29,9 +29,8 @@ export const QueueList: React.FC<QueueListProps> = ({
     return (
       <View style={styles.container}>
         <View style={styles.emptyContainer}>
-          <Icon
+          <MaterialCommunityIcons
             name="playlist-music"
-            type="material-community"
             size={moderateScale(48)}
             color={theme.colors.text}
             style={styles.emptyIcon}
@@ -81,9 +80,8 @@ export const QueueList: React.FC<QueueListProps> = ({
             <Pressable
               style={styles.removeButton}
               onPress={() => onRemoveQueueItem(index)}>
-              <Icon
+              <MaterialCommunityIcons
                 name="close"
-                type="material-community"
                 size={moderateScale(20)}
                 color={theme.colors.text}
               />

--- a/components/player/v2/PlayerContent/UploadPlaceholder.tsx
+++ b/components/player/v2/PlayerContent/UploadPlaceholder.tsx
@@ -6,7 +6,7 @@ import {usePlayerActions} from '@/hooks/usePlayerActions';
 import {useUploadsStore} from '@/store/uploadsStore';
 import {MicrophoneIcon} from '@/components/Icons';
 import {SheetManager} from 'react-native-actions-sheet';
-import {Icon} from '@rneui/themed';
+import {FontAwesome5} from '@expo/vector-icons';
 import type {Track} from '@/types/audio';
 
 interface UploadPlaceholderProps {
@@ -53,9 +53,8 @@ export const UploadPlaceholder: React.FC<UploadPlaceholderProps> = ({
             opacity: pressed ? 0.7 : 1,
           },
         ]}>
-        <Icon
+        <FontAwesome5
           name="sliders-h"
-          type="font-awesome-5"
           size={moderateScale(14)}
           color={theme.colors.text}
         />

--- a/components/playlist-detail/LovedHeader.tsx
+++ b/components/playlist-detail/LovedHeader.tsx
@@ -6,8 +6,7 @@ import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {Theme} from '@/utils/themeUtils';
 import {PlayIcon, ShuffleIcon, HeartIcon, CheckIcon} from '@/components/Icons';
-import {Ionicons} from '@expo/vector-icons';
-import {Icon} from '@rneui/themed';
+import {Feather, Ionicons} from '@expo/vector-icons';
 import Color from 'color';
 import Animated, {
   useSharedValue,
@@ -64,8 +63,8 @@ export const LovedHeader: React.FC<LovedHeaderProps> = ({
       button === 'download'
         ? downloadScale
         : button === 'shuffle'
-          ? shuffleScale
-          : playScale;
+        ? shuffleScale
+        : playScale;
     scale.value = withSpring(0.92, {
       damping: 15,
       stiffness: 300,
@@ -77,8 +76,8 @@ export const LovedHeader: React.FC<LovedHeaderProps> = ({
       button === 'download'
         ? downloadScale
         : button === 'shuffle'
-          ? shuffleScale
-          : playScale;
+        ? shuffleScale
+        : playScale;
     scale.value = withSpring(1, {
       damping: 15,
       stiffness: 300,
@@ -93,9 +92,8 @@ export const LovedHeader: React.FC<LovedHeaderProps> = ({
           style={styles.backButton}
           onPress={() => router.back()}
           hitSlop={8}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(24)}
             color={theme.colors.text}
           />

--- a/components/playlist-detail/PlaylistHeader.tsx
+++ b/components/playlist-detail/PlaylistHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {View, Text, Pressable} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {Theme} from '@/utils/themeUtils';
@@ -58,8 +58,8 @@ export const PlaylistHeader: React.FC<PlaylistHeaderProps> = ({
       button === 'options'
         ? optionsScale
         : button === 'shuffle'
-          ? shuffleScale
-          : playScale;
+        ? shuffleScale
+        : playScale;
     scale.value = withSpring(0.92, {
       damping: 15,
       stiffness: 300,
@@ -71,8 +71,8 @@ export const PlaylistHeader: React.FC<PlaylistHeaderProps> = ({
       button === 'options'
         ? optionsScale
         : button === 'shuffle'
-          ? shuffleScale
-          : playScale;
+        ? shuffleScale
+        : playScale;
     scale.value = withSpring(1, {
       damping: 15,
       stiffness: 300,
@@ -87,9 +87,8 @@ export const PlaylistHeader: React.FC<PlaylistHeaderProps> = ({
           style={styles.backButton}
           onPress={() => router.back()}
           hitSlop={8}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(24)}
             color={theme.colors.text}
           />
@@ -122,9 +121,8 @@ export const PlaylistHeader: React.FC<PlaylistHeaderProps> = ({
             onPress={onOptionsPress}
             onPressIn={() => handlePressIn('options')}
             onPressOut={() => handlePressOut('options')}>
-            <Icon
+            <Feather
               name="more-horizontal"
-              type="feather"
               size={moderateScale(20)}
               color={theme.colors.text}
             />

--- a/components/playlist-detail/ReciterDownloadsHeader.tsx
+++ b/components/playlist-detail/ReciterDownloadsHeader.tsx
@@ -5,7 +5,7 @@ import {ScaledSheet} from 'react-native-size-matters';
 import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {Theme} from '@/utils/themeUtils';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {PlayIcon, ShuffleIcon} from '@/components/Icons';
 import {ReciterImage} from '@/components/ReciterImage';
 import Animated, {
@@ -80,9 +80,8 @@ export const ReciterDownloadsHeader: React.FC<ReciterDownloadsHeaderProps> = ({
           style={styles.backButton}
           onPress={() => router.back()}
           hitSlop={8}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(24)}
             color={theme.colors.text}
           />

--- a/components/reciter-profile/ReciterProfile.tsx
+++ b/components/reciter-profile/ReciterProfile.tsx
@@ -31,7 +31,7 @@ import {useFavoriteReciters} from '@/hooks/useFavoriteReciters';
 import {useDownloadQueries} from '@/services/player/store/downloadSelectors';
 import {createSharedStyles} from './styles';
 import {useSettings} from '@/hooks/useSettings';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {HeartIcon} from '@/components/Icons';
 import Animated, {
   useSharedValue,
@@ -890,9 +890,8 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                     <Pressable
                       style={styles.viewModeButton}
                       onPress={toggleViewMode}>
-                      <Icon
+                      <Feather
                         name={viewMode === 'card' ? 'list' : 'grid'}
-                        type="feather"
                         size={moderateScale(16)}
                         color={theme.colors.text}
                       />

--- a/components/reciter-profile/components/NavigationButtons/index.tsx
+++ b/components/reciter-profile/components/NavigationButtons/index.tsx
@@ -3,7 +3,7 @@ import {Animated, Pressable} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useRouter} from 'expo-router';
 
 interface NavigationButtonsProps {
@@ -37,9 +37,8 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
           },
         ]}>
         <Pressable onPress={() => router.back()}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(24)}
             color={theme.colors.text}
           />
@@ -56,9 +55,8 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
           },
         ]}>
         <Pressable onPress={onSearchPress}>
-          <Icon
+          <Feather
             name="search"
-            type="feather"
             size={moderateScale(20)}
             color={theme.colors.text}
           />

--- a/components/reciter-profile/components/UploadCard.tsx
+++ b/components/reciter-profile/components/UploadCard.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {LinearGradient} from 'expo-linear-gradient';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {useTheme} from '@/hooks/useTheme';
 
@@ -88,9 +88,8 @@ export const UploadCard: React.FC<UploadCardProps> = ({
       />
       <View style={styles.content}>
         <View style={styles.iconContainer}>
-          <Icon
+          <Feather
             name="music"
-            type="feather"
             size={moderateScale(22)}
             color={theme.colors.textSecondary}
           />

--- a/components/reciter-profile/components/UploadsTabContent.tsx
+++ b/components/reciter-profile/components/UploadsTabContent.tsx
@@ -8,7 +8,7 @@ import {
   NativeScrollEvent,
 } from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -191,9 +191,8 @@ export const UploadsTabContent = React.forwardRef<
             onPress={() => handlePlay(item, index)}
             onLongPress={() => handleShowOptions(item, index)}>
             <View style={styles.itemIconContainer}>
-              <Icon
+              <Feather
                 name="music"
-                type="feather"
                 size={moderateScale(16)}
                 color={theme.colors.textSecondary}
               />
@@ -213,9 +212,8 @@ export const UploadsTabContent = React.forwardRef<
           <Pressable
             style={styles.itemOptionsZone}
             onPress={() => handleShowOptions(item, index)}>
-            <Icon
+            <Feather
               name="more-horizontal"
-              type="feather"
               size={moderateScale(16)}
               color={theme.colors.text}
             />
@@ -228,9 +226,8 @@ export const UploadsTabContent = React.forwardRef<
     const addButton = useMemo(
       () => (
         <Pressable style={styles.addButton} onPress={handleAddRecitation}>
-          <Icon
+          <Feather
             name="plus"
-            type="feather"
             size={moderateScale(16)}
             color={theme.colors.textSecondary}
           />
@@ -243,9 +240,8 @@ export const UploadsTabContent = React.forwardRef<
     const emptyState = useMemo(
       () => (
         <View style={styles.emptyContainer}>
-          <Icon
+          <Feather
             name="mic"
-            type="feather"
             size={moderateScale(40)}
             color={theme.colors.textSecondary}
           />
@@ -256,9 +252,8 @@ export const UploadsTabContent = React.forwardRef<
           <Pressable
             style={styles.emptyAddButton}
             onPress={handleAddRecitation}>
-            <Icon
+            <Feather
               name="plus"
-              type="feather"
               size={moderateScale(16)}
               color={theme.colors.textSecondary}
             />

--- a/components/search/SearchView.tsx
+++ b/components/search/SearchView.tsx
@@ -15,7 +15,7 @@ import {getAllReciters, getAllSurahs} from '@/services/dataService';
 import {Surah} from '@/data/surahData';
 import {Reciter} from '@/data/reciterData';
 import Fuse from 'fuse.js';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {ReciterItem} from '@/components/ReciterItem';
 import {SurahItem} from '@/components/SurahItem';
 import {useTheme} from '@/hooks/useTheme';
@@ -457,9 +457,8 @@ export function SearchView({onClose, visible}: SearchViewProps) {
             </View>
           ) : (
             <View style={styles.emptyRecentContainer}>
-              <Icon
+              <Feather
                 name="search"
-                type="feather"
                 size={moderateScale(48)}
                 color={theme.colors.textSecondary}
               />

--- a/components/sheets/AddToCollectionSheet.tsx
+++ b/components/sheets/AddToCollectionSheet.tsx
@@ -7,7 +7,7 @@ import ActionSheet, {
   SheetProps,
   SheetManager,
 } from 'react-native-actions-sheet';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {PlaylistIcon} from '@/components/Icons';
 import Color from 'color';
 import {useUploadsStore} from '@/store/uploadsStore';
@@ -89,9 +89,8 @@ export const AddToCollectionSheet = (
               pressed && styles.optionPressed,
             ]}
             onPress={handleAddFavoriteReciter}>
-            <Icon
+            <Feather
               name="star"
-              type="feather"
               size={moderateScale(20)}
               color={theme.colors.text}
             />
@@ -104,10 +103,7 @@ export const AddToCollectionSheet = (
               pressed && styles.optionPressed,
             ]}
             onPress={handleNewPlaylist}>
-            <PlaylistIcon
-              color={theme.colors.text}
-              size={moderateScale(20)}
-            />
+            <PlaylistIcon color={theme.colors.text} size={moderateScale(20)} />
             <Text style={styles.optionText}>Create New Playlist</Text>
           </Pressable>
 
@@ -117,9 +113,8 @@ export const AddToCollectionSheet = (
               pressed && styles.optionPressed,
             ]}
             onPress={handleNewUpload}>
-            <Icon
+            <Feather
               name="mic"
-              type="feather"
               size={moderateScale(20)}
               color={theme.colors.text}
             />

--- a/components/sheets/AdhkarCopyOptionsSheet.tsx
+++ b/components/sheets/AdhkarCopyOptionsSheet.tsx
@@ -12,7 +12,7 @@ import ActionSheet, {
   SheetManager,
 } from 'react-native-actions-sheet';
 import Color from 'color';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import {Dhikr} from '@/types/adhkar';
 
@@ -46,9 +46,8 @@ const CheckboxRow: React.FC<CheckboxRowProps> = ({
           disabled && styles.checkboxDisabled,
         ]}>
         {checked ? (
-          <Icon
+          <Feather
             name="check"
-            type="feather"
             size={moderateScale(14)}
             color={theme.colors.background}
           />
@@ -146,9 +145,8 @@ export const AdhkarCopyOptionsSheet = (
           onPress={handleCopy}
           activeOpacity={1}
           disabled={!canCopy}>
-          <Icon
+          <Feather
             name="copy"
-            type="feather"
             size={moderateScale(18)}
             color={
               canCopy ? theme.colors.background : theme.colors.textSecondary

--- a/components/sheets/AdhkarLayoutSheet.tsx
+++ b/components/sheets/AdhkarLayoutSheet.tsx
@@ -16,7 +16,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
 import ActionSheet, {SheetProps} from 'react-native-actions-sheet';
 import Color from 'color';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {
   useAdhkarSettingsStore,
   getActualFontSize,
@@ -79,9 +79,8 @@ const FontSizeControl: React.FC<FontSizeControlProps> = ({
             activeOpacity={1}
             hitSlop={10}
             disabled={currentDisplayValue <= DISPLAY_MIN}>
-            <Icon
+            <Feather
               name="minus"
-              type="feather"
               size={moderateScale(18)}
               color={
                 currentDisplayValue <= DISPLAY_MIN
@@ -96,9 +95,8 @@ const FontSizeControl: React.FC<FontSizeControlProps> = ({
             activeOpacity={1}
             hitSlop={10}
             disabled={currentDisplayValue >= DISPLAY_MAX}>
-            <Icon
+            <Feather
               name="plus"
-              type="feather"
               size={moderateScale(18)}
               color={
                 currentDisplayValue >= DISPLAY_MAX

--- a/components/sheets/CreatePlaylistSheet.tsx
+++ b/components/sheets/CreatePlaylistSheet.tsx
@@ -151,7 +151,6 @@ export const CreatePlaylistSheet = (props: SheetProps<'create-playlist'>) => {
           label="Playlist Name"
           showIcon
           iconName="edit-3"
-          iconType="feather"
           placeholder="e.g., Morning Recitations"
           value={playlistName}
           onChangeText={setPlaylistName}

--- a/components/sheets/DownloadOptionsSheet.tsx
+++ b/components/sheets/DownloadOptionsSheet.tsx
@@ -16,7 +16,7 @@ import ActionSheet, {
   SheetProps,
   SheetManager,
 } from 'react-native-actions-sheet';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useLoved} from '@/hooks/useLoved';
 import Color from 'color';
 import RenderHtml, {
@@ -268,9 +268,8 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
                 pressed && styles.optionPressed,
               ]}
               onPress={handleAddToPlaylist}>
-              <Icon
+              <Feather
                 name="plus-circle"
-                type="feather"
                 size={moderateScale(20)}
                 color={theme.colors.text}
               />
@@ -289,9 +288,8 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
                 pressed && styles.optionPressed,
               ]}
               onPress={handleViewInfo}>
-              <Icon
+              <Feather
                 name="info"
-                type="feather"
                 size={moderateScale(20)}
                 color={theme.colors.text}
               />
@@ -304,9 +302,8 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
                 pressed && styles.optionDestructivePressed,
               ]}
               onPress={handleRemoveDownload}>
-              <Icon
+              <Feather
                 name="trash-2"
-                type="feather"
                 size={moderateScale(20)}
                 color="#ff4444"
               />

--- a/components/sheets/FavoriteRecitersSheet.tsx
+++ b/components/sheets/FavoriteRecitersSheet.tsx
@@ -18,7 +18,7 @@ import {Theme} from '@/utils/themeUtils';
 import Color from 'color';
 import {SearchInput} from '@/components/SearchInput';
 import {ReciterImage} from '@/components/ReciterImage';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 
 export const FavoriteRecitersSheet = (
   props: SheetProps<'favorite-reciters'>,
@@ -88,9 +88,8 @@ export const FavoriteRecitersSheet = (
               isFavorite && styles.checkCircleActive,
             ]}>
             {isFavorite && (
-              <Icon
+              <Feather
                 name="check"
-                type="feather"
                 size={moderateScale(14)}
                 color={theme.colors.text}
               />

--- a/components/sheets/OrganizeRecitationSheet.tsx
+++ b/components/sheets/OrganizeRecitationSheet.tsx
@@ -17,7 +17,7 @@ import ActionSheet, {
   SheetManager,
 } from 'react-native-actions-sheet';
 import Color from 'color';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useUploadsStore} from '@/store/uploadsStore';
 import {
   searchSurahs,
@@ -455,9 +455,8 @@ export const OrganizeRecitationSheet = (
         {/* File Info */}
         <View style={styles.fileInfoRow}>
           <View style={styles.fileIconContainer}>
-            <Icon
+            <Feather
               name="music"
-              type="feather"
               size={moderateScale(16)}
               color={theme.colors.textSecondary}
             />
@@ -523,9 +522,8 @@ export const OrganizeRecitationSheet = (
                 <Pressable
                   onPress={handleClearSurah}
                   style={styles.clearButton}>
-                  <Icon
+                  <Feather
                     name="x"
-                    type="feather"
                     size={moderateScale(14)}
                     color={theme.colors.textSecondary}
                   />
@@ -534,9 +532,8 @@ export const OrganizeRecitationSheet = (
             ) : (
               <>
                 <View style={styles.searchInputContainer}>
-                  <Icon
+                  <Feather
                     name="search"
-                    type="feather"
                     size={moderateScale(14)}
                     color={theme.colors.textSecondary}
                   />
@@ -695,9 +692,8 @@ export const OrganizeRecitationSheet = (
                 <Pressable
                   onPress={handleClearReciter}
                   style={styles.clearButton}>
-                  <Icon
+                  <Feather
                     name="x"
-                    type="feather"
                     size={moderateScale(14)}
                     color={theme.colors.textSecondary}
                   />
@@ -706,9 +702,8 @@ export const OrganizeRecitationSheet = (
             ) : (
               <>
                 <View style={styles.searchInputContainer}>
-                  <Icon
+                  <Feather
                     name="search"
-                    type="feather"
                     size={moderateScale(14)}
                     color={theme.colors.textSecondary}
                   />
@@ -745,9 +740,8 @@ export const OrganizeRecitationSheet = (
                         <Pressable
                           style={styles.resultItem}
                           onPress={handleCreateReciter}>
-                          <Icon
+                          <Feather
                             name="plus-circle"
-                            type="feather"
                             size={moderateScale(16)}
                             color={theme.colors.text}
                           />
@@ -800,9 +794,8 @@ export const OrganizeRecitationSheet = (
                 style={styles.moreOptionsToggle}
                 onPress={() => setShowMoreOptions(prev => !prev)}>
                 <Text style={styles.moreOptionsText}>More Options</Text>
-                <Icon
+                <Feather
                   name={showMoreOptions ? 'chevron-up' : 'chevron-down'}
-                  type="feather"
                   size={moderateScale(14)}
                   color={theme.colors.textSecondary}
                 />
@@ -871,12 +864,7 @@ export const OrganizeRecitationSheet = (
 
         {/* Delete Button */}
         <Pressable style={styles.deleteButton} onPress={handleDelete}>
-          <Icon
-            name="trash-2"
-            type="feather"
-            size={moderateScale(16)}
-            color="#EF4444"
-          />
+          <Feather name="trash-2" size={moderateScale(16)} color="#EF4444" />
           <Text style={styles.deleteText}>Delete Recitation</Text>
         </Pressable>
       </ScrollView>

--- a/components/sheets/PlayerOptionsSheet.tsx
+++ b/components/sheets/PlayerOptionsSheet.tsx
@@ -15,7 +15,7 @@ import ActionSheet, {
   SheetProps,
   SheetManager,
 } from 'react-native-actions-sheet';
-import {Icon} from '@rneui/themed';
+import {Feather, FontAwesome5, Ionicons} from '@expo/vector-icons';
 import {useLoved} from '@/hooks/useLoved';
 import {
   useDownloadActions,
@@ -28,7 +28,6 @@ import {downloadSurah} from '@/services/downloadService';
 import {getReciterName} from '@/services/dataService';
 import Color from 'color';
 import {CircularProgress} from '@/components/CircularProgress';
-import {Ionicons} from '@expo/vector-icons';
 import RenderHtml, {
   MixedStyleDeclaration,
   RenderHTMLProps,
@@ -335,9 +334,8 @@ export const PlayerOptionsSheet = (props: SheetProps<'player-options'>) => {
                   pressed && styles.optionPressed,
                 ]}
                 onPress={handleEditDetails}>
-                <Icon
+                <FontAwesome5
                   name="sliders-h"
-                  type="font-awesome-5"
                   size={moderateScale(18)}
                   color={theme.colors.text}
                 />
@@ -375,8 +373,8 @@ export const PlayerOptionsSheet = (props: SheetProps<'player-options'>) => {
                   {isCurrentlyDownloading
                     ? `Downloading ${Math.round(downloadProgress * 100)}%`
                     : isTrackDownloaded
-                      ? 'Downloaded'
-                      : 'Download'}
+                    ? 'Downloaded'
+                    : 'Download'}
                 </Text>
               </Pressable>
             )}
@@ -388,9 +386,8 @@ export const PlayerOptionsSheet = (props: SheetProps<'player-options'>) => {
                   pressed && styles.optionPressed,
                 ]}
                 onPress={handleAddToPlaylist}>
-                <Icon
+                <Feather
                   name="plus-circle"
-                  type="feather"
                   size={moderateScale(20)}
                   color={theme.colors.text}
                 />
@@ -439,9 +436,8 @@ export const PlayerOptionsSheet = (props: SheetProps<'player-options'>) => {
                   pressed && styles.optionPressed,
                 ]}
                 onPress={handleViewInfo}>
-                <Icon
+                <Feather
                   name="info"
-                  type="feather"
                   size={moderateScale(20)}
                   color={theme.colors.text}
                 />

--- a/components/sheets/PlaylistContextSheet.tsx
+++ b/components/sheets/PlaylistContextSheet.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useCallback, useRef, useEffect} from 'react';
 import {View, Text, TouchableOpacity, StyleSheet, Alert} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import ActionSheet, {
   SheetProps,
   SheetManager,
@@ -480,16 +480,15 @@ export const PlaylistContextSheet = (props: SheetProps<'playlist-context'>) => {
                   />
                 )
               ) : (
-                <Icon
-                  name={option.icon}
-                  type="feather"
+                <Feather
+                  name={option.icon as any}
                   size={moderateScale(20)}
                   color={
                     option.disabled
                       ? theme.colors.textSecondary
                       : option.destructive
-                        ? '#ff4444'
-                        : theme.colors.text
+                      ? '#ff4444'
+                      : theme.colors.text
                   }
                 />
               )}

--- a/components/sheets/SelectPlaylistSheet.tsx
+++ b/components/sheets/SelectPlaylistSheet.tsx
@@ -18,7 +18,7 @@ import ActionSheet, {
 import {usePlaylists} from '@/hooks/usePlaylists';
 import {useLoved} from '@/hooks/useLoved';
 import {PlaylistItem} from '@/components/PlaylistItem';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
@@ -186,9 +186,8 @@ export const SelectPlaylistSheet = (props: SheetProps<'select-playlist'>) => {
               activeOpacity={0.7}
               disabled={isCreating}>
               <View style={styles.createButtonContent}>
-                <Icon
+                <Feather
                   name="plus"
-                  type="feather"
                   size={moderateScale(20)}
                   color={theme.colors.text}
                 />

--- a/components/sheets/SurahOptionsSheet.tsx
+++ b/components/sheets/SurahOptionsSheet.tsx
@@ -15,7 +15,7 @@ import ActionSheet, {
   SheetProps,
   SheetManager,
 } from 'react-native-actions-sheet';
-import {Icon} from '@rneui/themed';
+import {Feather, Ionicons} from '@expo/vector-icons';
 import {useLoved} from '@/hooks/useLoved';
 import {
   useDownloadActions,
@@ -28,7 +28,6 @@ import {downloadSurah} from '@/services/downloadService';
 import {getReciterName} from '@/services/dataService';
 import Color from 'color';
 import {CircularProgress} from '@/components/CircularProgress';
-import {Ionicons} from '@expo/vector-icons';
 import RenderHtml, {
   MixedStyleDeclaration,
   RenderHTMLProps,
@@ -341,8 +340,8 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
                 {isCurrentlyDownloading
                   ? `Downloading ${Math.round(downloadProgress * 100)}%`
                   : isTrackDownloaded
-                    ? 'Downloaded'
-                    : 'Download'}
+                  ? 'Downloaded'
+                  : 'Download'}
               </Text>
             </TouchableOpacity>
 
@@ -382,9 +381,8 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
               onPressIn={() => setPressedOption('collection')}
               onPressOut={() => setPressedOption(null)}
               activeOpacity={1}>
-              <Icon
+              <Feather
                 name="plus-circle"
-                type="feather"
                 size={moderateScale(20)}
                 color={theme.colors.text}
               />
@@ -406,9 +404,8 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
               onPressIn={() => setPressedOption('info')}
               onPressOut={() => setPressedOption(null)}
               activeOpacity={1}>
-              <Icon
+              <Feather
                 name="info"
-                type="feather"
                 size={moderateScale(20)}
                 color={theme.colors.text}
               />

--- a/components/sheets/UploadOptionsSheet.tsx
+++ b/components/sheets/UploadOptionsSheet.tsx
@@ -8,7 +8,7 @@ import ActionSheet, {
   SheetProps,
   SheetManager,
 } from 'react-native-actions-sheet';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {useUploadsStore, getCustomReciterName} from '@/store/uploadsStore';
 import {getSurahById, getReciterName} from '@/services/dataService';
@@ -156,9 +156,8 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
               pressed && styles.optionPressed,
             ]}
             onPress={handleOrganize}>
-            <Icon
+            <Feather
               name="sliders"
-              type="feather"
               size={moderateScale(20)}
               color={theme.colors.text}
             />
@@ -187,12 +186,7 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
               pressed && styles.optionDestructivePressed,
             ]}
             onPress={handleDelete}>
-            <Icon
-              name="trash-2"
-              type="feather"
-              size={moderateScale(20)}
-              color="#ff4444"
-            />
+            <Feather name="trash-2" size={moderateScale(20)} color="#ff4444" />
             <Text style={styles.optionTextDestructive}>Delete</Text>
           </Pressable>
         </View>

--- a/components/system-playlist/SystemPlaylistHeader.tsx
+++ b/components/system-playlist/SystemPlaylistHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {View, Text, Pressable} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
-import {Icon} from '@rneui/themed';
+import {Feather} from '@expo/vector-icons';
 import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {Theme} from '@/utils/themeUtils';
@@ -83,9 +83,8 @@ export const SystemPlaylistHeader: React.FC<SystemPlaylistHeaderProps> = ({
           style={styles.backButton}
           onPress={() => router.back()}
           hitSlop={8}>
-          <Icon
+          <Feather
             name="arrow-left"
-            type="feather"
             size={moderateScale(24)}
             color={theme.colors.text}
           />

--- a/data/categories.ts
+++ b/data/categories.ts
@@ -1,5 +1,3 @@
-import {IconProps} from '@rneui/themed';
-
 export interface Surah {
   id: number;
   name: string;
@@ -14,12 +12,17 @@ export interface Category {
   surahs: Surah[];
 }
 
+export interface BrowseCategoryIcon {
+  name: string;
+  type: string;
+}
+
 export interface BrowseCategory {
   id: string;
   title: string;
   description?: string;
   backgroundColor: string;
-  icon: Pick<IconProps, 'name' | 'type'>;
+  icon: BrowseCategoryIcon;
   route: string;
   featured?: boolean;
 }


### PR DESCRIPTION
## Summary
- Replaced all `@rneui/themed` and `@rneui/base` `Icon` imports with direct `@expo/vector-icons` components across **70 files**
- Eliminates the `react-native-vector-icons` deprecation runtime warning
- Net reduction of ~150 lines (313 insertions, 464 deletions)

### Icon families migrated:
| RNEUI `type=` | `@expo/vector-icons` component |
|---|---|
| `feather` | `Feather` |
| `ionicon` | `Ionicons` |
| `material` | `MaterialIcons` |
| `material-community` | `MaterialCommunityIcons` |
| `font-awesome-5` | `FontAwesome5` |
| `entypo` | `Entypo` |
| `antdesign` | `AntDesign` |

### Special cases handled:
- Multi-type files (settings, WhatsNewModal) — imported multiple icon families
- Dynamic icon names (PlaylistContextSheet, ReciterProfile, DhikrReader) — type casts for dynamic names
- `Input.tsx` — removed `iconType` prop, hardcoded to Feather
- `data/categories.ts` — replaced `IconProps` from `@rneui` with local type
- Icons with `onPress` — wrapped in `Pressable`
- Icons with `containerStyle` — wrapped in `View`

## Test plan
- [ ] Verify no deprecation warning on app start
- [ ] Spot-check icons render correctly across screens (home, settings, collection, player, sheets)
- [ ] Verify `npx tsc --noEmit` passes (confirmed pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)