### PR TITLE
fix(adhkar): pause Quran player when starting Play All mode

### DIFF
--- a/store/adhkarPlayAllStore.ts
+++ b/store/adhkarPlayAllStore.ts
@@ -9,6 +9,7 @@
 import {create} from 'zustand';
 import {Dhikr} from '@/types/adhkar';
 import {useAdhkarAudioStore} from '@/store/adhkarAudioStore';
+import {usePlayerStore} from '@/services/player/store/playerStore';
 
 type SourceType = 'morning' | 'evening' | 'saved' | 'other';
 
@@ -71,6 +72,12 @@ export const useAdhkarPlayAllStore = create<
     // Stop single-dhikr playback
     useAdhkarAudioStore.getState().pause();
 
+    // Pause main Quran player if it's playing
+    const mainPlayerState = usePlayerStore.getState();
+    if (mainPlayerState.playback.state === 'playing') {
+      mainPlayerState.pause();
+    }
+
     set({
       isPlayAllMode: true,
       queue: adhkarList,
@@ -128,6 +135,13 @@ export const useAdhkarPlayAllStore = create<
   play: () => {
     const {isPlayAllMode} = get();
     if (!isPlayAllMode) return;
+
+    // Pause main Quran player if it's playing
+    const mainPlayerState = usePlayerStore.getState();
+    if (mainPlayerState.playback.state === 'playing') {
+      mainPlayerState.pause();
+    }
+
     set({isPlaying: true});
   },
 


### PR DESCRIPTION
## Summary
- Adhkar Play All mode was missing the bidirectional pause logic, allowing it to play over the Quran player
- Added Quran-pause checks in `startPlayAll()` and `play()` in `adhkarPlayAllStore.ts`, matching the existing pattern in `adhkarAudioStore.ts`

## Test plan
- [ ] Start Quran playback → open adhkar → hit "Play All" → Quran should pause, adhkar plays
- [ ] Start Quran playback → pause adhkar Play All → resume Play All → Quran should pause again
- [ ] Start adhkar Play All → tap a surah → adhkar should pause (regression check)
- [ ] Single-dhikr play still pauses Quran (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)