### PR TITLE
fix(player): fix queue auto-advance and previous button

### DIFF
--- a/components/player/v2/PlayerContent/PlaybackControls/Controls.tsx
+++ b/components/player/v2/PlayerContent/PlaybackControls/Controls.tsx
@@ -56,9 +56,9 @@ export const Controls = () => {
   }, [playbackState]);
 
   const handlePrevious = useCallback(async () => {
-    if (trackLoading || currentIndex === 0) return;
+    if (trackLoading) return;
     await skipToPrevious();
-  }, [trackLoading, currentIndex, skipToPrevious]);
+  }, [trackLoading, skipToPrevious]);
 
   const handleNext = useCallback(async () => {
     if (trackLoading || currentIndex === tracksLength - 1) return;
@@ -75,7 +75,6 @@ export const Controls = () => {
     await seekTo(playbackPosition + SEEK_INTERVAL);
   }, [trackLoading, playbackPosition, seekTo]);
 
-  const isFirstTrack = currentIndex === 0;
   const isLastTrack = currentIndex === tracksLength - 1;
 
   return (
@@ -107,11 +106,11 @@ export const Controls = () => {
       <View style={styles.centerControls}>
         <Pressable
           onPress={handlePrevious}
-          style={[styles.sideButton, isFirstTrack && styles.disabledButton]}
-          disabled={isFirstTrack || trackLoading}>
+          style={[styles.sideButton, trackLoading && styles.disabledButton]}
+          disabled={trackLoading}>
           <PreviousIcon
             color={
-              isFirstTrack ? theme.colors.textSecondary : theme.colors.text
+              trackLoading ? theme.colors.textSecondary : theme.colors.text
             }
             size={moderateScale(16)}
           />

--- a/services/audio/ExpoAudioProvider.tsx
+++ b/services/audio/ExpoAudioProvider.tsx
@@ -41,7 +41,6 @@ export function ExpoAudioProvider({children}: ExpoAudioProviderProps) {
     state => state.updatePlaybackState,
   );
   const skipToNext = usePlayerStore(state => state.skipToNext);
-  const settings = usePlayerStore(state => state.settings);
 
   // Connect player to service on mount
   useEffect(() => {
@@ -177,8 +176,8 @@ export function ExpoAudioProvider({children}: ExpoAudioProviderProps) {
     if (__DEV__) console.log('[ExpoAudioProvider] Track ended');
 
     try {
-      const {repeatMode} = settings;
       const store = usePlayerStore.getState();
+      const {repeatMode} = store.settings;
       const {currentIndex, tracks} = store.queue;
 
       if (repeatMode === 'track') {
@@ -202,12 +201,12 @@ export function ExpoAudioProvider({children}: ExpoAudioProviderProps) {
     } finally {
       isHandlingTrackEnd.current = false;
     }
-  }, [settings, skipToNext, updatePlaybackState]);
+  }, [skipToNext, updatePlaybackState]);
 
   // Monitor for track end via didJustFinish
   useEffect(() => {
     // expo-audio sets didJustFinish to true when track completes
-    if (status.didJustFinish && wasPlaying.current) {
+    if (status.didJustFinish) {
       handleTrackEnd();
     }
   }, [status.didJustFinish, handleTrackEnd]);


### PR DESCRIPTION
## Summary
- **Auto-advance fix:** Removed `wasPlaying` ref check from `didJustFinish` handler in `ExpoAudioProvider`. The playback state effect was clearing it before the finish effect could read it (same render cycle race condition), preventing `handleTrackEnd()` from ever firing.
- **Previous button fix:** Removed first-track guard from `Controls.tsx` so the store's `skipToPrevious` logic can restart the current track instead of being blocked by the UI.
- **Minor cleanup:** Read `settings` from `getState()` instead of a reactive subscription to avoid stale closures and unnecessary provider re-renders.

## Test plan
- [ ] Play a track and let it finish naturally → next track should auto-advance
- [ ] Set repeat mode to 'track', let track finish → same track restarts
- [ ] Set repeat mode to 'queue', let last track finish → first track starts
- [ ] No repeat, last track finishes → playback ends
- [ ] On first track, wait >3s, tap previous → track restarts from 0
- [ ] On first track, tap previous within 3s → track restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)