### PR TITLE
UI clean-up: player polish and Pressable migration

### DIFF
--- a/app/(tabs)/(c.collection)/collection/uploads.tsx
+++ b/app/(tabs)/(c.collection)/collection/uploads.tsx
@@ -29,6 +29,11 @@ import Animated, {
 import type {UploadedRecitation} from '@/types/uploads';
 import {CollectionStickyHeader} from '@/components/collection/CollectionStickyHeader';
 import {pickAndImportAudioFiles} from '@/utils/importAudio';
+import {usePlayerStore} from '@/services/player/store/playerStore';
+import {NowPlayingIndicator} from '@/components/NowPlayingIndicator';
+import {GradientText} from '@/components/GradientText';
+import {ReciterImage} from '@/components/ReciterImage';
+import {surahGlyphMap} from '@/utils/surahGlyphMap';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
@@ -70,6 +75,135 @@ function getDisplaySubtitle(item: UploadedRecitation): string {
     ? parts.join(' \u00B7 ')
     : stripExtension(item.originalFilename);
 }
+
+interface UploadListItemProps {
+  item: UploadedRecitation;
+  index: number;
+  onPlay: (item: UploadedRecitation, index: number) => void;
+  onShowOptions: (item: UploadedRecitation, index: number) => void;
+}
+
+const UploadListItem: React.FC<UploadListItemProps> = React.memo(
+  ({item, index, onPlay, onShowOptions}) => {
+    const {theme} = useTheme();
+    const styles = useMemo(() => createStyles(theme), [theme]);
+
+    const playbackState = usePlayerStore(state => state.playback.state);
+    const currentIndex = usePlayerStore(state => state.queue.currentIndex);
+    const tracks = usePlayerStore(state => state.queue.tracks);
+
+    const trackId = `upload-${item.id}`;
+
+    const isCurrentTrack = useMemo(() => {
+      const current =
+        tracks && currentIndex >= 0 && currentIndex < tracks.length
+          ? tracks[currentIndex]
+          : null;
+      return current?.id === trackId;
+    }, [tracks, currentIndex, trackId]);
+
+    const isPlaying =
+      isCurrentTrack &&
+      (playbackState === 'playing' || playbackState === 'buffering');
+
+    const displaySubtitle = getDisplaySubtitle(item);
+
+    const reciterName = useMemo(() => {
+      if (!item.reciterId) return null;
+      return getReciterName(item.reciterId);
+    }, [item.reciterId]);
+
+    // Build title with surah number prefix when applicable
+    const displayTitle = useMemo(() => {
+      if (item.type === 'surah' && item.surahNumber) {
+        const surah = getSurahById(item.surahNumber);
+        if (surah) return `${item.surahNumber}. ${surah.name}`;
+      }
+      return getDisplayTitle(item);
+    }, [item]);
+
+    return (
+      <View style={styles.itemRow}>
+        <Pressable
+          style={styles.itemPlayZone}
+          onPress={() => onPlay(item, index)}
+          onLongPress={() => onShowOptions(item, index)}>
+          {reciterName ? (
+            <ReciterImage
+              reciterName={reciterName}
+              style={styles.itemReciterImage}
+            />
+          ) : (
+            <View style={styles.itemIconContainer}>
+              <Feather
+                name="music"
+                size={moderateScale(18)}
+                color={theme.colors.textSecondary}
+              />
+            </View>
+          )}
+          <View style={styles.itemInfoContainer}>
+            <View style={styles.itemNameRow}>
+              {isCurrentTrack && item.surahNumber ? (
+                <GradientText
+                  style={styles.itemName}
+                  surahId={item.surahNumber}>
+                  {displayTitle}
+                </GradientText>
+              ) : (
+                <Text
+                  style={styles.itemName}
+                  numberOfLines={1}
+                  ellipsizeMode="middle">
+                  {displayTitle}
+                </Text>
+              )}
+              {item.surahNumber && surahGlyphMap[item.surahNumber] && (
+                <Text style={styles.itemSurahGlyph}>
+                  {surahGlyphMap[item.surahNumber]}
+                </Text>
+              )}
+            </View>
+            <View style={styles.itemSecondaryRow}>
+              <Text style={styles.itemSecondaryText} numberOfLines={1}>
+                {displaySubtitle}
+              </Text>
+            </View>
+            {item.type === 'surah' && item.rewayah && (
+              <Text style={styles.itemTertiaryText}>
+                {item.rewayah}
+                {item.style
+                  ? ` \u00B7 ${
+                      item.style.charAt(0).toUpperCase() + item.style.slice(1)
+                    }`
+                  : ''}
+              </Text>
+            )}
+          </View>
+        </Pressable>
+        <Pressable
+          style={styles.itemOptionsZone}
+          onPress={() => onShowOptions(item, index)}>
+          {isCurrentTrack ? (
+            <NowPlayingIndicator
+              isPlaying={isPlaying}
+              barCount={3}
+              surahId={item.surahNumber ?? undefined}
+            />
+          ) : (
+            <Feather
+              name="more-horizontal"
+              size={moderateScale(18)}
+              color={theme.colors.text}
+            />
+          )}
+        </Pressable>
+      </View>
+    );
+  },
+);
+
+UploadListItem.displayName = 'UploadListItem';
 
 export default function UploadsScreen() {
   const {theme} = useTheme();
@@ -193,66 +327,15 @@ export default function UploadsScreen() {
   const hasRecitations = recitations.length > 0;
 
   const renderItem = useCallback(
-    ({item, index}: ListRenderItemInfo<UploadedRecitation>) => {
-      const displayTitle = getDisplayTitle(item);
-      const displaySubtitle = getDisplaySubtitle(item);
-
-      return (
-        <View style={styles.itemRow}>
-          <Pressable
-            style={styles.itemPlayZone}
-            onPress={() => handlePlayRecitation(item, index)}
-            onLongPress={() => handleShowOptions(item, index)}>
-            <View style={styles.itemIconContainer}>
-              <Feather
-                name="music"
-                size={moderateScale(18)}
-                color={theme.colors.textSecondary}
-              />
-            </View>
-            <View style={styles.itemInfoContainer}>
-              <Text
-                style={styles.itemName}
-                numberOfLines={1}
-                ellipsizeMode="middle">
-                {displayTitle}
-              </Text>
-              <View style={styles.itemSecondaryRow}>
-                <Text style={styles.itemSecondaryText} numberOfLines={1}>
-                  {displaySubtitle}
-                </Text>
-              </View>
-              {item.type === 'surah' && item.rewayah && (
-                <Text style={styles.itemTertiaryText}>
-                  {item.rewayah}
-                  {item.style
-                    ? ` \u00B7 ${
-                        item.style.charAt(0).toUpperCase() + item.style.slice(1)
-                      }`
-                    : ''}
-                </Text>
-              )}
-            </View>
-          </Pressable>
-          <Pressable
-            style={styles.itemOptionsZone}
-            onPress={() => handleShowOptions(item, index)}>
-            <Feather
-              name="more-horizontal"
-              size={moderateScale(18)}
-              color={theme.colors.text}
-            />
-          </Pressable>
-        </View>
-      );
-    },
-    [
-      styles,
-      theme.colors.textSecondary,
-      theme.colors.text,
-      handlePlayRecitation,
-      handleShowOptions,
-    ],
+    ({item, index}: ListRenderItemInfo<UploadedRecitation>) => (
+      <UploadListItem
+        item={item}
+        index={index}
+        onPlay={handlePlayRecitation}
+        onShowOptions={handleShowOptions}
+      />
+    ),
+    [handlePlayRecitation, handleShowOptions],
   );
 
   const keyExtractor = useCallback((item: UploadedRecitation) => item.id, []);
@@ -565,8 +648,24 @@ const createStyles = (theme: {colors: any; fonts: any}) =>
       alignItems: 'center',
       marginRight: moderateScale(10),
     },
+    itemReciterImage: {
+      width: moderateScale(44),
+      height: moderateScale(44),
+      borderRadius: moderateScale(10),
+      marginRight: moderateScale(10),
+    },
     itemInfoContainer: {
       flex: 1,
+    },
+    itemNameRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    itemSurahGlyph: {
+      fontSize: moderateScale(16),
+      fontFamily: 'SurahNames',
+      color: theme.colors.text,
+      marginLeft: moderateScale(6),
     },
     itemName: {
       fontSize: moderateScale(13),

--- a/components/player/v2/FloatingPlayer/PlayButton.tsx
+++ b/components/player/v2/FloatingPlayer/PlayButton.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {TouchableOpacity, StyleSheet} from 'react-native';
+import {Pressable, StyleSheet} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {PlayIcon, PauseIcon} from '@/components/Icons';
 import {useTheme} from '@/hooks/useTheme';
@@ -39,17 +39,16 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
   };
 
   return (
-    <TouchableOpacity
-      activeOpacity={0.7}
+    <Pressable
       onPress={handlePress}
       disabled={disabled}
-      style={styles.button}>
+      style={({pressed}) => [styles.button, {opacity: pressed ? 0.7 : 1}]}>
       {optimisticIsPlaying ? (
         <PauseIcon color={theme.colors.text} size={moderateScale(24)} />
       ) : (
         <PlayIcon color={theme.colors.text} size={moderateScale(24)} />
       )}
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 

--- a/components/player/v2/FloatingPlayer/index.tsx
+++ b/components/player/v2/FloatingPlayer/index.tsx
@@ -4,7 +4,6 @@ import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import Animated, {
   useSharedValue,
-  withTiming,
   withSpring,
   useAnimatedStyle,
 } from 'react-native-reanimated';
@@ -157,45 +156,18 @@ export const FloatingPlayer: React.FC = React.memo(function FloatingPlayer() {
     opacity: opacity.value,
   }));
 
-  // Animation handlers
-  const showPlayer = useCallback(() => {
-    'worklet';
-    translateY.value = withSpring(0, {
-      damping: 15,
-      stiffness: 150,
-    });
-    opacity.value = withTiming(1, {
-      duration: 200,
-    });
-    scale.value = withSpring(1, {
-      damping: 15,
-      stiffness: 150,
-    });
-  }, [translateY, opacity, scale]);
-
-  const hidePlayer = useCallback(() => {
-    'worklet';
-    translateY.value = withSpring(100, {
-      damping: 15,
-      stiffness: 150,
-    });
-    opacity.value = withTiming(0, {
-      duration: 200,
-    });
-    scale.value = withSpring(0.95, {
-      damping: 15,
-      stiffness: 150,
-    });
-  }, [translateY, opacity, scale]);
-
-  // Handle visibility
+  // Handle visibility (instant, no animation)
   useEffect(() => {
     if (shouldShow) {
-      showPlayer();
+      translateY.value = 0;
+      opacity.value = 1;
+      scale.value = 1;
     } else {
-      hidePlayer();
+      translateY.value = 100;
+      opacity.value = 0;
+      scale.value = 0.95;
     }
-  }, [shouldShow, showPlayer, hidePlayer]);
+  }, [shouldShow, translateY, opacity, scale]);
 
   const handlePress = useCallback(() => {
     setSheetMode('full');

--- a/components/player/v2/PlayerContent/QueueList.tsx
+++ b/components/player/v2/PlayerContent/QueueList.tsx
@@ -8,10 +8,163 @@ import {
   Platform,
 } from 'react-native';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
+import {Feather} from '@expo/vector-icons';
 import {useTheme} from '@/hooks/useTheme';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {MaterialCommunityIcons} from '@expo/vector-icons';
 import {TrackItem} from '@/components/TrackItem';
+import {Track} from '@/types/audio';
+import {ReciterImage} from '@/components/ReciterImage';
+import {NowPlayingIndicator} from '@/components/NowPlayingIndicator';
+import {GradientText} from '@/components/GradientText';
+import {surahGlyphMap} from '@/utils/surahGlyphMap';
+import Color from 'color';
+
+interface UploadQueueItemProps {
+  track: Track;
+  index: number;
+  onPress: () => void;
+}
+
+const UploadQueueItem: React.FC<UploadQueueItemProps> = React.memo(
+  ({track, index, onPress}) => {
+    const {theme} = useTheme();
+
+    const playbackState = usePlayerStore(state => state.playback.state);
+    const currentIndex = usePlayerStore(state => state.queue.currentIndex);
+
+    const isCurrentTrack = currentIndex === index;
+    const isPlaying =
+      isCurrentTrack &&
+      (playbackState === 'playing' || playbackState === 'buffering');
+
+    const surahNum = track.surahId ? parseInt(track.surahId, 10) : undefined;
+    const surahGlyph =
+      surahNum && surahGlyphMap[surahNum] ? surahGlyphMap[surahNum] : undefined;
+
+    const displayTitle = surahNum ? `${surahNum}. ${track.title}` : track.title;
+
+    return (
+      <Pressable style={uploadQueueStyles.container} onPress={onPress}>
+        {track.reciterName && track.reciterName !== 'My Recitations' ? (
+          <ReciterImage
+            reciterName={track.reciterName}
+            style={uploadQueueStyles.reciterImage}
+          />
+        ) : (
+          <View
+            style={[
+              uploadQueueStyles.iconContainer,
+              {
+                backgroundColor: Color(theme.colors.text)
+                  .alpha(0.06)
+                  .toString(),
+              },
+            ]}>
+            <Feather
+              name="music"
+              size={moderateScale(16)}
+              color={theme.colors.textSecondary}
+            />
+          </View>
+        )}
+        <View style={uploadQueueStyles.info}>
+          <View style={uploadQueueStyles.nameRow}>
+            {isCurrentTrack && surahNum ? (
+              <GradientText
+                style={[uploadQueueStyles.title, {color: theme.colors.text}]}
+                surahId={surahNum}>
+                {displayTitle}
+              </GradientText>
+            ) : (
+              <Text
+                style={[uploadQueueStyles.title, {color: theme.colors.text}]}
+                numberOfLines={1}>
+                {displayTitle}
+              </Text>
+            )}
+            {surahGlyph && (
+              <Text
+                style={[
+                  uploadQueueStyles.surahGlyph,
+                  {color: theme.colors.text},
+                ]}>
+                {surahGlyph}
+              </Text>
+            )}
+          </View>
+          <Text
+            style={[
+              uploadQueueStyles.artist,
+              {color: theme.colors.textSecondary},
+            ]}
+            numberOfLines={1}>
+            {track.artist}
+          </Text>
+        </View>
+        {isCurrentTrack && (
+          <View style={uploadQueueStyles.indicator}>
+            <NowPlayingIndicator
+              isPlaying={isPlaying}
+              barCount={3}
+              surahId={surahNum}
+            />
+          </View>
+        )}
+      </Pressable>
+    );
+  },
+);
+
+UploadQueueItem.displayName = 'UploadQueueItem';
+
+const uploadQueueStyles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: moderateScale(8),
+    paddingHorizontal: moderateScale(18),
+    flex: 1,
+  },
+  reciterImage: {
+    width: moderateScale(50),
+    height: moderateScale(50),
+    borderRadius: moderateScale(10),
+    marginRight: moderateScale(12),
+  },
+  iconContainer: {
+    width: moderateScale(50),
+    height: moderateScale(50),
+    borderRadius: moderateScale(10),
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: moderateScale(12),
+  },
+  info: {
+    flex: 1,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: moderateScale(1),
+  },
+  title: {
+    fontSize: moderateScale(14),
+    fontFamily: 'Manrope-SemiBold',
+  },
+  surahGlyph: {
+    fontSize: moderateScale(16),
+    fontFamily: 'SurahNames',
+    marginLeft: moderateScale(6),
+  },
+  artist: {
+    fontSize: moderateScale(12),
+    fontFamily: 'Manrope-Regular',
+  },
+  indicator: {
+    marginLeft: moderateScale(8),
+  },
+});
 
 interface QueueListProps {
   onQueueItemPress: (index: number) => void;
@@ -63,7 +216,7 @@ export const QueueList: React.FC<QueueListProps> = ({
           </View>
           <View style={styles.headerRight}>
             <Text style={[styles.queueCount, {color: theme.colors.text}]}>
-              {queue.tracks.length} surahs
+              {queue.tracks.length} track{queue.tracks.length !== 1 ? 's' : ''}
             </Text>
           </View>
         </View>
@@ -71,12 +224,20 @@ export const QueueList: React.FC<QueueListProps> = ({
         {/* Queue Items */}
         {queue.tracks.map((track, index) => (
           <View key={`${track.id}-${index}`} style={styles.trackItemContainer}>
-            <TrackItem
-              reciterId={track.reciterId}
-              surahId={track.surahId || ''}
-              rewayatId={track.rewayatId}
-              onPress={() => onQueueItemPress(index)}
-            />
+            {track.isUserUpload ? (
+              <UploadQueueItem
+                track={track}
+                index={index}
+                onPress={() => onQueueItemPress(index)}
+              />
+            ) : (
+              <TrackItem
+                reciterId={track.reciterId}
+                surahId={track.surahId || ''}
+                rewayatId={track.rewayatId}
+                onPress={() => onQueueItemPress(index)}
+              />
+            )}
             <Pressable
               style={styles.removeButton}
               onPress={() => onRemoveQueueItem(index)}>

--- a/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
+++ b/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
@@ -1,5 +1,5 @@
 import React, {memo, useCallback, useState, useEffect, useRef} from 'react';
-import {StyleSheet, TouchableOpacity, Text, View} from 'react-native';
+import {StyleSheet, Pressable, Text, View} from 'react-native';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {Verse} from '@/types/quran';
 import Color from 'color';
@@ -293,9 +293,11 @@ export const VerseItem = memo<VerseItemProps>(
     // <--- End Get Indopak text
 
     return (
-      <TouchableOpacity
-        activeOpacity={0.7}
-        style={[styles.container, {borderBottomColor: borderColor}]}
+      <Pressable
+        style={({pressed}) => [
+          styles.container,
+          {borderBottomColor: borderColor, opacity: pressed ? 0.7 : 1},
+        ]}
         onPress={onPress}>
         <View style={styles.verseInfoContainer}>
           <View style={[styles.verseInfoPill, {backgroundColor: bgColor}]}>
@@ -396,18 +398,21 @@ export const VerseItem = memo<VerseItemProps>(
               <Text style={[styles.footnoteTitle, {color: textColor}]}>
                 Footnote
               </Text>
-              <TouchableOpacity
+              <Pressable
                 onPress={closeFootnote}
-                style={styles.closeButton}>
+                style={({pressed}) => [
+                  styles.closeButton,
+                  {opacity: pressed ? 0.7 : 1},
+                ]}>
                 <Ionicons name="close" size={20} color={textColor} />
-              </TouchableOpacity>
+              </Pressable>
             </View>
             <Text style={[styles.footnoteContent, {color: textColor}]}>
               {activeFootnote.content}
             </Text>
           </View>
         )}
-      </TouchableOpacity>
+      </Pressable>
     );
   },
 );

--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -156,7 +156,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     left: 0,
-    paddingHorizontal: moderateScale(20),
   },
   controlsContainer: {
     width: '100%',

--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -146,16 +146,16 @@ const styles = StyleSheet.create({
   viewsContainer: {
     flex: 1,
     width: '100%',
-    paddingHorizontal: moderateScale(20),
     marginTop: moderateScale(5),
     position: 'relative',
   },
   viewWrapper: {
-    width: '100%',
     height: '100%',
     position: 'absolute',
     top: 0,
     left: 0,
+    right: 0,
+    paddingHorizontal: moderateScale(20),
   },
   controlsContainer: {
     width: '100%',

--- a/components/reciter-profile/ReciterProfile.tsx
+++ b/components/reciter-profile/ReciterProfile.tsx
@@ -622,20 +622,29 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
     ],
   );
 
-  // Continuous scroll listener — updates activeTab at 50% swipe threshold.
+  // Scroll listener — only clears programmatic scroll gate; no side effects during swipe.
   const handleHorizontalScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (scrollTargetRef.current !== null) {
+        const offsetX = e.nativeEvent.contentOffset.x;
+        const pageIndex = Math.round(offsetX / screenWidth);
+        const tab = tabs[pageIndex];
+        if (tab && tab.id === scrollTargetRef.current) {
+          scrollTargetRef.current = null;
+        }
+      }
+    },
+    [tabs, screenWidth],
+  );
+
+  // Fires after paging snap completes — updates tab state without interrupting gesture.
+  const handleHorizontalMomentumEnd = useCallback(
     (e: NativeSyntheticEvent<NativeScrollEvent>) => {
       const offsetX = e.nativeEvent.contentOffset.x;
       const pageIndex = Math.round(offsetX / screenWidth);
       const tab = tabs[pageIndex];
 
-      // Ignore intermediate scroll events during programmatic tab changes
-      if (scrollTargetRef.current !== null) {
-        if (tab && tab.id === scrollTargetRef.current) {
-          scrollTargetRef.current = null;
-        }
-        return;
-      }
+      if (scrollTargetRef.current !== null) return; // programmatic scroll handled elsewhere
 
       if (tab && tab.id !== activeTabRef.current) {
         activeTabRef.current = tab.id;
@@ -643,7 +652,6 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
         if (tab.id !== 'uploads') {
           handleRewayatChange(tab.id);
         }
-        // Reset outer scroll position (same logic as handleTabChange)
         const maxScroll = Math.max(0, collapsibleHeight - stickyTitleHeight);
         const isCollapsed = currentScrollYRef.current >= maxScroll - 1;
         outerScrollRef.current?.scrollTo({
@@ -915,6 +923,8 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                 ref={horizontalRef}
                 horizontal
                 pagingEnabled
+                decelerationRate="fast"
+                directionalLockEnabled
                 showsHorizontalScrollIndicator={false}
                 scrollEventThrottle={16}
                 style={{opacity: pagerOpacity}}
@@ -922,6 +932,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                 onScrollBeginDrag={() => {
                   scrollTargetRef.current = null;
                 }}
+                onMomentumScrollEnd={handleHorizontalMomentumEnd}
                 onScroll={RNAnimated.event(
                   [{nativeEvent: {contentOffset: {x: scrollX}}}],
                   {useNativeDriver: true, listener: handleHorizontalScroll},

--- a/components/reciter-profile/components/UploadCard.tsx
+++ b/components/reciter-profile/components/UploadCard.tsx
@@ -12,6 +12,10 @@ import {LinearGradient} from 'expo-linear-gradient';
 import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {useTheme} from '@/hooks/useTheme';
+import {usePlayerStore} from '@/services/player/store/playerStore';
+import {NowPlayingIndicator} from '@/components/NowPlayingIndicator';
+import {GradientText} from '@/components/GradientText';
+import {surahGlyphMap} from '@/utils/surahGlyphMap';
 
 interface UploadCardProps {
   title: string;
@@ -20,6 +24,8 @@ interface UploadCardProps {
   onLongPress?: () => void;
   color: string;
   style?: StyleProp<ViewStyle>;
+  uploadId?: string;
+  surahNumber?: number;
 }
 
 export const UploadCard: React.FC<UploadCardProps> = ({
@@ -29,8 +35,29 @@ export const UploadCard: React.FC<UploadCardProps> = ({
   onLongPress,
   color,
   style,
+  uploadId,
+  surahNumber,
 }) => {
   const {theme} = useTheme();
+
+  const playbackState = usePlayerStore(state => state.playback.state);
+  const currentIndex = usePlayerStore(state => state.queue.currentIndex);
+  const tracks = usePlayerStore(state => state.queue.tracks);
+
+  const trackId = uploadId ? `upload-${uploadId}` : null;
+
+  const isCurrentTrack = useMemo(() => {
+    if (!trackId) return false;
+    const current =
+      tracks && currentIndex >= 0 && currentIndex < tracks.length
+        ? tracks[currentIndex]
+        : null;
+    return current?.id === trackId;
+  }, [tracks, currentIndex, trackId]);
+
+  const isPlaying =
+    isCurrentTrack &&
+    (playbackState === 'playing' || playbackState === 'buffering');
 
   const gradientColors = useMemo((): [string, string] => {
     const base = Color(theme.colors.textSecondary);
@@ -70,6 +97,17 @@ export const UploadCard: React.FC<UploadCardProps> = ({
           textAlign: 'center',
           marginTop: moderateScale(2),
         },
+        nowPlayingCorner: {
+          position: 'absolute',
+          bottom: moderateScale(6),
+          right: moderateScale(6),
+        },
+        surahGlyph: {
+          fontSize: moderateScale(10),
+          fontFamily: 'SurahNames',
+          color: theme.colors.textSecondary,
+          marginTop: moderateScale(2),
+        },
       }),
     [theme],
   );
@@ -94,13 +132,32 @@ export const UploadCard: React.FC<UploadCardProps> = ({
             color={theme.colors.textSecondary}
           />
         </View>
-        <Text style={styles.title} numberOfLines={2} ellipsizeMode="tail">
-          {title}
-        </Text>
-        <Text style={styles.subtitle} numberOfLines={1} ellipsizeMode="tail">
-          {subtitle}
-        </Text>
+        {isCurrentTrack && surahNumber ? (
+          <GradientText style={styles.title} surahId={surahNumber}>
+            {title}
+          </GradientText>
+        ) : (
+          <Text style={styles.title} numberOfLines={2} ellipsizeMode="tail">
+            {title}
+          </Text>
+        )}
+        {surahNumber && surahGlyphMap[surahNumber] ? (
+          <Text style={styles.surahGlyph}>{surahGlyphMap[surahNumber]}</Text>
+        ) : (
+          <Text style={styles.subtitle} numberOfLines={1} ellipsizeMode="tail">
+            {subtitle}
+          </Text>
+        )}
       </View>
+      {isCurrentTrack && (
+        <View style={styles.nowPlayingCorner}>
+          <NowPlayingIndicator
+            isPlaying={isPlaying}
+            barCount={3}
+            surahId={surahNumber}
+          />
+        </View>
+      )}
     </Pressable>
   );
 };

--- a/components/reciter-profile/components/UploadsTabContent.tsx
+++ b/components/reciter-profile/components/UploadsTabContent.tsx
@@ -19,6 +19,9 @@ import {getSurahById} from '@/services/dataService';
 import {SheetManager} from 'react-native-actions-sheet';
 import {UploadCard} from './UploadCard';
 import type {UploadedRecitation} from '@/types/uploads';
+import {usePlayerStore} from '@/services/player/store/playerStore';
+import {NowPlayingIndicator} from '@/components/NowPlayingIndicator';
+import {GradientText} from '@/components/GradientText';
 
 interface UploadsTabContentProps {
   reciterId: string;
@@ -68,6 +71,100 @@ function getDisplaySubtitle(item: UploadedRecitation): string {
 
   return parts.join(' · ');
 }
+
+interface ReciterUploadListItemProps {
+  item: UploadedRecitation;
+  index: number;
+  onPlay: (item: UploadedRecitation, index: number) => void;
+  onShowOptions: (item: UploadedRecitation, index: number) => void;
+}
+
+const ReciterUploadListItem: React.FC<ReciterUploadListItemProps> = React.memo(
+  ({item, index, onPlay, onShowOptions}) => {
+    const {theme} = useTheme();
+    const styles = useMemo(() => createStyles(theme), [theme]);
+
+    const playbackState = usePlayerStore(state => state.playback.state);
+    const currentIndex = usePlayerStore(state => state.queue.currentIndex);
+    const tracks = usePlayerStore(state => state.queue.tracks);
+
+    const trackId = `upload-${item.id}`;
+
+    const isCurrentTrack = useMemo(() => {
+      const current =
+        tracks && currentIndex >= 0 && currentIndex < tracks.length
+          ? tracks[currentIndex]
+          : null;
+      return current?.id === trackId;
+    }, [tracks, currentIndex, trackId]);
+
+    const isPlaying =
+      isCurrentTrack &&
+      (playbackState === 'playing' || playbackState === 'buffering');
+
+    // Build title with surah number prefix when applicable
+    const displayTitle = useMemo(() => {
+      if (item.type === 'surah' && item.surahNumber) {
+        const surah = getSurahById(item.surahNumber);
+        if (surah) return `${item.surahNumber}. ${surah.name}`;
+      }
+      return getDisplayTitle(item);
+    }, [item]);
+
+    return (
+      <View style={styles.itemRow}>
+        <Pressable
+          style={styles.itemPlayZone}
+          onPress={() => onPlay(item, index)}
+          onLongPress={() => onShowOptions(item, index)}>
+          <View style={styles.itemIconContainer}>
+            <Feather
+              name="music"
+              size={moderateScale(16)}
+              color={theme.colors.textSecondary}
+            />
+          </View>
+          <View style={styles.itemInfoContainer}>
+            {isCurrentTrack && item.surahNumber ? (
+              <GradientText style={styles.itemName} surahId={item.surahNumber}>
+                {displayTitle}
+              </GradientText>
+            ) : (
+              <Text
+                style={styles.itemName}
+                numberOfLines={1}
+                ellipsizeMode="middle">
+                {displayTitle}
+              </Text>
+            )}
+            <Text style={styles.itemSubtitle} numberOfLines={1}>
+              {getDisplaySubtitle(item)}
+            </Text>
+          </View>
+        </Pressable>
+        <Pressable
+          style={styles.itemOptionsZone}
+          onPress={() => onShowOptions(item, index)}>
+          {isCurrentTrack ? (
+            <NowPlayingIndicator
+              isPlaying={isPlaying}
+              barCount={3}
+              surahId={item.surahNumber ?? undefined}
+            />
+          ) : (
+            <Feather
+              name="more-horizontal"
+              size={moderateScale(16)}
+              color={theme.colors.text}
+            />
+          )}
+        </Pressable>
+      </View>
+    );
+  },
+);
+
+ReciterUploadListItem.displayName = 'ReciterUploadListItem';
 
 export const UploadsTabContent = React.forwardRef<
   Animated.FlatList,
@@ -172,6 +269,8 @@ export const UploadsTabContent = React.forwardRef<
               : theme.colors.textSecondary
           }
           style={styles.cardItem}
+          uploadId={item.id}
+          surahNumber={item.surahNumber ?? undefined}
         />
       ),
       [
@@ -185,42 +284,14 @@ export const UploadsTabContent = React.forwardRef<
 
     const renderListItem = useCallback(
       ({item, index}: {item: UploadedRecitation; index: number}) => (
-        <View style={styles.itemRow}>
-          <Pressable
-            style={styles.itemPlayZone}
-            onPress={() => handlePlay(item, index)}
-            onLongPress={() => handleShowOptions(item, index)}>
-            <View style={styles.itemIconContainer}>
-              <Feather
-                name="music"
-                size={moderateScale(16)}
-                color={theme.colors.textSecondary}
-              />
-            </View>
-            <View style={styles.itemInfoContainer}>
-              <Text
-                style={styles.itemName}
-                numberOfLines={1}
-                ellipsizeMode="middle">
-                {getDisplayTitle(item)}
-              </Text>
-              <Text style={styles.itemSubtitle} numberOfLines={1}>
-                {getDisplaySubtitle(item)}
-              </Text>
-            </View>
-          </Pressable>
-          <Pressable
-            style={styles.itemOptionsZone}
-            onPress={() => handleShowOptions(item, index)}>
-            <Feather
-              name="more-horizontal"
-              size={moderateScale(16)}
-              color={theme.colors.text}
-            />
-          </Pressable>
-        </View>
+        <ReciterUploadListItem
+          item={item}
+          index={index}
+          onPlay={handlePlay}
+          onShowOptions={handleShowOptions}
+        />
       ),
-      [handlePlay, handleShowOptions, theme, styles],
+      [handlePlay, handleShowOptions],
     );
 
     const addButton = useMemo(

--- a/utils/track.ts
+++ b/utils/track.ts
@@ -157,22 +157,22 @@ export function createUserUploadTrack(recitation: UploadedRecitation): Track {
   // Build artist from reciter tags, fallback to 'My Recitations'
   let artist = 'My Recitations';
   let resolvedRewayatId: string | undefined;
+  let artwork = '';
   if (recitation.reciterId) {
+    const reciter = RECITERS.find(r => r.id === recitation.reciterId);
     const name = getReciterName(recitation.reciterId);
     if (name) artist = name;
+    if (reciter) artwork = getReciterArtwork(reciter);
 
     // Resolve rewayah name to rewayat UUID so the player can look it up
     // Only for surah recitations — other categories don't need rewayah display
-    if (recitation.type === 'surah' && recitation.rewayah) {
-      const reciter = RECITERS.find(r => r.id === recitation.reciterId);
-      if (reciter) {
-        const match = reciter.rewayat.find(
-          rw =>
-            rw.name === recitation.rewayah &&
-            (!recitation.style || rw.style === recitation.style),
-        );
-        if (match) resolvedRewayatId = match.id;
-      }
+    if (recitation.type === 'surah' && recitation.rewayah && reciter) {
+      const match = reciter.rewayat.find(
+        rw =>
+          rw.name === recitation.rewayah &&
+          (!recitation.style || rw.style === recitation.style),
+      );
+      if (match) resolvedRewayatId = match.id;
     }
   }
 
@@ -181,7 +181,7 @@ export function createUserUploadTrack(recitation: UploadedRecitation): Track {
     url,
     title,
     artist,
-    artwork: '',
+    artwork,
     surahId: recitation.surahNumber
       ? String(recitation.surahNumber)
       : undefined,


### PR DESCRIPTION
## Summary
- **Now-playing indicators, reciter images, and queue support for uploads** — upload tracks now show reciter artwork, now-playing highlights, and integrate with the queue
- **Fix asymmetric margins in Quran/Queue view** — corrected layout inconsistency in the player content area
- **Remove FloatingPlayer slide-up animation and polish player/reciter UX** — cleaner transition, improved reciter screen styling
- **Replace TouchableOpacity with Pressable in player components** — migrated PlayButton and VerseItem to Pressable for consistent press behavior

## Test plan
- [ ] Verify floating player play/pause button responds to taps
- [ ] Verify verse items in Quran view respond to taps and footnote close works
- [ ] Verify upload tracks show reciter images and now-playing indicators
- [ ] Verify Quran/Queue view margins are symmetric
- [ ] Verify FloatingPlayer opens without slide-up animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)