### PR TITLE
feat(collection): now-playing indicator, extended upload options, remove from playlist

### DIFF
--- a/app/(tabs)/(c.collection)/collection/downloads.tsx
+++ b/app/(tabs)/(c.collection)/collection/downloads.tsx
@@ -1,7 +1,8 @@
-import React, {useState, useEffect, useCallback, useRef} from 'react';
+import React, {useState, useEffect, useCallback, useRef, useMemo} from 'react';
 import {
   View,
   Text,
+  Pressable,
   StyleSheet,
   ListRenderItem,
   Animated as RNAnimated,
@@ -9,8 +10,8 @@ import {
 import {useTheme} from '@/hooks/useTheme';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
-import {Pressable} from 'react-native';
 import {TrackItem} from '@/components/TrackItem';
+import {ReciterDownloadsListItem} from '@/components/ReciterDownloadsListItem';
 import {DownloadedSurah} from '@/services/player/store/downloadStore';
 import {
   useDownloadActions,
@@ -24,11 +25,11 @@ import {usePlayerStore} from '@/services/player/store/playerStore';
 import {createDownloadedTrack} from '@/utils/track';
 import {moderateScale} from 'react-native-size-matters';
 import {Feather} from '@expo/vector-icons';
-import {DownloadCollectionActionButtons} from '@/components/DownloadCollectionActionButtons';
-import {CollectionCard} from '@/components/CollectionCard';
-import {DownloadIcon} from '@/components/Icons';
+import {DownloadIcon, PlayIcon, ShuffleIcon} from '@/components/Icons';
 import {SheetManager} from 'react-native-actions-sheet';
 import {CollectionStickyHeader} from '@/components/collection/CollectionStickyHeader';
+import {shuffleArray} from '@/utils/arrayUtils';
+import Color from 'color';
 
 interface DownloadDataItem {
   download: DownloadedSurah;
@@ -36,63 +37,194 @@ interface DownloadDataItem {
   surah: Surah | null;
 }
 
+interface GroupedItem {
+  type: 'single' | 'group';
+  reciterId: string;
+  downloadData?: DownloadDataItem;
+  downloadCount?: number;
+}
+
 export default function DownloadsScreen() {
   const {theme} = useTheme();
   const insets = useSafeAreaInsets();
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: theme.colors.background,
-    },
-    headerContainer: {
-      width: '100%',
-      overflow: 'hidden',
-    },
-    contentArea: {
-      width: '100%',
-      alignItems: 'center',
-      paddingTop: insets.top + moderateScale(40),
-      paddingBottom: moderateScale(20),
-      overflow: 'hidden',
-      backgroundColor: theme.colors.background,
-    },
-    backButton: {
-      position: 'absolute',
-      top: insets.top + moderateScale(10),
-      left: moderateScale(15),
-      zIndex: 10,
-      padding: moderateScale(8),
-    },
-    contentContainer: {
-      paddingHorizontal: moderateScale(16),
-      paddingBottom: moderateScale(10),
-    },
-    listContentContainer: {
-      flexGrow: 1,
-      paddingBottom: moderateScale(65),
-    },
-    emptyText: {
-      fontSize: moderateScale(16),
-      color: theme.colors.text,
-      textAlign: 'center',
-      marginTop: moderateScale(32),
-    },
-  });
-
   const router = useRouter();
   const downloads = useDownloads();
-  const {removeDownload} = useDownloadActions();
+  const {removeDownload, clearAllDownloads} = useDownloadActions();
   const {updateQueue, addToQueue, play, pause} = usePlayerActions();
   const playbackState = usePlayerStore(state => state.playback.state);
 
-  // Scroll tracking for sticky header
   const scrollY = useRef(new RNAnimated.Value(0)).current;
 
-  // State to store reciter and surah data for each download
   const [downloadData, setDownloadData] = useState<DownloadDataItem[]>([]);
 
-  // Load reciter and surah data for all downloads
+  const handleOptionsMenu = useCallback(() => {
+    SheetManager.show('collection-options', {
+      payload: {
+        title: 'Downloads',
+        subtitle: `${downloads.length} ${
+          downloads.length === 1 ? 'surah' : 'surahs'
+        } downloaded`,
+        options: [
+          {
+            label: 'Remove All Downloads',
+            icon: 'trash-2',
+            destructive: true,
+            onPress: () => clearAllDownloads(),
+          },
+        ],
+      },
+    });
+  }, [downloads.length, clearAllDownloads]);
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: theme.colors.background,
+        },
+        headerContainer: {
+          width: '100%',
+          overflow: 'hidden',
+        },
+        contentArea: {
+          width: '100%',
+          alignItems: 'center',
+          paddingTop: insets.top + moderateScale(40),
+          paddingBottom: moderateScale(10),
+          overflow: 'hidden',
+          backgroundColor: theme.colors.background,
+        },
+        contentCenter: {
+          alignItems: 'center',
+          paddingHorizontal: moderateScale(20),
+        },
+        heroIconContainer: {
+          width: moderateScale(64),
+          height: moderateScale(64),
+          borderRadius: moderateScale(32),
+          justifyContent: 'center',
+          alignItems: 'center',
+          marginBottom: moderateScale(12),
+          backgroundColor: Color(theme.colors.textSecondary)
+            .alpha(0.1)
+            .toString(),
+        },
+        heroIconInner: {
+          width: moderateScale(56),
+          height: moderateScale(56),
+          borderRadius: moderateScale(28),
+          justifyContent: 'center',
+          alignItems: 'center',
+          backgroundColor: Color(theme.colors.textSecondary)
+            .alpha(0.08)
+            .toString(),
+        },
+        title: {
+          fontSize: moderateScale(17),
+          fontFamily: theme.fonts.bold,
+          color: theme.colors.text,
+          textAlign: 'center',
+          marginBottom: moderateScale(8),
+          letterSpacing: -0.3,
+        },
+        subtitle: {
+          fontSize: moderateScale(12),
+          color: theme.colors.text,
+          fontFamily: theme.fonts.regular,
+          textAlign: 'center',
+          marginBottom: moderateScale(8),
+        },
+        actionButtons: {
+          flexDirection: 'row',
+          justifyContent: 'center',
+          alignItems: 'center',
+          paddingTop: moderateScale(4),
+          paddingBottom: moderateScale(12),
+          paddingHorizontal: moderateScale(20),
+          gap: moderateScale(16),
+        },
+        circleButton: {
+          width: moderateScale(42),
+          height: moderateScale(42),
+          justifyContent: 'center',
+          alignItems: 'center',
+          borderRadius: moderateScale(12),
+          backgroundColor: Color(theme.colors.textSecondary)
+            .alpha(0.08)
+            .toString(),
+          padding: moderateScale(8),
+        },
+        playButton: {
+          width: moderateScale(42),
+          height: moderateScale(42),
+          backgroundColor: theme.colors.text,
+        },
+        playIconContainer: {
+          paddingLeft: moderateScale(4),
+        },
+        disabledButton: {
+          opacity: 0.4,
+        },
+        listContentContainer: {
+          flexGrow: 1,
+          paddingBottom: moderateScale(65),
+        },
+        fixedBackButton: {
+          position: 'absolute',
+          top: insets.top + moderateScale(10),
+          left: moderateScale(15),
+          zIndex: 5,
+          padding: moderateScale(8),
+        },
+        emptyHeader: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingBottom: moderateScale(12),
+          paddingHorizontal: moderateScale(16),
+        },
+        emptyHeaderBack: {
+          width: moderateScale(36),
+          height: moderateScale(36),
+          justifyContent: 'center',
+          alignItems: 'center',
+        },
+        emptyHeaderTitle: {
+          flex: 1,
+          fontSize: moderateScale(17),
+          fontFamily: theme.fonts.bold,
+          color: theme.colors.text,
+          textAlign: 'center',
+        },
+        emptyContent: {
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingHorizontal: moderateScale(32),
+          paddingBottom: moderateScale(60),
+        },
+        emptyIcon: {
+          marginBottom: moderateScale(16),
+        },
+        emptyTitle: {
+          fontSize: moderateScale(17),
+          fontFamily: theme.fonts.bold,
+          color: theme.colors.text,
+          textAlign: 'center',
+          marginBottom: moderateScale(8),
+        },
+        emptySubtitle: {
+          fontSize: moderateScale(13),
+          fontFamily: theme.fonts.regular,
+          color: theme.colors.textSecondary,
+          textAlign: 'center',
+          marginBottom: moderateScale(20),
+        },
+      }),
+    [theme, insets.top],
+  );
+
   useEffect(() => {
     const loadDownloadData = async () => {
       const data = await Promise.all(
@@ -118,19 +250,45 @@ export default function DownloadsScreen() {
     }
   }, [downloads]);
 
-  // Handle surah press to play downloaded file
+  const groupedItems = useMemo(() => {
+    const byReciter: Record<string, DownloadDataItem[]> = {};
+    for (const item of downloadData) {
+      const rid = item.download.reciterId;
+      if (!byReciter[rid]) {
+        byReciter[rid] = [];
+      }
+      byReciter[rid].push(item);
+    }
+
+    const items: GroupedItem[] = [];
+    for (const [reciterId, reciterDownloads] of Object.entries(byReciter)) {
+      if (reciterDownloads.length === 1) {
+        items.push({
+          type: 'single',
+          reciterId,
+          downloadData: reciterDownloads[0],
+        });
+      } else {
+        items.push({
+          type: 'group',
+          reciterId,
+          downloadCount: reciterDownloads.length,
+        });
+      }
+    }
+
+    return items;
+  }, [downloadData]);
+
   const handleSurahPress = useCallback(
     async (download: DownloadedSurah, reciter: Reciter, surah: Surah) => {
       try {
-        // Create track using local file path
         const track = createDownloadedTrack(
           reciter,
           surah,
           download.filePath,
           download.rewayatId,
         );
-
-        // Update queue with the downloaded track and start playing
         await updateQueue([track], 0);
         await play();
       } catch (error) {
@@ -177,18 +335,73 @@ export default function DownloadsScreen() {
     [handleSurahPress, addToQueue, handleRemoveDownload],
   );
 
-  // play all downloads
+  const handleReciterGroupOptions = useCallback(
+    (reciterId: string) => {
+      const reciterDownloads = downloadData.filter(
+        item => item.download.reciterId === reciterId,
+      );
+      const reciterName = reciterDownloads[0]?.reciter?.name || 'Reciter';
+
+      SheetManager.show('collection-options', {
+        payload: {
+          title: reciterName,
+          subtitle: `${reciterDownloads.length} ${
+            reciterDownloads.length === 1 ? 'surah' : 'surahs'
+          } downloaded`,
+          options: [
+            {
+              label: 'Play All',
+              icon: 'play',
+              customIcon: (
+                <PlayIcon color={theme.colors.text} size={moderateScale(20)} />
+              ),
+              onPress: async () => {
+                const tracks = reciterDownloads
+                  .filter(item => item.reciter && item.surah)
+                  .map(item =>
+                    createDownloadedTrack(
+                      item.reciter!,
+                      item.surah!,
+                      item.download.filePath,
+                      item.download.rewayatId,
+                    ),
+                  );
+                if (tracks.length > 0) {
+                  await updateQueue(tracks, 0);
+                  await play();
+                }
+              },
+            },
+            {
+              label: 'Remove All Downloads',
+              icon: 'trash-2',
+              destructive: true,
+              onPress: async () => {
+                for (const item of reciterDownloads) {
+                  await removeDownload(
+                    item.download.reciterId,
+                    item.download.surahId,
+                    item.download.rewayatId || undefined,
+                  );
+                }
+              },
+            },
+          ],
+        },
+      });
+    },
+    [downloadData, updateQueue, play, removeDownload, theme.colors.text],
+  );
+
   const handlePlayAll = useCallback(async () => {
     if (downloadData.length === 0) return;
 
     try {
-      // If currently playing, pause
       if (playbackState === 'playing') {
         await pause();
         return;
       }
 
-      // If paused or stopped, play all downloads
       const trackPromises = downloadData.map(async item => {
         if (!item.reciter || !item.surah) return null;
         return createDownloadedTrack(
@@ -212,45 +425,149 @@ export default function DownloadsScreen() {
     }
   }, [downloadData, updateQueue, play, pause, playbackState]);
 
-  const ListHeaderComponent = useCallback(() => {
+  const handleShuffle = useCallback(async () => {
+    if (downloadData.length === 0) return;
+
+    try {
+      const shuffledItems = shuffleArray([...downloadData]).filter(
+        item => item.reciter && item.surah,
+      );
+
+      if (shuffledItems.length === 0) return;
+
+      const tracks = shuffledItems.map(item =>
+        createDownloadedTrack(
+          item.reciter!,
+          item.surah!,
+          item.download.filePath,
+          item.download.rewayatId,
+        ),
+      );
+
+      await updateQueue(tracks, 0);
+      await play();
+    } catch (error) {
+      console.error('Error shuffling downloads:', error);
+    }
+  }, [downloadData, updateQueue, play]);
+
+  const hasDownloads = downloadData.length > 0;
+
+  if (downloads.length === 0) {
     return (
-      <View style={styles.headerContainer}>
-        <View style={styles.contentArea}>
-          {/* Back Button */}
+      <View style={styles.container}>
+        <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
           <Pressable
-            style={styles.backButton}
+            style={styles.emptyHeaderBack}
             onPress={() => router.back()}
             hitSlop={8}>
             <Feather
               name="arrow-left"
-              size={moderateScale(24)}
+              size={moderateScale(22)}
               color={theme.colors.text}
             />
           </Pressable>
-          <CollectionCard
-            icon={
-              <DownloadIcon
-                color={theme.colors.text}
-                size={moderateScale(80)}
-                filled={true}
-              />
-            }
-            title="Downloads"
-            subtitle={`${downloadData.length} surahs downloaded`}
-          />
+          <Text style={styles.emptyHeaderTitle}>Downloads</Text>
+          <View style={styles.emptyHeaderBack} />
         </View>
-        <View style={styles.contentContainer}>
-          <DownloadCollectionActionButtons
-            onPlayPress={handlePlayAll}
-            disabled={downloadData.length === 0}
-          />
+        <View style={styles.emptyContent}>
+          <View style={styles.emptyIcon}>
+            <DownloadIcon
+              color={theme.colors.textSecondary}
+              size={moderateScale(48)}
+              filled={true}
+            />
+          </View>
+          <Text style={styles.emptyTitle}>No downloads yet</Text>
+          <Text style={styles.emptySubtitle}>
+            Download surahs to see them here
+          </Text>
         </View>
       </View>
     );
-  }, [styles, theme.colors.text, router, downloadData.length, handlePlayAll]);
+  }
 
-  const renderItem: ListRenderItem<DownloadDataItem> = ({item}) => {
-    const {download, reciter, surah} = item;
+  const ListHeaderComponent = () => {
+    return (
+      <View style={styles.headerContainer}>
+        <View style={styles.contentArea}>
+          <View style={styles.contentCenter}>
+            <View style={styles.heroIconContainer}>
+              <View style={styles.heroIconInner}>
+                <DownloadIcon
+                  color={theme.colors.text}
+                  size={moderateScale(30)}
+                  filled={true}
+                />
+              </View>
+            </View>
+            <Text style={styles.title}>Downloads</Text>
+            <Text style={styles.subtitle}>
+              {downloads.length} {downloads.length === 1 ? 'surah' : 'surahs'}{' '}
+              downloaded
+            </Text>
+          </View>
+        </View>
+
+        <View style={styles.actionButtons}>
+          <Pressable
+            style={[
+              styles.circleButton,
+              !hasDownloads && styles.disabledButton,
+            ]}
+            onPress={hasDownloads ? handleOptionsMenu : undefined}
+            disabled={!hasDownloads}>
+            <Feather
+              name="more-horizontal"
+              size={moderateScale(20)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+          <Pressable
+            style={[
+              styles.circleButton,
+              styles.playButton,
+              !hasDownloads && styles.disabledButton,
+            ]}
+            onPress={hasDownloads ? handlePlayAll : undefined}
+            disabled={!hasDownloads}>
+            <View style={styles.playIconContainer}>
+              <PlayIcon
+                color={theme.colors.background}
+                size={moderateScale(16)}
+              />
+            </View>
+          </Pressable>
+          <Pressable
+            style={[
+              styles.circleButton,
+              !hasDownloads && styles.disabledButton,
+            ]}
+            onPress={hasDownloads ? handleShuffle : undefined}
+            disabled={!hasDownloads}>
+            <ShuffleIcon color={theme.colors.text} size={moderateScale(20)} />
+          </Pressable>
+        </View>
+      </View>
+    );
+  };
+
+  const renderItem: ListRenderItem<GroupedItem> = ({item}) => {
+    if (item.type === 'group') {
+      return (
+        <ReciterDownloadsListItem
+          reciterId={item.reciterId}
+          downloadCount={item.downloadCount!}
+          onPress={() =>
+            router.push(`/collection/reciter-downloads/${item.reciterId}`)
+          }
+          onOptionsPress={() => handleReciterGroupOptions(item.reciterId)}
+          onLongPress={() => handleReciterGroupOptions(item.reciterId)}
+        />
+      );
+    }
+
+    const {download, reciter, surah} = item.downloadData!;
 
     if (!reciter || !surah) {
       return null;
@@ -264,23 +581,43 @@ export default function DownloadsScreen() {
         onPress={() => handleSurahPress(download, reciter, surah)}
         onPlayPress={() => handleSurahPress(download, reciter, surah)}
         onOptionsPress={() => handleShowOptions(download, reciter, surah)}
+        onLongPress={() => handleShowOptions(download, reciter, surah)}
       />
     );
   };
 
   return (
     <View style={styles.container}>
+      <RNAnimated.View
+        style={[
+          styles.fixedBackButton,
+          {
+            opacity: scrollY.interpolate({
+              inputRange: [80, 120],
+              outputRange: [1, 0],
+              extrapolate: 'clamp',
+            }),
+          },
+        ]}>
+        <Pressable onPress={() => router.back()} hitSlop={8}>
+          <Feather
+            name="arrow-left"
+            size={moderateScale(24)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+      </RNAnimated.View>
+
       <RNAnimated.FlatList
-        data={downloadData}
+        data={groupedItems}
         renderItem={renderItem}
         keyExtractor={item =>
-          `${item.download.reciterId}-${item.download.surahId}`
+          item.type === 'group'
+            ? `group-${item.reciterId}`
+            : `single-${item.reciterId}-${item.downloadData!.download.surahId}`
         }
         ListHeaderComponent={ListHeaderComponent}
         contentContainerStyle={styles.listContentContainer}
-        ListEmptyComponent={
-          <Text style={styles.emptyText}>No downloads yet</Text>
-        }
         onScroll={RNAnimated.event(
           [{nativeEvent: {contentOffset: {y: scrollY}}}],
           {useNativeDriver: true},

--- a/app/(tabs)/(c.collection)/collection/favorite-reciters.tsx
+++ b/app/(tabs)/(c.collection)/collection/favorite-reciters.tsx
@@ -1,303 +1,396 @@
-import React, {useRef, useState, useEffect, useCallback} from 'react';
+import React, {useRef, useState, useCallback, useMemo} from 'react';
 import {
   View,
   Text,
-  TouchableOpacity,
-  Animated,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
+  Pressable,
   StyleSheet,
-  ScrollView,
-  useWindowDimensions,
+  Animated as RNAnimated,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
-import {createStyles} from './_styles';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {CircularReciterCard} from '@/components/cards/CircularReciterCard';
+import {ReciterItem} from '@/components/ReciterItem';
 import {useFavoriteReciters} from '@/hooks/useFavoriteReciters';
 import {useRouter} from 'expo-router';
 import {moderateScale} from 'react-native-size-matters';
 import {Feather} from '@expo/vector-icons';
-import {LinearGradient} from 'expo-linear-gradient';
-import {StatusBar} from 'expo-status-bar';
-import {CollectionCard} from '@/components/CollectionCard';
+import {ProfileIcon} from '@/components/Icons';
+import {CollectionStickyHeader} from '@/components/collection/CollectionStickyHeader';
 import SearchBar from '@/components/SearchBar';
 import {Reciter} from '@/data/reciterData';
 import {SheetManager} from 'react-native-actions-sheet';
-import {Ionicons} from '@expo/vector-icons';
-
-type ReciterListItem =
-  | Reciter
-  | {
-      id: string;
-      name: string;
-      type: 'add';
-    };
-
-function calculateColumns(width: number) {
-  const screenMargin = moderateScale(20) * 2; // Left and right screen margins
-  const itemMinWidth = moderateScale(75); // Minimum width we want for each item
-  const gapWidth = moderateScale(8); // Gap between items
-
-  const availableWidth = width - screenMargin;
-  const maxColumns = Math.floor(
-    (availableWidth + gapWidth) / (itemMinWidth + gapWidth),
-  );
-
-  return Math.max(3, Math.min(maxColumns, 5)); // Minimum 3, maximum 5 columns
-}
-
-function calculateItemWidth(width: number, columns: number) {
-  const screenMargin = moderateScale(20) * 2; // Left and right screen margins
-  const gapWidth = moderateScale(8); // Gap between items
-  const totalGapWidth = gapWidth * (columns - 1);
-
-  const availableWidth = width - screenMargin - totalGapWidth;
-  return availableWidth / columns;
-}
+import Color from 'color';
 
 export default function FavoriteRecitersScreen() {
   const {theme} = useTheme();
-  const styles = createStyles(theme);
   const insets = useSafeAreaInsets();
-  const {favoriteReciters} = useFavoriteReciters();
+  const {favoriteReciters, removeFavorite} = useFavoriteReciters();
   const router = useRouter();
-  const {width} = useWindowDimensions();
-  const columns = calculateColumns(width);
-  const itemWidth = calculateItemWidth(width, columns);
-  const scrollY = useRef(new Animated.Value(0)).current as Animated.Value;
-  const [isHeaderVisible, setIsHeaderVisible] = useState(false);
-  const [isStatusBarDark, setIsStatusBarDark] = useState(false);
+
+  const scrollY = useRef(new RNAnimated.Value(0)).current;
   const [showSearch, setShowSearch] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
-  const scrollViewRef = useRef<ScrollView>(null);
-  const [isSearchFocused, setIsSearchFocused] = useState(false);
 
-  const headerOpacity = scrollY.interpolate({
-    inputRange: [150, 200],
-    outputRange: [0, 1],
-    extrapolate: 'clamp',
-  });
+  const filteredReciters = useMemo(
+    () =>
+      favoriteReciters.filter(reciter =>
+        reciter.name.toLowerCase().includes(searchQuery.toLowerCase()),
+      ),
+    [favoriteReciters, searchQuery],
+  );
 
-  useEffect(() => {
-    const listener = headerOpacity.addListener(({value}) => {
-      if (value === 1 && !isHeaderVisible) {
-        setIsHeaderVisible(true);
-      } else if (value < 1 && isHeaderVisible) {
-        setIsHeaderVisible(false);
-      }
-    });
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: theme.colors.background,
+        },
+        headerContainer: {
+          width: '100%',
+          overflow: 'hidden',
+        },
+        contentArea: {
+          width: '100%',
+          alignItems: 'center',
+          paddingTop: insets.top + moderateScale(40),
+          paddingBottom: moderateScale(30),
+          overflow: 'hidden',
+          backgroundColor: theme.colors.background,
+        },
+        contentCenter: {
+          alignItems: 'center',
+          paddingHorizontal: moderateScale(20),
+        },
+        heroIconContainer: {
+          width: moderateScale(64),
+          height: moderateScale(64),
+          borderRadius: moderateScale(32),
+          justifyContent: 'center',
+          alignItems: 'center',
+          marginBottom: moderateScale(12),
+          backgroundColor: Color(theme.colors.textSecondary)
+            .alpha(0.1)
+            .toString(),
+        },
+        heroIconInner: {
+          width: moderateScale(56),
+          height: moderateScale(56),
+          borderRadius: moderateScale(28),
+          justifyContent: 'center',
+          alignItems: 'center',
+          backgroundColor: Color(theme.colors.textSecondary)
+            .alpha(0.08)
+            .toString(),
+        },
+        title: {
+          fontSize: moderateScale(17),
+          fontFamily: theme.fonts.bold,
+          color: theme.colors.text,
+          textAlign: 'center',
+          marginBottom: moderateScale(8),
+          letterSpacing: -0.3,
+        },
+        subtitle: {
+          fontSize: moderateScale(12),
+          color: theme.colors.text,
+          fontFamily: theme.fonts.regular,
+          textAlign: 'center',
+          marginBottom: moderateScale(8),
+        },
+        addBar: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingVertical: moderateScale(12),
+          marginHorizontal: moderateScale(16),
+          marginTop: moderateScale(8),
+          marginBottom: moderateScale(8),
+          borderRadius: moderateScale(12),
+          backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+          gap: moderateScale(8),
+        },
+        addBarText: {
+          fontSize: moderateScale(13),
+          fontFamily: 'Manrope-SemiBold',
+          color: theme.colors.textSecondary,
+        },
+        searchBarContainer: {
+          paddingHorizontal: moderateScale(16),
+          marginBottom: moderateScale(12),
+        },
+        listContentContainer: {
+          flexGrow: 1,
+          paddingBottom: moderateScale(65),
+        },
+        fixedBackButton: {
+          position: 'absolute',
+          top: insets.top + moderateScale(10),
+          left: moderateScale(15),
+          zIndex: 5,
+          padding: moderateScale(8),
+        },
+        fixedSearchToggle: {
+          position: 'absolute',
+          top: insets.top + moderateScale(10),
+          right: moderateScale(15),
+          zIndex: 5,
+          padding: moderateScale(8),
+        },
+        emptyHeader: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingBottom: moderateScale(12),
+          paddingHorizontal: moderateScale(16),
+        },
+        emptyHeaderBack: {
+          width: moderateScale(36),
+          height: moderateScale(36),
+          justifyContent: 'center',
+          alignItems: 'center',
+        },
+        emptyHeaderTitle: {
+          flex: 1,
+          fontSize: moderateScale(17),
+          fontFamily: theme.fonts.bold,
+          color: theme.colors.text,
+          textAlign: 'center',
+        },
+        emptyContent: {
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingHorizontal: moderateScale(32),
+          paddingBottom: moderateScale(60),
+        },
+        emptyIcon: {
+          marginBottom: moderateScale(16),
+        },
+        emptyTitle: {
+          fontSize: moderateScale(17),
+          fontFamily: theme.fonts.bold,
+          color: theme.colors.text,
+          textAlign: 'center',
+          marginBottom: moderateScale(8),
+        },
+        emptySubtitle: {
+          fontSize: moderateScale(13),
+          fontFamily: theme.fonts.regular,
+          color: theme.colors.textSecondary,
+          textAlign: 'center',
+          marginBottom: moderateScale(20),
+        },
+        emptyActionBar: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingVertical: moderateScale(12),
+          paddingHorizontal: moderateScale(32),
+          borderRadius: moderateScale(12),
+          backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+          gap: moderateScale(8),
+        },
+        emptyActionText: {
+          fontSize: moderateScale(13),
+          fontFamily: 'Manrope-SemiBold',
+          color: theme.colors.textSecondary,
+        },
+      }),
+    [theme, insets.top],
+  );
 
-    return () => headerOpacity.removeListener(listener);
-  }, [headerOpacity, isHeaderVisible]);
-
-  const handleReciterPress = (reciterId: string) => {
-    router.push(`/reciter/${reciterId}`);
-  };
-
-  const filteredReciters = favoriteReciters.filter(reciter =>
-    reciter.name.toLowerCase().includes(searchQuery.toLowerCase()),
+  const handleReciterPress = useCallback(
+    (reciterId: string) => {
+      router.push(`/reciter/${reciterId}`);
+    },
+    [router],
   );
 
   const handleOpenSelectReciters = useCallback(() => {
     SheetManager.show('favorite-reciters');
   }, []);
 
-  return (
-    <View style={styles.container}>
-      <StatusBar style={isStatusBarDark ? 'dark' : 'light'} />
-      <ScrollView
-        ref={scrollViewRef}
-        bounces={false}
-        showsVerticalScrollIndicator={false}
-        onScroll={Animated.event(
-          [{nativeEvent: {contentOffset: {y: scrollY}}}],
-          {
-            useNativeDriver: false,
-            listener: (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-              const offsetY = event.nativeEvent.contentOffset.y;
-              setIsStatusBarDark(offsetY > 100);
-            },
-          },
-        )}
-        scrollEventThrottle={16}>
-        <LinearGradient
-          colors={
-            [theme.colors.primary, theme.colors.background] as [string, string]
-          }
-          style={[
-            styles.gradientContainer,
+  const handleReciterOptions = useCallback(
+    (reciter: Reciter) => {
+      SheetManager.show('collection-options', {
+        payload: {
+          title: reciter.name,
+          subtitle: reciter.rewayat[0]?.name || '',
+          options: [
             {
-              paddingTop: insets.top + moderateScale(20),
-              backgroundColor: theme.colors.primary,
+              label: 'Remove from Favorites',
+              icon: 'user-minus',
+              destructive: true,
+              onPress: () => removeFavorite(reciter.id),
             },
-          ]}>
-          <CollectionCard
-            icon={
-              <Ionicons
-                name="star"
-                size={moderateScale(80)}
-                color={theme.colors.text}
-              />
-            }
-            title="Favorite Reciters"
-            subtitle={`${favoriteReciters.length} reciters`}
-          />
-        </LinearGradient>
-        <View style={styles.contentContainer}>
-          {showSearch && (
-            <View style={styles.searchBarContainer}>
-              <SearchBar
-                placeholder="Search favorite reciters"
-                value={searchQuery}
-                onChangeText={setSearchQuery}
-                onFocus={() => setIsSearchFocused(true)}
-                onBlur={() => setIsSearchFocused(false)}
-              />
-            </View>
-          )}
-          <Animated.FlatList
-            data={
-              [
-                ...(!isSearchFocused
-                  ? [
-                      {
-                        id: 'add-button',
-                        name: 'Add reciters',
-                        type: 'add' as const,
-                      },
-                    ]
-                  : []),
-                ...filteredReciters,
-              ] as ReciterListItem[]
-            }
-            showsVerticalScrollIndicator={false}
-            renderItem={({item}: {item: ReciterListItem}) => (
-              <View
-                style={{
-                  width: itemWidth,
-                  marginBottom: moderateScale(8),
-                  alignItems: 'center',
-                }}>
-                <CircularReciterCard
-                  imageUrl={
-                    'image_url' in item
-                      ? item.image_url || undefined
-                      : undefined
-                  }
-                  name={item.name}
-                  onPress={() =>
-                    'type' in item && item.type === 'add'
-                      ? handleOpenSelectReciters()
-                      : handleReciterPress(item.id)
-                  }
-                  width={itemWidth * 0.85}
-                  variant={
-                    'type' in item && item.type === 'add' ? 'add' : 'default'
-                  }
-                />
-              </View>
-            )}
-            keyExtractor={item => item.id}
-            numColumns={columns}
-            contentContainerStyle={[styles.gridContainer, {paddingBottom: 65}]}
-            columnWrapperStyle={{
-              gap: moderateScale(8),
-              flex: 1,
-              justifyContent: 'flex-start',
-            }}
-            ListEmptyComponent={
-              <Text style={styles.emptyText}>No favorite reciters yet</Text>
-            }
-            scrollEnabled={false}
-          />
-        </View>
-      </ScrollView>
-      <Animated.View
-        style={[
-          styles.stickyHeader,
-          {
-            opacity: headerOpacity,
-            paddingTop: insets.top,
-          },
-        ]}>
-        <LinearGradient
-          colors={
-            [theme.colors.primary, theme.colors.background] as [string, string]
-          }
-          style={StyleSheet.absoluteFill}
-        />
-        <Text style={styles.stickyHeaderTitle}>Favorite Reciters</Text>
-      </Animated.View>
-      <Animated.View
-        style={[
-          styles.backButton,
-          {
-            top: insets.top,
-            left: moderateScale(20),
-          },
-        ]}>
-        <TouchableOpacity activeOpacity={0.99} onPress={() => router.back()}>
-          <Animated.View
-            style={{
-              opacity: headerOpacity.interpolate({
-                inputRange: [0, 1],
-                outputRange: [1, 0],
-              }),
-            }}>
-            <Feather name="arrow-left" size={moderateScale(24)} color="white" />
-          </Animated.View>
-          <Animated.View
-            style={{
-              position: 'absolute',
-              opacity: headerOpacity,
-            }}>
+          ],
+        },
+      });
+    },
+    [removeFavorite],
+  );
+
+  const renderItem = useCallback(
+    ({item}: {item: Reciter}) => (
+      <ReciterItem
+        item={item}
+        onPress={reciter => handleReciterPress(reciter.id)}
+        onOptionsPress={handleReciterOptions}
+        onLongPress={handleReciterOptions}
+      />
+    ),
+    [handleReciterPress, handleReciterOptions],
+  );
+
+  if (favoriteReciters.length === 0) {
+    return (
+      <View style={styles.container}>
+        <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
+          <Pressable
+            style={styles.emptyHeaderBack}
+            onPress={() => router.back()}
+            hitSlop={8}>
             <Feather
               name="arrow-left"
-              size={moderateScale(24)}
+              size={moderateScale(22)}
               color={theme.colors.text}
             />
-          </Animated.View>
-        </TouchableOpacity>
-      </Animated.View>
-      <Animated.View
+          </Pressable>
+          <Text style={styles.emptyHeaderTitle}>Favorite Reciters</Text>
+          <View style={styles.emptyHeaderBack} />
+        </View>
+        <View style={styles.emptyContent}>
+          <View style={styles.emptyIcon}>
+            <ProfileIcon
+              color={theme.colors.textSecondary}
+              size={moderateScale(48)}
+              filled={true}
+            />
+          </View>
+          <Text style={styles.emptyTitle}>No favorite reciters yet</Text>
+          <Text style={styles.emptySubtitle}>
+            Add reciters to see them here
+          </Text>
+          <Pressable
+            style={styles.emptyActionBar}
+            onPress={handleOpenSelectReciters}>
+            <Feather
+              name="plus"
+              size={moderateScale(16)}
+              color={theme.colors.textSecondary}
+            />
+            <Text style={styles.emptyActionText}>Add Reciters</Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
+
+  const ListHeaderComponent = () => {
+    return (
+      <View style={styles.headerContainer}>
+        <View style={styles.contentArea}>
+          <View style={styles.contentCenter}>
+            <View style={styles.heroIconContainer}>
+              <View style={styles.heroIconInner}>
+                <ProfileIcon
+                  color={theme.colors.text}
+                  size={moderateScale(30)}
+                  filled={true}
+                />
+              </View>
+            </View>
+            <Text style={styles.title}>Favorite Reciters</Text>
+            <Text style={styles.subtitle}>
+              {favoriteReciters.length}{' '}
+              {favoriteReciters.length === 1 ? 'reciter' : 'reciters'}
+            </Text>
+          </View>
+        </View>
+
+        <Pressable style={styles.addBar} onPress={handleOpenSelectReciters}>
+          <Feather
+            name="plus"
+            size={moderateScale(16)}
+            color={theme.colors.textSecondary}
+          />
+          <Text style={styles.addBarText}>Add Reciters</Text>
+        </Pressable>
+
+        {showSearch && (
+          <View style={styles.searchBarContainer}>
+            <SearchBar
+              placeholder="Search favorite reciters"
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+            />
+          </View>
+        )}
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <RNAnimated.View
         style={[
-          styles.searchButton,
+          styles.fixedBackButton,
           {
-            top: insets.top,
-            right: moderateScale(20),
+            opacity: scrollY.interpolate({
+              inputRange: [80, 120],
+              outputRange: [1, 0],
+              extrapolate: 'clamp',
+            }),
           },
         ]}>
-        <TouchableOpacity
-          activeOpacity={0.99}
+        <Pressable onPress={() => router.back()} hitSlop={8}>
+          <Feather
+            name="arrow-left"
+            size={moderateScale(24)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+      </RNAnimated.View>
+
+      <RNAnimated.View
+        style={[
+          styles.fixedSearchToggle,
+          {
+            opacity: scrollY.interpolate({
+              inputRange: [80, 120],
+              outputRange: [1, 0],
+              extrapolate: 'clamp',
+            }),
+          },
+        ]}>
+        <Pressable
           onPress={() => {
-            setShowSearch(!showSearch);
-            if (!showSearch) {
-              scrollViewRef.current?.scrollTo({y: 0, animated: true});
-            }
-          }}>
-          <Animated.View
-            style={{
-              opacity: headerOpacity.interpolate({
-                inputRange: [0, 1],
-                outputRange: [1, 0],
-              }),
-            }}>
-            <Feather name="search" size={moderateScale(20)} color="white" />
-          </Animated.View>
-          <Animated.View
-            style={{
-              position: 'absolute',
-              opacity: headerOpacity,
-            }}>
-            <Feather
-              name="search"
-              size={moderateScale(20)}
-              color={theme.colors.text}
-            />
-          </Animated.View>
-        </TouchableOpacity>
-      </Animated.View>
+            setShowSearch(prev => !prev);
+            if (showSearch) setSearchQuery('');
+          }}
+          hitSlop={8}>
+          <Feather
+            name="search"
+            size={moderateScale(20)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+      </RNAnimated.View>
+
+      <RNAnimated.FlatList
+        data={filteredReciters}
+        renderItem={renderItem}
+        keyExtractor={item => item.id}
+        ListHeaderComponent={ListHeaderComponent}
+        contentContainerStyle={styles.listContentContainer}
+        onScroll={RNAnimated.event(
+          [{nativeEvent: {contentOffset: {y: scrollY}}}],
+          {useNativeDriver: true},
+        )}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator={false}
+      />
+      <CollectionStickyHeader title="Favorite Reciters" scrollY={scrollY} />
     </View>
   );
 }

--- a/app/(tabs)/(c.collection)/collection/loved.tsx
+++ b/app/(tabs)/(c.collection)/collection/loved.tsx
@@ -2,15 +2,19 @@ import React, {useState, useEffect, useCallback, useRef} from 'react';
 import {
   View,
   Text,
+  Pressable,
   StyleSheet,
   Alert,
   StatusBar,
   Animated as RNAnimated,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {useRouter} from 'expo-router';
 import {TrackItem} from '@/components/TrackItem';
 import {getReciterById, getSurahById} from '@/services/dataService';
 import {moderateScale} from 'react-native-size-matters';
+import {Feather} from '@expo/vector-icons';
 import {ListRenderItem} from 'react-native';
 import {Reciter} from '@/data/reciterData';
 import {Surah} from '@/data/surahData';
@@ -20,8 +24,11 @@ import {useRecentlyPlayedStore} from '@/services/player/store/recentlyPlayedStor
 import {shuffleArray} from '@/utils/arrayUtils';
 import {generateSmartAudioUrl} from '@/utils/audioUtils';
 import {getReciterArtwork} from '@/utils/artworkUtils';
+import {useUploadsStore} from '@/store/uploadsStore';
+import {createUserUploadTrack} from '@/utils/track';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {LovedHeader} from '@/components/playlist-detail/LovedHeader';
+import {HeartIcon, CheckIcon} from '@/components/Icons';
 import {
   useDownloadActions,
   useDownloadQueries,
@@ -35,6 +42,7 @@ interface LovedTrack {
   reciterId: string;
   surahId: string;
   rewayatId?: string;
+  userRecitationId?: string;
 }
 
 interface LovedTrackData {
@@ -45,7 +53,9 @@ interface LovedTrackData {
 
 const LovedScreen = () => {
   const {theme} = useTheme();
-  const {lovedTracks, toggleLoved} = useLoved();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const {lovedTracks, toggleLoved, unloveAll} = useLoved();
   const {pause, addToQueue, updateQueue, play, toggleShuffle} =
     usePlayerActions();
   const playbackState = usePlayerStore(state => state.playback.state);
@@ -78,14 +88,64 @@ const LovedScreen = () => {
       flexGrow: 1,
       paddingBottom: moderateScale(65),
     },
-    emptyText: {
-      fontSize: moderateScale(16),
-      color: theme.colors.text,
-      textAlign: 'center',
-      marginTop: moderateScale(32),
-    },
     listItem: {
       marginVertical: moderateScale(2),
+    },
+    fixedBackButton: {
+      position: 'absolute',
+      top: insets.top + moderateScale(10),
+      left: moderateScale(15),
+      zIndex: 5,
+      padding: moderateScale(8),
+    },
+    emptyHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingBottom: moderateScale(12),
+      paddingHorizontal: moderateScale(16),
+    },
+    emptyHeaderBack: {
+      width: moderateScale(36),
+      height: moderateScale(36),
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    emptyHeaderTitle: {
+      flex: 1,
+      fontSize: moderateScale(17),
+      fontFamily: theme.fonts.bold,
+      color: theme.colors.text,
+      textAlign: 'center',
+    },
+    emptyContent: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: moderateScale(32),
+      paddingBottom: moderateScale(60),
+    },
+    emptyIcon: {
+      marginBottom: moderateScale(16),
+    },
+    emptyTitle: {
+      fontSize: moderateScale(17),
+      fontFamily: theme.fonts.bold,
+      color: theme.colors.text,
+      textAlign: 'center',
+      marginBottom: moderateScale(8),
+    },
+    emptySubtitle: {
+      fontSize: moderateScale(13),
+      fontFamily: theme.fonts.regular,
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
+      marginBottom: moderateScale(20),
+    },
+    loadingText: {
+      fontSize: moderateScale(16),
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
     },
   });
 
@@ -109,6 +169,7 @@ const LovedScreen = () => {
               reciterId: track.reciterId,
               surahId: track.surahId,
               rewayatId: track.rewayatId,
+              userRecitationId: track.userRecitationId,
             },
             reciter: reciter || null,
             surah: surah || null,
@@ -171,6 +232,13 @@ const LovedScreen = () => {
         const allTracks = reorderedItems
           .filter(item => item.reciter && item.surah)
           .map(item => {
+            if (item.track.userRecitationId) {
+              const upload = useUploadsStore
+                .getState()
+                .recitations.find(r => r.id === item.track.userRecitationId);
+              if (upload) return createUserUploadTrack(upload);
+              return null;
+            }
             const itemRewayatId =
               item.track.rewayatId || item.reciter!.rewayat[0]?.id;
             return {
@@ -188,7 +256,8 @@ const LovedScreen = () => {
               reciterName: item.reciter!.name,
               rewayatId: itemRewayatId,
             };
-          });
+          })
+          .filter((t): t is NonNullable<typeof t> => t !== null);
 
         if (allTracks.length === 0) return;
 
@@ -216,6 +285,13 @@ const LovedScreen = () => {
       const allTracks = lovedData
         .filter(item => item.reciter && item.surah)
         .map(item => {
+          if (item.track.userRecitationId) {
+            const upload = useUploadsStore
+              .getState()
+              .recitations.find(r => r.id === item.track.userRecitationId);
+            if (upload) return createUserUploadTrack(upload);
+            return null;
+          }
           const itemRewayatId =
             item.track.rewayatId || item.reciter!.rewayat[0]?.id;
           return {
@@ -233,7 +309,8 @@ const LovedScreen = () => {
             reciterName: item.reciter!.name,
             rewayatId: itemRewayatId,
           };
-        });
+        })
+        .filter((t): t is NonNullable<typeof t> => t !== null);
 
       if (allTracks.length === 0) return;
 
@@ -266,25 +343,34 @@ const LovedScreen = () => {
         toggleShuffle();
       }
 
-      const allTracks = shuffledItems.map(item => {
-        const itemRewayatId =
-          item.track.rewayatId || item.reciter!.rewayat[0]?.id;
-        return {
-          id: `${item.reciter!.id}:${item.surah!.id}`,
-          url: generateSmartAudioUrl(
-            item.reciter!,
-            item.surah!.id.toString(),
-            itemRewayatId,
-          ),
-          title: item.surah!.name,
-          artist: item.reciter!.name,
-          reciterId: item.reciter!.id,
-          artwork: getReciterArtwork(item.reciter!),
-          surahId: item.surah!.id.toString(),
-          reciterName: item.reciter!.name,
-          rewayatId: itemRewayatId,
-        };
-      });
+      const allTracks = shuffledItems
+        .map(item => {
+          if (item.track.userRecitationId) {
+            const upload = useUploadsStore
+              .getState()
+              .recitations.find(r => r.id === item.track.userRecitationId);
+            if (upload) return createUserUploadTrack(upload);
+            return null;
+          }
+          const itemRewayatId =
+            item.track.rewayatId || item.reciter!.rewayat[0]?.id;
+          return {
+            id: `${item.reciter!.id}:${item.surah!.id}`,
+            url: generateSmartAudioUrl(
+              item.reciter!,
+              item.surah!.id.toString(),
+              itemRewayatId,
+            ),
+            title: item.surah!.name,
+            artist: item.reciter!.name,
+            reciterId: item.reciter!.id,
+            artwork: getReciterArtwork(item.reciter!),
+            surahId: item.surah!.id.toString(),
+            reciterName: item.reciter!.name,
+            rewayatId: itemRewayatId,
+          };
+        })
+        .filter((t): t is NonNullable<typeof t> => t !== null);
 
       await updateQueue(allTracks, 0);
 
@@ -426,6 +512,54 @@ const LovedScreen = () => {
     setDownloadProgress,
   ]);
 
+  // Calculate download state for all loved tracks using custom hook
+  const downloadState = useCollectionDownloadState(lovedData);
+
+  // Handle options menu
+  const handleOptionsMenu = useCallback(() => {
+    SheetManager.show('collection-options', {
+      payload: {
+        title: 'Loved',
+        subtitle: `${lovedData.length} ${
+          lovedData.length === 1 ? 'surah' : 'surahs'
+        }`,
+        options: [
+          {
+            label: downloadState.allDownloaded
+              ? 'All Downloaded'
+              : 'Download All',
+            icon: 'download',
+            onPress: handleBulkDownload,
+            disabled: downloadState.allDownloaded || downloadState.hasNoTracks,
+            customIcon:
+              downloadState.allDownloaded && !downloadState.hasNoTracks ? (
+                <CheckIcon color={theme.colors.text} size={moderateScale(20)} />
+              ) : undefined,
+          },
+          {
+            label: 'Unlove All Surahs',
+            icon: 'heart',
+            destructive: true,
+            customIcon: (
+              <HeartIcon
+                color="#ff4444"
+                size={moderateScale(20)}
+                filled={true}
+              />
+            ),
+            onPress: () => unloveAll(),
+          },
+        ],
+      },
+    });
+  }, [
+    lovedData.length,
+    downloadState,
+    handleBulkDownload,
+    unloveAll,
+    theme.colors.text,
+  ]);
+
   // Handle show options for a track
   const handleShowOptions = useCallback(
     (track: LovedTrack, reciter: Reciter, surah: Surah) => {
@@ -435,6 +569,15 @@ const LovedScreen = () => {
           reciterId: track.reciterId,
           rewayatId: track.rewayatId,
           onAddToQueue: async (s: Surah) => {
+            if (track.userRecitationId) {
+              const upload = useUploadsStore
+                .getState()
+                .recitations.find(r => r.id === track.userRecitationId);
+              if (upload) {
+                await addToQueue([createUserUploadTrack(upload)]);
+                return;
+              }
+            }
             const rewayatId = track.rewayatId || reciter.rewayat[0]?.id;
             const artwork = getReciterArtwork(reciter);
             const queueTrack = {
@@ -456,32 +599,25 @@ const LovedScreen = () => {
     [addToQueue],
   );
 
-  // Calculate download state for all loved tracks using custom hook
-  const downloadState = useCollectionDownloadState(lovedData);
-
   const ListHeaderComponent = useCallback(() => {
     return (
       <LovedHeader
-        title="Loved Surahs"
+        title="Loved"
         subtitle={`${lovedData.length} ${
           lovedData.length === 1 ? 'surah' : 'surahs'
         }`}
         onPlayPress={handlePlayAll}
         onShufflePress={handleShuffle}
-        onDownloadPress={handleBulkDownload}
+        onOptionsPress={handleOptionsMenu}
         theme={theme}
-        allDownloaded={downloadState.allDownloaded}
-        hasNoTracks={downloadState.hasNoTracks}
       />
     );
   }, [
     lovedData.length,
     handlePlayAll,
     handleShuffle,
-    handleBulkDownload,
+    handleOptionsMenu,
     theme,
-    downloadState.allDownloaded,
-    downloadState.hasNoTracks,
   ]);
 
   const renderItem: ListRenderItem<LovedTrackData> = ({item}) => {
@@ -497,9 +633,11 @@ const LovedScreen = () => {
           reciterId={track.reciterId}
           surahId={track.surahId}
           rewayatId={track.rewayatId}
+          userRecitationId={track.userRecitationId}
           onPress={() => handleSurahPress(track, reciter, surah)}
           onPlayPress={() => handleSurahPress(track, reciter, surah)}
           onOptionsPress={() => handleShowOptions(track, reciter, surah)}
+          onLongPress={() => handleShowOptions(track, reciter, surah)}
         />
       </View>
     );
@@ -513,7 +651,55 @@ const LovedScreen = () => {
   if (loading) {
     return (
       <View style={styles.container}>
-        <Text style={styles.emptyText}>Loading...</Text>
+        <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
+          <Pressable
+            style={styles.emptyHeaderBack}
+            onPress={() => router.back()}
+            hitSlop={8}>
+            <Feather
+              name="arrow-left"
+              size={moderateScale(22)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+          <Text style={styles.emptyHeaderTitle}>Loved</Text>
+          <View style={styles.emptyHeaderBack} />
+        </View>
+        <View style={styles.emptyContent}>
+          <Text style={styles.loadingText}>Loading...</Text>
+        </View>
+      </View>
+    );
+  }
+
+  if (lovedData.length === 0) {
+    return (
+      <View style={styles.container}>
+        <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
+          <Pressable
+            style={styles.emptyHeaderBack}
+            onPress={() => router.back()}
+            hitSlop={8}>
+            <Feather
+              name="arrow-left"
+              size={moderateScale(22)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+          <Text style={styles.emptyHeaderTitle}>Loved</Text>
+          <View style={styles.emptyHeaderBack} />
+        </View>
+        <View style={styles.emptyContent}>
+          <View style={styles.emptyIcon}>
+            <HeartIcon
+              color={theme.colors.textSecondary}
+              size={moderateScale(48)}
+              filled={true}
+            />
+          </View>
+          <Text style={styles.emptyTitle}>No loved surahs yet</Text>
+          <Text style={styles.emptySubtitle}>Love surahs to see them here</Text>
+        </View>
       </View>
     );
   }
@@ -521,15 +707,33 @@ const LovedScreen = () => {
   return (
     <View style={styles.container}>
       <StatusBar barStyle="default" />
+
+      <RNAnimated.View
+        style={[
+          styles.fixedBackButton,
+          {
+            opacity: scrollY.interpolate({
+              inputRange: [80, 120],
+              outputRange: [1, 0],
+              extrapolate: 'clamp',
+            }),
+          },
+        ]}>
+        <Pressable onPress={() => router.back()} hitSlop={8}>
+          <Feather
+            name="arrow-left"
+            size={moderateScale(24)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+      </RNAnimated.View>
+
       <RNAnimated.FlatList
         data={lovedData}
         renderItem={renderItem}
         keyExtractor={getItemKey}
         ListHeaderComponent={ListHeaderComponent}
         contentContainerStyle={styles.listContentContainer}
-        ListEmptyComponent={
-          <Text style={styles.emptyText}>No loved surahs yet</Text>
-        }
         onScroll={RNAnimated.event(
           [{nativeEvent: {contentOffset: {y: scrollY}}}],
           {useNativeDriver: true},
@@ -537,7 +741,7 @@ const LovedScreen = () => {
         scrollEventThrottle={16}
         showsVerticalScrollIndicator={false}
       />
-      <CollectionStickyHeader title="Loved Surahs" scrollY={scrollY} />
+      <CollectionStickyHeader title="Loved" scrollY={scrollY} />
     </View>
   );
 };

--- a/app/(tabs)/(c.collection)/collection/playlists.tsx
+++ b/app/(tabs)/(c.collection)/collection/playlists.tsx
@@ -1,66 +1,360 @@
-import React from 'react';
-import {View, Text, FlatList, TouchableOpacity} from 'react-native';
+import React, {useRef, useCallback, useMemo} from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  Animated as RNAnimated,
+} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
-import {createStyles} from './_styles';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {PlaylistCard} from '@/components/cards/PlaylistCard';
+import {PlaylistItem} from '@/components/PlaylistItem';
 import {useRouter} from 'expo-router';
-import {Ionicons} from '@expo/vector-icons';
+import {Feather} from '@expo/vector-icons';
 import {moderateScale} from 'react-native-size-matters';
 import {usePlaylists} from '@/hooks/usePlaylists';
+import {PlaylistIcon} from '@/components/Icons';
+import {CollectionStickyHeader} from '@/components/collection/CollectionStickyHeader';
+import {SheetManager} from 'react-native-actions-sheet';
+import Color from 'color';
 
 export default function PlaylistsScreen() {
   const {theme} = useTheme();
-  const styles = createStyles(theme);
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const {playlists} = usePlaylists();
+  const {playlists, deletePlaylist, updatePlaylist} = usePlaylists();
 
-  const handlePlaylistPress = (playlistId: string) => {
-    router.push(`/playlist/${playlistId}`);
-  };
+  const scrollY = useRef(new RNAnimated.Value(0)).current;
 
-  const renderItem = ({item}: {item: (typeof playlists)[0]}) => (
-    <PlaylistCard
-      name={item.name}
-      itemCount={item.itemCount}
-      color={item.color}
-      onPress={() => handlePlaylistPress(item.id)}
-    />
+  const existingColors = useMemo(
+    () => playlists.map(p => p.color),
+    [playlists],
   );
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: theme.colors.background,
+        },
+        headerContainer: {
+          width: '100%',
+          overflow: 'hidden',
+        },
+        contentArea: {
+          width: '100%',
+          alignItems: 'center',
+          paddingTop: insets.top + moderateScale(40),
+          paddingBottom: moderateScale(30),
+          overflow: 'hidden',
+          backgroundColor: theme.colors.background,
+        },
+        contentCenter: {
+          alignItems: 'center',
+          paddingHorizontal: moderateScale(20),
+        },
+        heroIconContainer: {
+          width: moderateScale(64),
+          height: moderateScale(64),
+          borderRadius: moderateScale(32),
+          justifyContent: 'center',
+          alignItems: 'center',
+          marginBottom: moderateScale(12),
+          backgroundColor: Color(theme.colors.textSecondary)
+            .alpha(0.1)
+            .toString(),
+        },
+        heroIconInner: {
+          width: moderateScale(56),
+          height: moderateScale(56),
+          borderRadius: moderateScale(28),
+          justifyContent: 'center',
+          alignItems: 'center',
+          backgroundColor: Color(theme.colors.textSecondary)
+            .alpha(0.08)
+            .toString(),
+        },
+        title: {
+          fontSize: moderateScale(17),
+          fontFamily: theme.fonts.bold,
+          color: theme.colors.text,
+          textAlign: 'center',
+          marginBottom: moderateScale(8),
+          letterSpacing: -0.3,
+        },
+        subtitle: {
+          fontSize: moderateScale(12),
+          color: theme.colors.text,
+          fontFamily: theme.fonts.regular,
+          textAlign: 'center',
+          marginBottom: moderateScale(8),
+        },
+        createBar: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingVertical: moderateScale(12),
+          marginHorizontal: moderateScale(16),
+          marginTop: moderateScale(8),
+          marginBottom: moderateScale(8),
+          borderRadius: moderateScale(12),
+          backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+          gap: moderateScale(8),
+        },
+        createBarText: {
+          fontSize: moderateScale(13),
+          fontFamily: 'Manrope-SemiBold',
+          color: theme.colors.textSecondary,
+        },
+        listContentContainer: {
+          flexGrow: 1,
+          paddingBottom: moderateScale(65),
+        },
+        fixedBackButton: {
+          position: 'absolute',
+          top: insets.top + moderateScale(10),
+          left: moderateScale(15),
+          zIndex: 5,
+          padding: moderateScale(8),
+        },
+        emptyHeader: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingBottom: moderateScale(12),
+          paddingHorizontal: moderateScale(16),
+        },
+        emptyHeaderBack: {
+          width: moderateScale(36),
+          height: moderateScale(36),
+          justifyContent: 'center',
+          alignItems: 'center',
+        },
+        emptyHeaderTitle: {
+          flex: 1,
+          fontSize: moderateScale(17),
+          fontFamily: theme.fonts.bold,
+          color: theme.colors.text,
+          textAlign: 'center',
+        },
+        emptyContent: {
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingHorizontal: moderateScale(32),
+          paddingBottom: moderateScale(60),
+        },
+        emptyIcon: {
+          marginBottom: moderateScale(16),
+        },
+        emptyTitle: {
+          fontSize: moderateScale(17),
+          fontFamily: theme.fonts.bold,
+          color: theme.colors.text,
+          textAlign: 'center',
+          marginBottom: moderateScale(8),
+        },
+        emptySubtitle: {
+          fontSize: moderateScale(13),
+          fontFamily: theme.fonts.regular,
+          color: theme.colors.textSecondary,
+          textAlign: 'center',
+          marginBottom: moderateScale(20),
+        },
+        emptyActionBar: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingVertical: moderateScale(12),
+          paddingHorizontal: moderateScale(32),
+          borderRadius: moderateScale(12),
+          backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+          gap: moderateScale(8),
+        },
+        emptyActionText: {
+          fontSize: moderateScale(13),
+          fontFamily: 'Manrope-SemiBold',
+          color: theme.colors.textSecondary,
+        },
+      }),
+    [theme, insets.top],
+  );
+
+  const handlePlaylistPress = useCallback(
+    (playlistId: string) => {
+      router.push(`/playlist/${playlistId}`);
+    },
+    [router],
+  );
+
+  const handlePlaylistOptions = useCallback(
+    (item: (typeof playlists)[0]) => {
+      const handleEdit = async () => {
+        const result = await SheetManager.show('create-playlist', {
+          payload: {
+            existingColors,
+            isEditMode: true,
+            initialName: item.name,
+            initialColor: item.color || '#6366F1',
+          },
+        });
+        if (result?.name && result?.color) {
+          await updatePlaylist(item.id, {
+            name: result.name,
+            color: result.color,
+          });
+        }
+      };
+      const handleDelete = async () => {
+        await deletePlaylist(item.id);
+      };
+      SheetManager.show('playlist-context', {
+        payload: {
+          playlistId: item.id,
+          playlistName: item.name,
+          playlistColor: item.color,
+          onDelete: handleDelete,
+          onEdit: handleEdit,
+        },
+      });
+    },
+    [existingColors, updatePlaylist, deletePlaylist],
+  );
+
+  const handleCreatePlaylist = useCallback(() => {
+    SheetManager.show('create-playlist', {
+      payload: {existingColors},
+    });
+  }, [existingColors]);
+
+  const renderItem = useCallback(
+    ({item}: {item: (typeof playlists)[0]}) => (
+      <PlaylistItem
+        id={item.id}
+        name={item.name}
+        itemCount={item.itemCount}
+        color={item.color}
+        onPress={() => handlePlaylistPress(item.id)}
+        onLongPress={() => handlePlaylistOptions(item)}
+        onOptionsPress={() => handlePlaylistOptions(item)}
+      />
+    ),
+    [handlePlaylistPress, handlePlaylistOptions],
+  );
+
+  if (playlists.length === 0) {
+    return (
+      <View style={styles.container}>
+        <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
+          <Pressable
+            style={styles.emptyHeaderBack}
+            onPress={() => router.back()}
+            hitSlop={8}>
+            <Feather
+              name="arrow-left"
+              size={moderateScale(22)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+          <Text style={styles.emptyHeaderTitle}>Playlists</Text>
+          <View style={styles.emptyHeaderBack} />
+        </View>
+        <View style={styles.emptyContent}>
+          <View style={styles.emptyIcon}>
+            <PlaylistIcon
+              color={theme.colors.textSecondary}
+              size={moderateScale(48)}
+            />
+          </View>
+          <Text style={styles.emptyTitle}>No playlists yet</Text>
+          <Text style={styles.emptySubtitle}>
+            Create playlists to see them here
+          </Text>
+          <Pressable
+            style={styles.emptyActionBar}
+            onPress={handleCreatePlaylist}>
+            <Feather
+              name="plus"
+              size={moderateScale(16)}
+              color={theme.colors.textSecondary}
+            />
+            <Text style={styles.emptyActionText}>Create New Playlist</Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
+
+  const ListHeaderComponent = () => {
+    return (
+      <View style={styles.headerContainer}>
+        <View style={styles.contentArea}>
+          <View style={styles.contentCenter}>
+            <View style={styles.heroIconContainer}>
+              <View style={styles.heroIconInner}>
+                <PlaylistIcon
+                  color={theme.colors.text}
+                  size={moderateScale(30)}
+                />
+              </View>
+            </View>
+            <Text style={styles.title}>Playlists</Text>
+            <Text style={styles.subtitle}>
+              {playlists.length}{' '}
+              {playlists.length === 1 ? 'playlist' : 'playlists'}
+            </Text>
+          </View>
+        </View>
+
+        <Pressable style={styles.createBar} onPress={handleCreatePlaylist}>
+          <Feather
+            name="plus"
+            size={moderateScale(16)}
+            color={theme.colors.textSecondary}
+          />
+          <Text style={styles.createBarText}>Create New Playlist</Text>
+        </Pressable>
+      </View>
+    );
+  };
 
   return (
     <View style={styles.container}>
-      <View style={[styles.headerContainer, {paddingTop: insets.top}]}>
-        <View style={styles.header}>
-          <Text style={styles.headerTitle}>Playlists</Text>
-        </View>
-      </View>
-      <FlatList
+      <RNAnimated.View
+        style={[
+          styles.fixedBackButton,
+          {
+            opacity: scrollY.interpolate({
+              inputRange: [80, 120],
+              outputRange: [1, 0],
+              extrapolate: 'clamp',
+            }),
+          },
+        ]}>
+        <Pressable onPress={() => router.back()} hitSlop={8}>
+          <Feather
+            name="arrow-left"
+            size={moderateScale(24)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+      </RNAnimated.View>
+
+      <RNAnimated.FlatList
         data={playlists}
         renderItem={renderItem}
         keyExtractor={item => item.id}
-        numColumns={2}
-        contentContainerStyle={styles.gridContainer}
-        ListEmptyComponent={
-          <Text style={styles.emptyText}>No playlists yet</Text>
-        }
-        ListHeaderComponent={
-          <TouchableOpacity
-            activeOpacity={0.99}
-            style={styles.createPlaylistButton}
-            onPress={() => {
-              /* Handle create playlist */
-            }}>
-            <Ionicons
-              name="add"
-              size={moderateScale(24)}
-              color={theme.colors.primary}
-            />
-            <Text style={styles.createPlaylistText}>Create New Playlist</Text>
-          </TouchableOpacity>
-        }
+        ListHeaderComponent={ListHeaderComponent}
+        contentContainerStyle={styles.listContentContainer}
+        onScroll={RNAnimated.event(
+          [{nativeEvent: {contentOffset: {y: scrollY}}}],
+          {useNativeDriver: true},
+        )}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator={false}
       />
+      <CollectionStickyHeader title="Playlists" scrollY={scrollY} />
     </View>
   );
 }

--- a/app/(tabs)/(c.collection)/collection/uploads.tsx
+++ b/app/(tabs)/(c.collection)/collection/uploads.tsx
@@ -21,11 +21,6 @@ import {createUserUploadTrack} from '@/utils/track';
 import {getSurahById, getReciterName} from '@/services/dataService';
 import {shuffleArray} from '@/utils/arrayUtils';
 import Color from 'color';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from 'react-native-reanimated';
 import type {UploadedRecitation, RecordingType} from '@/types/uploads';
 import {CollectionStickyHeader} from '@/components/collection/CollectionStickyHeader';
 import {pickAndImportAudioFiles} from '@/utils/importAudio';
@@ -33,8 +28,6 @@ import {usePlayerStore} from '@/services/player/store/playerStore';
 import {NowPlayingIndicator} from '@/components/NowPlayingIndicator';
 import {GradientText} from '@/components/GradientText';
 import {ReciterImage} from '@/components/ReciterImage';
-
-const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 function stripExtension(filename: string): string {
   return filename.replace(/\.[^/.]+$/, '');
@@ -231,8 +224,14 @@ export default function UploadsScreen() {
   const {theme} = useTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const {recitations, totalCount, importFile, importFiles, loadRecitations} =
-    useUploadsStore();
+  const {
+    recitations,
+    totalCount,
+    importFile,
+    importFiles,
+    loadRecitations,
+    deleteAllRecitations,
+  } = useUploadsStore();
   const {updateQueue, addToQueue, play} = usePlayerActions();
 
   const [isImporting, setIsImporting] = useState(false);
@@ -244,32 +243,22 @@ export default function UploadsScreen() {
     loadRecitations();
   }, [loadRecitations]);
 
-  // Animated button scales
-  const shuffleScale = useSharedValue(1);
-  const playScale = useSharedValue(1);
-
-  const shuffleAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: shuffleScale.value}],
-  }));
-  const playAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: playScale.value}],
-  }));
-
-  const handlePressIn = useCallback(
-    (button: 'shuffle' | 'play') => {
-      const scale = button === 'shuffle' ? shuffleScale : playScale;
-      scale.value = withSpring(0.92, {damping: 15, stiffness: 300});
-    },
-    [shuffleScale, playScale],
-  );
-
-  const handlePressOut = useCallback(
-    (button: 'shuffle' | 'play') => {
-      const scale = button === 'shuffle' ? shuffleScale : playScale;
-      scale.value = withSpring(1, {damping: 15, stiffness: 300});
-    },
-    [shuffleScale, playScale],
-  );
+  const handleOptionsMenu = useCallback(() => {
+    SheetManager.show('collection-options', {
+      payload: {
+        title: 'Uploads',
+        subtitle: `${totalCount} recitation${totalCount !== 1 ? 's' : ''}`,
+        options: [
+          {
+            label: 'Remove All Uploads',
+            icon: 'trash-2',
+            destructive: true,
+            onPress: () => deleteAllRecitations(),
+          },
+        ],
+      },
+    });
+  }, [totalCount, deleteAllRecitations]);
 
   const handleOrganize = useCallback((item: UploadedRecitation) => {
     SheetManager.show('organize-recitation', {
@@ -362,7 +351,60 @@ export default function UploadsScreen() {
 
   const keyExtractor = useCallback((item: UploadedRecitation) => item.id, []);
 
-  const ListHeaderComponent = useCallback(() => {
+  if (!hasRecitations) {
+    return (
+      <View style={styles.container}>
+        <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
+          <Pressable
+            style={styles.emptyHeaderBack}
+            onPress={() => router.back()}
+            hitSlop={8}>
+            <Feather
+              name="arrow-left"
+              size={moderateScale(22)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+          <Text style={styles.emptyHeaderTitle}>Uploads</Text>
+          <View style={styles.emptyHeaderBack} />
+        </View>
+        <View style={styles.emptyContent}>
+          <View style={styles.emptyIcon}>
+            <MicrophoneIcon
+              color={theme.colors.textSecondary}
+              size={moderateScale(48)}
+            />
+          </View>
+          <Text style={styles.emptyTitle}>No uploads yet</Text>
+          <Text style={styles.emptySubtitle}>
+            Upload recitations to see them here
+          </Text>
+          <Pressable
+            style={styles.emptyActionBar}
+            onPress={handleImportFile}
+            disabled={isImporting}>
+            {isImporting ? (
+              <ActivityIndicator
+                size="small"
+                color={theme.colors.textSecondary}
+              />
+            ) : (
+              <Feather
+                name="plus"
+                size={moderateScale(16)}
+                color={theme.colors.textSecondary}
+              />
+            )}
+            <Text style={styles.emptyActionText}>
+              {isImporting ? 'Opening...' : 'Add Recitation'}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
+
+  const ListHeaderComponent = () => {
     return (
       <View style={styles.headerContainer}>
         <View
@@ -370,18 +412,6 @@ export default function UploadsScreen() {
             styles.contentArea,
             {paddingTop: insets.top + moderateScale(40)},
           ]}>
-          {/* Back Button */}
-          <Pressable
-            style={[styles.backButton, {top: insets.top + moderateScale(10)}]}
-            onPress={() => router.back()}
-            hitSlop={8}>
-            <Feather
-              name="arrow-left"
-              size={moderateScale(24)}
-              color={theme.colors.text}
-            />
-          </Pressable>
-
           {/* Hero Icon */}
           <View style={styles.contentCenter}>
             <View style={styles.heroIconContainer}>
@@ -400,54 +430,44 @@ export default function UploadsScreen() {
         </View>
 
         {/* Action Buttons */}
-        <View style={styles.contentWrapper}>
-          <View style={styles.actionButtons}>
-            <View />
-            {/* Right side buttons */}
-            <View style={styles.rightAlignedButtons}>
-              <AnimatedPressable
-                style={[
-                  styles.circleButton,
-                  shuffleAnimatedStyle,
-                  !hasRecitations && styles.disabledButton,
-                ]}
-                onPress={hasRecitations ? handleShuffle : undefined}
-                onPressIn={
-                  hasRecitations ? () => handlePressIn('shuffle') : undefined
-                }
-                onPressOut={
-                  hasRecitations ? () => handlePressOut('shuffle') : undefined
-                }
-                disabled={!hasRecitations}>
-                <ShuffleIcon
-                  color={theme.colors.text}
-                  size={moderateScale(20)}
-                />
-              </AnimatedPressable>
-              <AnimatedPressable
-                style={[
-                  styles.circleButton,
-                  styles.playButton,
-                  playAnimatedStyle,
-                  !hasRecitations && styles.disabledButton,
-                ]}
-                onPress={hasRecitations ? handlePlayAll : undefined}
-                onPressIn={
-                  hasRecitations ? () => handlePressIn('play') : undefined
-                }
-                onPressOut={
-                  hasRecitations ? () => handlePressOut('play') : undefined
-                }
-                disabled={!hasRecitations}>
-                <View style={styles.playIconContainer}>
-                  <PlayIcon
-                    color={theme.colors.background}
-                    size={moderateScale(16)}
-                  />
-                </View>
-              </AnimatedPressable>
+        <View style={styles.actionButtons}>
+          <Pressable
+            style={[
+              styles.circleButton,
+              !hasRecitations && styles.disabledButton,
+            ]}
+            onPress={hasRecitations ? handleOptionsMenu : undefined}
+            disabled={!hasRecitations}>
+            <Feather
+              name="more-horizontal"
+              size={moderateScale(20)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+          <Pressable
+            style={[
+              styles.circleButton,
+              styles.playButton,
+              !hasRecitations && styles.disabledButton,
+            ]}
+            onPress={hasRecitations ? handlePlayAll : undefined}
+            disabled={!hasRecitations}>
+            <View style={styles.playIconContainer}>
+              <PlayIcon
+                color={theme.colors.background}
+                size={moderateScale(16)}
+              />
             </View>
-          </View>
+          </Pressable>
+          <Pressable
+            style={[
+              styles.circleButton,
+              !hasRecitations && styles.disabledButton,
+            ]}
+            onPress={hasRecitations ? handleShuffle : undefined}
+            disabled={!hasRecitations}>
+            <ShuffleIcon color={theme.colors.text} size={moderateScale(20)} />
+          </Pressable>
         </View>
 
         {/* Add Recitation Bar */}
@@ -473,41 +493,38 @@ export default function UploadsScreen() {
         </Pressable>
       </View>
     );
-  }, [
-    styles,
-    theme,
-    insets.top,
-    totalCount,
-    router,
-    handleImportFile,
-    isImporting,
-    hasRecitations,
-    handlePlayAll,
-    handleShuffle,
-    handlePressIn,
-    handlePressOut,
-    shuffleAnimatedStyle,
-    playAnimatedStyle,
-  ]);
-
-  const ListEmptyComponent = useCallback(() => {
-    return (
-      <View style={styles.emptyContainer}>
-        <Text style={styles.emptyText}>
-          No uploads yet. Tap + to add recitations.
-        </Text>
-      </View>
-    );
-  }, [styles]);
+  };
 
   return (
     <View style={styles.container}>
+      <RNAnimated.View
+        style={[
+          styles.fixedBackButton,
+          {
+            top: insets.top + moderateScale(10),
+          },
+          {
+            opacity: scrollY.interpolate({
+              inputRange: [80, 120],
+              outputRange: [1, 0],
+              extrapolate: 'clamp',
+            }),
+          },
+        ]}>
+        <Pressable onPress={() => router.back()} hitSlop={8}>
+          <Feather
+            name="arrow-left"
+            size={moderateScale(24)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+      </RNAnimated.View>
+
       <RNAnimated.FlatList
         data={recitations}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         ListHeaderComponent={ListHeaderComponent}
-        ListEmptyComponent={ListEmptyComponent}
         contentContainerStyle={styles.listContentContainer}
         showsVerticalScrollIndicator={false}
         onScroll={RNAnimated.event(
@@ -534,15 +551,9 @@ const createStyles = (theme: {colors: any; fonts: any}) =>
     contentArea: {
       width: '100%',
       alignItems: 'center',
-      paddingBottom: moderateScale(30),
+      paddingBottom: moderateScale(10),
       overflow: 'hidden',
       backgroundColor: theme.colors.background,
-    },
-    backButton: {
-      position: 'absolute',
-      left: moderateScale(15),
-      zIndex: 10,
-      padding: moderateScale(8),
     },
     contentCenter: {
       alignItems: 'center',
@@ -580,15 +591,14 @@ const createStyles = (theme: {colors: any; fonts: any}) =>
       textAlign: 'center',
       marginBottom: moderateScale(8),
     },
-    contentWrapper: {
-      paddingHorizontal: moderateScale(16),
-    },
     actionButtons: {
       flexDirection: 'row',
-      justifyContent: 'space-between',
+      justifyContent: 'center',
       alignItems: 'center',
-      paddingVertical: moderateScale(5),
-      paddingHorizontal: moderateScale(5),
+      paddingTop: moderateScale(4),
+      paddingBottom: moderateScale(12),
+      paddingHorizontal: moderateScale(20),
+      gap: moderateScale(16),
     },
     uploadBar: {
       flexDirection: 'row',
@@ -606,11 +616,6 @@ const createStyles = (theme: {colors: any; fonts: any}) =>
       fontSize: moderateScale(13),
       fontFamily: 'Manrope-SemiBold',
       color: theme.colors.textSecondary,
-    },
-    rightAlignedButtons: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: moderateScale(8),
     },
     circleButton: {
       width: moderateScale(42),
@@ -636,18 +641,70 @@ const createStyles = (theme: {colors: any; fonts: any}) =>
       flexGrow: 1,
       paddingBottom: moderateScale(65),
     },
-    emptyContainer: {
+    fixedBackButton: {
+      position: 'absolute',
+      left: moderateScale(15),
+      zIndex: 5,
+      padding: moderateScale(8),
+    },
+    emptyHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingBottom: moderateScale(12),
+      paddingHorizontal: moderateScale(16),
+    },
+    emptyHeaderBack: {
+      width: moderateScale(36),
+      height: moderateScale(36),
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    emptyHeaderTitle: {
+      flex: 1,
+      fontSize: moderateScale(17),
+      fontFamily: theme.fonts?.bold || 'Manrope-Bold',
+      color: theme.colors.text,
+      textAlign: 'center',
+    },
+    emptyContent: {
       flex: 1,
       alignItems: 'center',
       justifyContent: 'center',
-      paddingTop: moderateScale(60),
       paddingHorizontal: moderateScale(32),
+      paddingBottom: moderateScale(60),
     },
-    emptyText: {
-      fontSize: moderateScale(16),
+    emptyIcon: {
+      marginBottom: moderateScale(16),
+    },
+    emptyTitle: {
+      fontSize: moderateScale(17),
+      fontFamily: theme.fonts?.bold || 'Manrope-Bold',
+      color: theme.colors.text,
+      textAlign: 'center',
+      marginBottom: moderateScale(8),
+    },
+    emptySubtitle: {
+      fontSize: moderateScale(13),
+      fontFamily: theme.fonts?.regular || 'Manrope-Regular',
       color: theme.colors.textSecondary,
       textAlign: 'center',
-      lineHeight: moderateScale(24),
+      marginBottom: moderateScale(20),
+    },
+    emptyActionBar: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: moderateScale(12),
+      paddingHorizontal: moderateScale(32),
+      borderRadius: moderateScale(12),
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      gap: moderateScale(8),
+    },
+    emptyActionText: {
+      fontSize: moderateScale(13),
+      fontFamily: 'Manrope-SemiBold',
+      color: theme.colors.textSecondary,
     },
     itemRow: {
       flexDirection: 'row',
@@ -659,7 +716,7 @@ const createStyles = (theme: {colors: any; fonts: any}) =>
       flexDirection: 'row',
       alignItems: 'center',
       paddingVertical: moderateScale(8),
-      paddingLeft: moderateScale(12),
+      paddingLeft: moderateScale(18),
     },
     itemIconContainer: {
       width: moderateScale(44),

--- a/app/(tabs)/(c.collection)/index.tsx
+++ b/app/(tabs)/(c.collection)/index.tsx
@@ -1,5 +1,5 @@
-import React, {useState, useRef, useMemo, useCallback} from 'react';
-import {View, ScrollView, Platform, Text} from 'react-native';
+import React, {useCallback} from 'react';
+import {View, ScrollView, Platform, Text, Pressable} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
@@ -7,50 +7,32 @@ import {moderateScale, ScaledSheet} from 'react-native-size-matters';
 import {Feather} from '@expo/vector-icons';
 import {useFavoriteReciters} from '@/hooks/useFavoriteReciters';
 import {useLoved} from '@/hooks/useLoved';
-import {useSettings} from '@/hooks/useSettings';
 import {Theme} from '@/utils/themeUtils';
 import {BlurView} from '@react-native-community/blur';
-import * as Haptics from 'expo-haptics';
+import Color from 'color';
 
-// Components
 import {CollectionHeader} from '@/components/collection/CollectionHeader';
-import {FilterBar} from '@/components/collection/FilterBar';
-import {SectionHeader} from '@/components/collection/SectionHeader';
-import {CollectionSearchModal} from '@/components/collection/CollectionSearchModal';
-import {
-  CollectionGrid,
-  CollectionItem as CollectionItemType,
-  PlaylistItemData,
-  LovedItemData,
-  ReciterItemData,
-  DownloadItemData,
-  TrackItemData,
-  ReciterDownloadsItemData,
-  UploadItemData,
-} from '@/components/collection/CollectionGrid';
-import {PlaylistItem} from '@/components/PlaylistItem';
-import {ReciterItem} from '@/components/ReciterItem';
-import {TrackItem} from '@/components/TrackItem';
-import {ReciterDownloadsListItem} from '@/components/ReciterDownloadsListItem';
 import {useDownloads} from '@/services/player/store/downloadSelectors';
 import {usePlaylists} from '@/hooks/usePlaylists';
 import {SheetManager} from 'react-native-actions-sheet';
-import {HeartIcon, DownloadIcon, MicrophoneIcon} from '@/components/Icons';
-import Color from 'color';
-import {Pressable} from 'react-native';
-import {usePlayerActions} from '@/hooks/usePlayerActions';
-import {getReciterById, getSurahById} from '@/services/dataService';
-import {createDownloadedTrack} from '@/utils/track';
+import {
+  HeartIcon,
+  DownloadIcon,
+  MicrophoneIcon,
+  PlaylistIcon,
+  ProfileIcon,
+} from '@/components/Icons';
 import {useUploadsStore} from '@/store/uploadsStore';
 
-// Filter options
-const FILTERS = [
-  {id: 'playlists', label: 'Playlists'},
-  {id: 'reciters', label: 'Reciters'},
-  {id: 'downloads', label: 'Downloads'},
-  {id: 'uploads', label: 'Uploads'},
-  {id: 'loved', label: 'Loved'},
-];
+interface CategoryItem {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  color: string;
+  count: number;
+  emptyText: string;
+  route: string;
+}
 
 export default function CollectionScreen() {
   const {theme} = useTheme();
@@ -59,450 +41,65 @@ export default function CollectionScreen() {
   const router = useRouter();
   const {lovedTracks} = useLoved();
   const {favoriteReciters} = useFavoriteReciters();
-
-  const [activeFilter, setActiveFilter] = useState('');
-  const collectionViewMode = useSettings(state => state.collectionViewMode);
-  const setCollectionViewMode = useSettings(
-    state => state.setCollectionViewMode,
-  );
-  const isGridView = collectionViewMode === 'grid';
-  const [showSearchModal, setShowSearchModal] = useState(false);
-  const [, setSelectedPlaylist] = useState<{
-    id: string;
-    name: string;
-    color?: string;
-  } | null>(null);
-  const shouldClearPlaylistRef = useRef(true);
   const downloads = useDownloads();
-  const {playlists, createPlaylist, deletePlaylist, updatePlaylist} =
-    usePlaylists();
-  const {updateQueue, play} = usePlayerActions();
-  const {recitations: uploadedRecitations, totalCount: uploadsTotalCount} =
-    useUploadsStore();
-
-  // Get existing playlist colors to avoid duplicates
-  const existingPlaylistColors = useMemo(
-    () => playlists.map(p => p.color).filter(Boolean) as string[],
-    [playlists],
-  );
+  const {playlists} = usePlaylists();
+  const {totalCount: uploadsTotalCount} = useUploadsStore();
 
   const handleAddPress = useCallback(() => {
     SheetManager.show('add-to-collection');
   }, []);
 
-  const handlePlaylistLongPress = useCallback(
-    (playlistId: string, playlistName: string, color?: string) => {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-      setSelectedPlaylist({id: playlistId, name: playlistName, color});
-      shouldClearPlaylistRef.current = true; // Reset flag when opening context menu
-
-      // Create a closure that captures the playlist data for editing
-      const handleEditForThisPlaylist = async () => {
-        // Prevent clearing selectedPlaylist BEFORE closing context menu
-        shouldClearPlaylistRef.current = false;
-
-        // Show the create-playlist sheet in edit mode
-        const result = await SheetManager.show('create-playlist', {
-          payload: {
-            existingColors: existingPlaylistColors,
-            isEditMode: true,
-            initialName: playlistName,
-            initialColor: color || '#6366F1',
-          },
-        });
-
-        if (result?.name && result?.color) {
-          try {
-            await updatePlaylist(playlistId, {
-              name: result.name,
-              color: result.color,
-            });
-          } catch (error: unknown) {
-            console.error('Failed to update playlist:', error);
-          }
-        }
-
-        // Clear the flag after modal is fully closed
-        setTimeout(() => {
-          shouldClearPlaylistRef.current = true;
-        }, 600);
-      };
-
-      // Create a closure that captures the playlist ID for deletion
-      const handleDeleteForThisPlaylist = async () => {
-        try {
-          await deletePlaylist(playlistId);
-          setSelectedPlaylist(null);
-        } catch (error: unknown) {
-          console.error('Failed to delete playlist:', error);
-          // Error handling is done in the confirmation dialog
-        }
-      };
-
-      SheetManager.show('playlist-context', {
-        payload: {
-          playlistId,
-          playlistName,
-          playlistColor: color,
-          onDelete: handleDeleteForThisPlaylist,
-          onEdit: handleEditForThisPlaylist,
-        },
-      });
+  const categories: CategoryItem[] = [
+    {
+      id: 'playlists',
+      label: 'Playlists',
+      icon: <PlaylistIcon color="#6366F1" size={moderateScale(22)} />,
+      color: '#6366F1',
+      count: playlists.length,
+      emptyText: 'Create your first playlist',
+      route: '/collection/playlists',
     },
-    [deletePlaylist, existingPlaylistColors, updatePlaylist],
-  );
-
-  const handleSearch = () => {
-    // Open the search modal
-    setShowSearchModal(true);
-  };
-
-  const handleViewToggle = () => {
-    const newMode = isGridView ? 'list' : 'grid';
-    setCollectionViewMode(newMode);
-  };
-
-  // Memoize collection items to ensure re-render when dependencies change
-  const collectionItems = useMemo(() => {
-    const items: Array<CollectionItemType & {timestamp: number}> = [];
-
-    // Add User Playlists
-    if (activeFilter === '' || activeFilter === 'playlists') {
-      if (playlists && Array.isArray(playlists)) {
-        playlists.forEach(playlist => {
-          items.push({
-            id: playlist.id,
-            type: 'playlist',
-            timestamp: playlist.updatedAt || playlist.createdAt || 0,
-            data: {
-              name: playlist.name,
-              itemCount: playlist.itemCount,
-              color: playlist.color,
-              onPress: () => router.push(`/playlist/${playlist.id}`),
-              onLongPress: () =>
-                handlePlaylistLongPress(
-                  playlist.id,
-                  playlist.name,
-                  playlist.color,
-                ),
-            },
-          });
-        });
-      }
-    }
-
-    // Add Loved Surahs Collection Card
-    if (activeFilter === '' || activeFilter === 'loved') {
-      // Get the most recent loved track timestamp
-      const mostRecentLovedTimestamp =
-        lovedTracks.length > 0
-          ? Math.max(...lovedTracks.map(t => t.timestamp || 0))
-          : 0;
-
-      items.push({
-        id: 'loved-collection',
-        type: 'loved',
-        timestamp: mostRecentLovedTimestamp,
-        data: {
-          name: 'Loved Surahs',
-          itemCount: lovedTracks.length,
-          onPress: () => router.push('/collection/loved'),
-        },
-      });
-    }
-
-    // Add Individual Favorite Reciters
-    if (activeFilter === '' || activeFilter === 'reciters') {
-      favoriteReciters.forEach(reciter => {
-        items.push({
-          id: `reciter-${reciter.id}`,
-          type: 'reciter',
-          timestamp: reciter.favoritedAt || 0,
-          data: {
-            name: reciter.name,
-            image_url: reciter.image_url,
-            onPress: () => router.push(`/reciter/${reciter.id}`),
-          },
-        });
-      });
-    }
-
-    // Add Downloads - grouped by reciter
-    if (activeFilter === '' || activeFilter === 'downloads') {
-      // Group downloads by reciterId
-      const downloadsByReciter = downloads.reduce((acc, download) => {
-        if (!acc[download.reciterId]) {
-          acc[download.reciterId] = [];
-        }
-        acc[download.reciterId].push(download);
-        return acc;
-      }, {} as Record<string, typeof downloads>);
-
-      Object.entries(downloadsByReciter).forEach(
-        ([reciterId, reciterDownloads]) => {
-          const mostRecentTimestamp = Math.max(
-            ...reciterDownloads.map(d => d.downloadDate || 0),
-          );
-
-          if (reciterDownloads.length === 1) {
-            // Single download - show as individual track
-            const download = reciterDownloads[0];
-            items.push({
-              id: `download-${download.reciterId}-${download.surahId}-${
-                download.rewayatId || 'default'
-              }`,
-              type: 'track',
-              timestamp: download.downloadDate || 0,
-              data: {
-                reciterId: download.reciterId,
-                surahId: download.surahId,
-                rewayatId: download.rewayatId,
-                onPress: async () => {
-                  try {
-                    const [reciter, surah] = await Promise.all([
-                      getReciterById(download.reciterId),
-                      getSurahById(parseInt(download.surahId, 10)),
-                    ]);
-
-                    if (reciter && surah) {
-                      const track = createDownloadedTrack(
-                        reciter,
-                        surah,
-                        download.filePath,
-                        download.rewayatId,
-                      );
-                      await updateQueue([track], 0);
-                      await play();
-                    }
-                  } catch (error) {
-                    console.error('Error playing downloaded track:', error);
-                  }
-                },
-              },
-            });
-          } else {
-            // Multiple downloads from same reciter - show as stacked card
-            items.push({
-              id: `reciter-downloads-${reciterId}`,
-              type: 'reciter-downloads',
-              timestamp: mostRecentTimestamp,
-              data: {
-                reciterId,
-                downloadCount: reciterDownloads.length,
-                onPress: () =>
-                  router.push(`/collection/reciter-downloads/${reciterId}`),
-              },
-            });
-          }
-        },
-      );
-    }
-
-    // Add Uploads Collection Card
-    if (activeFilter === '' || activeFilter === 'uploads') {
-      const mostRecentUploadTimestamp =
-        uploadedRecitations.length > 0
-          ? Math.max(...uploadedRecitations.map(r => r.dateAdded || 0))
-          : 0;
-
-      items.push({
-        id: 'uploads-collection',
-        type: 'upload',
-        timestamp: mostRecentUploadTimestamp,
-        data: {
-          itemCount: uploadsTotalCount,
-          onPress: () => router.push('/collection/uploads'),
-        },
-      });
-    }
-
-    // Sort by most recent first (descending order: highest timestamp at top)
-    // b.timestamp - a.timestamp means newer items (higher timestamp) come first
-    return items.sort((a, b) => b.timestamp - a.timestamp);
-  }, [
-    playlists,
-    lovedTracks,
-    favoriteReciters,
-    downloads,
-    uploadedRecitations,
-    uploadsTotalCount,
-    activeFilter,
-    router,
-    handlePlaylistLongPress,
-    updateQueue,
-    play,
-  ]);
-
-  // Render function for list items
-  const renderListItem = (item: CollectionItemType) => {
-    switch (item.type) {
-      case 'playlist': {
-        const playlistData = item.data as PlaylistItemData;
-        return (
-          <PlaylistItem
-            key={item.id}
-            id={item.id}
-            name={playlistData.name}
-            itemCount={playlistData.itemCount}
-            color={playlistData.color}
-            onPress={playlistData.onPress}
-            onLongPress={playlistData.onLongPress}
-          />
-        );
-      }
-      case 'loved': {
-        const lovedData = item.data as LovedItemData;
-        const lovedColor = '#FF6B6B';
-        return (
-          <View key={item.id} style={styles.listItemWrapper}>
-            <Pressable onPress={lovedData.onPress} style={styles.listItem}>
-              <View
-                style={[
-                  styles.listItemIcon,
-                  {
-                    backgroundColor: Color(lovedColor).alpha(0.15).toString(),
-                    borderColor: Color(lovedColor).alpha(0.3).toString(),
-                  },
-                ]}>
-                <HeartIcon
-                  color={lovedColor}
-                  size={moderateScale(24)}
-                  filled={true}
-                />
-              </View>
-              <View style={styles.listItemInfo}>
-                <Text style={[styles.listItemName, {color: theme.colors.text}]}>
-                  Loved Surahs
-                </Text>
-                <Text
-                  style={[
-                    styles.listItemSubtitle,
-                    {color: theme.colors.textSecondary},
-                  ]}
-                  numberOfLines={1}>
-                  Loved • {lovedData.itemCount}{' '}
-                  {lovedData.itemCount === 1 ? 'surah' : 'surahs'}
-                </Text>
-              </View>
-            </Pressable>
-          </View>
-        );
-      }
-      case 'reciter': {
-        const reciterData = item.data as ReciterItemData;
-        return (
-          <ReciterItem
-            key={item.id}
-            item={{
-              id: item.id.replace('reciter-', ''),
-              name: reciterData.name,
-              rewayat: [],
-              image_url: reciterData.image_url,
-              date: '',
-            }}
-            onPress={() => reciterData.onPress()}
-            secondaryText="Favorite"
-          />
-        );
-      }
-      case 'download': {
-        const downloadData = item.data as DownloadItemData;
-        const downloadColor = '#10AC84';
-        return (
-          <View key={item.id} style={styles.listItemWrapper}>
-            <Pressable onPress={downloadData.onPress} style={styles.listItem}>
-              <View
-                style={[
-                  styles.listItemIcon,
-                  {
-                    backgroundColor: Color(downloadColor)
-                      .alpha(0.15)
-                      .toString(),
-                    borderColor: Color(downloadColor).alpha(0.3).toString(),
-                  },
-                ]}>
-                <DownloadIcon color={downloadColor} size={moderateScale(24)} />
-              </View>
-              <View style={styles.listItemInfo}>
-                <Text style={[styles.listItemName, {color: theme.colors.text}]}>
-                  Downloads
-                </Text>
-                <Text
-                  style={[
-                    styles.listItemSubtitle,
-                    {color: theme.colors.textSecondary},
-                  ]}
-                  numberOfLines={1}>
-                  Downloaded • {downloadData.itemCount}{' '}
-                  {downloadData.itemCount === 1 ? 'surah' : 'surahs'}
-                </Text>
-              </View>
-            </Pressable>
-          </View>
-        );
-      }
-      case 'track': {
-        const trackData = item.data as TrackItemData;
-        return (
-          <TrackItem
-            key={item.id}
-            reciterId={trackData.reciterId}
-            surahId={trackData.surahId}
-            rewayatId={trackData.rewayatId}
-            onPress={trackData.onPress}
-            onPlayPress={trackData.onPress}
-          />
-        );
-      }
-      case 'reciter-downloads': {
-        const reciterDownloadsData = item.data as ReciterDownloadsItemData;
-        return (
-          <ReciterDownloadsListItem
-            key={item.id}
-            reciterId={reciterDownloadsData.reciterId}
-            downloadCount={reciterDownloadsData.downloadCount}
-            onPress={reciterDownloadsData.onPress}
-          />
-        );
-      }
-      case 'upload': {
-        const uploadData = item.data as UploadItemData;
-        const uploadColor = '#8B5CF6';
-        return (
-          <View key={item.id} style={styles.listItemWrapper}>
-            <Pressable onPress={uploadData.onPress} style={styles.listItem}>
-              <View
-                style={[
-                  styles.listItemIcon,
-                  {
-                    backgroundColor: Color(uploadColor).alpha(0.15).toString(),
-                    borderColor: Color(uploadColor).alpha(0.3).toString(),
-                  },
-                ]}>
-                <MicrophoneIcon color={uploadColor} size={moderateScale(24)} />
-              </View>
-              <View style={styles.listItemInfo}>
-                <Text style={[styles.listItemName, {color: theme.colors.text}]}>
-                  Uploads
-                </Text>
-                <Text
-                  style={[
-                    styles.listItemSubtitle,
-                    {color: theme.colors.textSecondary},
-                  ]}
-                  numberOfLines={1}>
-                  Uploaded • {uploadData.itemCount}{' '}
-                  {uploadData.itemCount === 1 ? 'recitation' : 'recitations'}
-                </Text>
-              </View>
-            </Pressable>
-          </View>
-        );
-      }
-      default:
-        return null;
-    }
-  };
+    {
+      id: 'reciters',
+      label: 'Reciters',
+      icon: (
+        <ProfileIcon color="#3B82F6" size={moderateScale(22)} filled={true} />
+      ),
+      color: '#3B82F6',
+      count: favoriteReciters.length,
+      emptyText: 'No favorites yet',
+      route: '/collection/favorite-reciters',
+    },
+    {
+      id: 'downloads',
+      label: 'Downloads',
+      icon: <DownloadIcon color="#10AC84" size={moderateScale(22)} />,
+      color: '#10AC84',
+      count: downloads.length,
+      emptyText: 'No downloads yet',
+      route: '/collection/downloads',
+    },
+    {
+      id: 'loved',
+      label: 'Loved',
+      icon: (
+        <HeartIcon color="#FF6B6B" size={moderateScale(22)} filled={true} />
+      ),
+      color: '#FF6B6B',
+      count: lovedTracks.length,
+      emptyText: 'No loved surahs yet',
+      route: '/collection/loved',
+    },
+    {
+      id: 'uploads',
+      label: 'Uploads',
+      icon: <MicrophoneIcon color="#8B5CF6" size={moderateScale(22)} />,
+      color: '#8B5CF6',
+      count: uploadsTotalCount,
+      emptyText: 'No uploads yet',
+      route: '/collection/uploads',
+    },
+  ];
 
   return (
     <View style={styles.container}>
@@ -552,22 +149,6 @@ export default function CollectionScreen() {
         {/* Header */}
         <CollectionHeader title="Your Collection" theme={theme} />
 
-        {/* Filter Bar */}
-        <FilterBar
-          filters={FILTERS}
-          activeFilter={activeFilter}
-          onFilterChange={setActiveFilter}
-          theme={theme}
-        />
-
-        {/* Section Header */}
-        <SectionHeader
-          title="Your Library"
-          onViewToggle={handleViewToggle}
-          isGridView={isGridView}
-          theme={theme}
-        />
-
         {/* Add to Collection Bar */}
         <Pressable style={styles.addBar} onPress={handleAddPress}>
           <Feather
@@ -581,24 +162,53 @@ export default function CollectionScreen() {
           </Text>
         </Pressable>
 
-        {/* Collection Items */}
-        {isGridView ? (
-          <CollectionGrid items={collectionItems} theme={theme} />
-        ) : (
-          <View style={styles.listContainer}>
-            {collectionItems.map(item => renderListItem(item))}
-          </View>
-        )}
+        {/* Category List */}
+        <View style={styles.categoryList}>
+          {categories.map(category => (
+            <Pressable
+              key={category.id}
+              style={styles.categoryRow}
+              onPress={() => router.push(category.route as never)}>
+              <View
+                style={[
+                  styles.categoryIcon,
+                  {
+                    backgroundColor: Color(category.color)
+                      .alpha(0.15)
+                      .toString(),
+                  },
+                ]}>
+                {category.icon}
+              </View>
+              <View style={styles.categoryInfo}>
+                <Text
+                  style={[styles.categoryLabel, {color: theme.colors.text}]}>
+                  {category.label}
+                </Text>
+                <Text
+                  style={[
+                    styles.categorySubtitle,
+                    {color: theme.colors.textSecondary},
+                  ]}
+                  numberOfLines={1}>
+                  {category.count > 0
+                    ? `${category.count} ${
+                        category.count === 1 ? 'item' : 'items'
+                      }`
+                    : category.emptyText}
+                </Text>
+              </View>
+              <Feather
+                name="chevron-right"
+                size={moderateScale(18)}
+                color={theme.colors.textSecondary}
+              />
+            </Pressable>
+          ))}
+        </View>
 
         <View style={{height: moderateScale(100)}} />
       </ScrollView>
-
-      {/* Collection Search Modal - DEEP SEARCH */}
-      <CollectionSearchModal
-        visible={showSearchModal}
-        onClose={() => setShowSearchModal(false)}
-        theme={theme}
-      />
     </View>
   );
 }
@@ -638,47 +248,13 @@ const createStyles = (theme: Theme) =>
     content: {
       flex: 1,
     },
-    listContainer: {
-      paddingVertical: moderateScale(8),
-    },
-    listItemWrapper: {
-      paddingHorizontal: moderateScale(18),
-    },
-    listItem: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: moderateScale(8),
-    },
-    listItemIcon: {
-      width: moderateScale(50),
-      height: moderateScale(50),
-      marginRight: moderateScale(12),
-      justifyContent: 'center',
-      alignItems: 'center',
-      overflow: 'hidden',
-      borderRadius: moderateScale(10),
-      borderWidth: moderateScale(1),
-    },
-    listItemInfo: {
-      flex: 1,
-      justifyContent: 'center',
-    },
-    listItemName: {
-      fontSize: moderateScale(14),
-      fontFamily: 'Manrope-SemiBold',
-      marginBottom: moderateScale(1),
-    },
-    listItemSubtitle: {
-      fontSize: moderateScale(12),
-      fontFamily: 'Manrope-Regular',
-    },
     addBar: {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'center',
       paddingVertical: moderateScale(12),
       marginHorizontal: moderateScale(16),
-      marginBottom: moderateScale(8),
+      marginBottom: moderateScale(16),
       borderRadius: moderateScale(12),
       backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
       gap: moderateScale(8),
@@ -686,5 +262,34 @@ const createStyles = (theme: Theme) =>
     addBarText: {
       fontSize: moderateScale(13),
       fontFamily: 'Manrope-SemiBold',
+    },
+    categoryList: {
+      paddingHorizontal: moderateScale(16),
+    },
+    categoryRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: moderateScale(12),
+    },
+    categoryIcon: {
+      width: moderateScale(46),
+      height: moderateScale(46),
+      borderRadius: moderateScale(12),
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginRight: moderateScale(14),
+    },
+    categoryInfo: {
+      flex: 1,
+      justifyContent: 'center',
+    },
+    categoryLabel: {
+      fontSize: moderateScale(15),
+      fontFamily: 'Manrope-SemiBold',
+      marginBottom: moderateScale(2),
+    },
+    categorySubtitle: {
+      fontSize: moderateScale(12),
+      fontFamily: 'Manrope-Regular',
     },
   });

--- a/components/PlaylistItem.tsx
+++ b/components/PlaylistItem.tsx
@@ -3,7 +3,7 @@ import {View, Text, Pressable} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
-import {MaterialIcons} from '@expo/vector-icons';
+import {MaterialIcons, Feather} from '@expo/vector-icons';
 import {PlaylistIcon} from '@/components/Icons';
 import Color from 'color';
 
@@ -14,11 +14,20 @@ interface PlaylistItemProps {
   color?: string;
   onPress: () => void;
   onLongPress?: () => void;
+  onOptionsPress?: () => void;
   isSelected?: boolean;
 }
 
 export const PlaylistItem: React.FC<PlaylistItemProps> = React.memo(
-  ({name, itemCount, color, onPress, onLongPress, isSelected}) => {
+  ({
+    name,
+    itemCount,
+    color,
+    onPress,
+    onLongPress,
+    onOptionsPress,
+    isSelected,
+  }) => {
     const {theme} = useTheme();
     const styles = createStyles(theme);
     const handlePress = React.useCallback(() => onPress(), [onPress]);
@@ -50,6 +59,18 @@ export const PlaylistItem: React.FC<PlaylistItemProps> = React.memo(
             Playlist • {itemCount} {itemCount === 1 ? 'surah' : 'surahs'}
           </Text>
         </View>
+        {onOptionsPress && !isSelected && (
+          <Pressable
+            style={styles.optionsButton}
+            onPress={onOptionsPress}
+            hitSlop={8}>
+            <Feather
+              name="more-horizontal"
+              size={moderateScale(18)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+        )}
         {isSelected && (
           <View style={styles.checkmarkContainer}>
             <MaterialIcons
@@ -104,6 +125,9 @@ const createStyles = (theme: Theme) =>
     },
     selectedIconContainer: {
       borderWidth: moderateScale(2),
+    },
+    optionsButton: {
+      padding: moderateScale(8),
     },
     checkmarkContainer: {
       marginLeft: moderateScale(8),

--- a/components/ReciterDownloadsListItem.tsx
+++ b/components/ReciterDownloadsListItem.tsx
@@ -1,68 +1,85 @@
 import React, {useEffect, useState} from 'react';
-import {View, Text, TouchableOpacity} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
 import {Reciter} from '@/data/reciterData';
 import {ReciterImage} from '@/components/ReciterImage';
 import {getReciterById} from '@/services/dataService';
+import {Feather} from '@expo/vector-icons';
 
 interface ReciterDownloadsListItemProps {
   reciterId: string;
   downloadCount: number;
   onPress: () => void;
+  onOptionsPress?: () => void;
+  onLongPress?: () => void;
 }
 
 export const ReciterDownloadsListItem: React.FC<ReciterDownloadsListItemProps> =
-  React.memo(({reciterId, downloadCount, onPress}) => {
-    const {theme} = useTheme();
-    const styles = createStyles(theme);
-    const [reciter, setReciter] = useState<Reciter | null>(null);
+  React.memo(
+    ({reciterId, downloadCount, onPress, onOptionsPress, onLongPress}) => {
+      const {theme} = useTheme();
+      const styles = createStyles(theme);
+      const [reciter, setReciter] = useState<Reciter | null>(null);
 
-    useEffect(() => {
-      let mounted = true;
-      const loadReciter = async () => {
-        try {
-          const data = await getReciterById(reciterId);
-          if (mounted && data) {
-            setReciter(data);
+      useEffect(() => {
+        let mounted = true;
+        const loadReciter = async () => {
+          try {
+            const data = await getReciterById(reciterId);
+            if (mounted && data) {
+              setReciter(data);
+            }
+          } catch (error) {
+            console.error('Error loading reciter:', error);
           }
-        } catch (error) {
-          console.error('Error loading reciter:', error);
-        }
-      };
-      loadReciter();
-      return () => {
-        mounted = false;
-      };
-    }, [reciterId]);
+        };
+        loadReciter();
+        return () => {
+          mounted = false;
+        };
+      }, [reciterId]);
 
-    if (!reciter) return null;
+      if (!reciter) return null;
 
-    return (
-      <TouchableOpacity
-        activeOpacity={0.99}
-        style={styles.container}
-        onPress={onPress}>
-        {/* Rectangular image for downloaded reciters */}
-        <View style={styles.imageContainer}>
-          <ReciterImage
-            imageUrl={reciter.image_url || undefined}
-            reciterName={reciter.name}
-            style={styles.reciterImage}
-            profileIconSize={moderateScale(20)}
-          />
-        </View>
-        <View style={styles.reciterInfo}>
-          <Text style={styles.reciterName}>{reciter.name}</Text>
-          <Text style={styles.reciterSubtitle} numberOfLines={1}>
-            Downloaded • {downloadCount}{' '}
-            {downloadCount === 1 ? 'surah' : 'surahs'}
-          </Text>
-        </View>
-      </TouchableOpacity>
-    );
-  });
+      return (
+        <Pressable
+          style={styles.container}
+          onPress={onPress}
+          onLongPress={onLongPress}>
+          {/* Rectangular image for downloaded reciters */}
+          <View style={styles.imageContainer}>
+            <ReciterImage
+              imageUrl={reciter.image_url || undefined}
+              reciterName={reciter.name}
+              style={styles.reciterImage}
+              profileIconSize={moderateScale(20)}
+            />
+          </View>
+          <View style={styles.reciterInfo}>
+            <Text style={styles.reciterName}>{reciter.name}</Text>
+            <Text style={styles.reciterSubtitle} numberOfLines={1}>
+              Downloaded • {downloadCount}{' '}
+              {downloadCount === 1 ? 'surah' : 'surahs'}
+            </Text>
+          </View>
+          {onOptionsPress && (
+            <Pressable
+              style={styles.optionsZone}
+              onPress={onOptionsPress}
+              hitSlop={8}>
+              <Feather
+                name="more-horizontal"
+                size={moderateScale(18)}
+                color={theme.colors.text}
+              />
+            </Pressable>
+          )}
+        </Pressable>
+      );
+    },
+  );
 
 ReciterDownloadsListItem.displayName = 'ReciterDownloadsListItem';
 
@@ -103,5 +120,11 @@ const createStyles = (theme: Theme) =>
       fontSize: moderateScale(12),
       fontFamily: theme.fonts.regular,
       color: theme.colors.textSecondary,
+    },
+    optionsZone: {
+      width: moderateScale(44),
+      alignItems: 'center',
+      justifyContent: 'center',
+      alignSelf: 'stretch',
     },
   });

--- a/components/ReciterItem.tsx
+++ b/components/ReciterItem.tsx
@@ -3,7 +3,7 @@ import {View, Text, Pressable} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
-import {MaterialIcons} from '@expo/vector-icons';
+import {MaterialIcons, Feather} from '@expo/vector-icons';
 import {Reciter} from '@/data/reciterData';
 import {ReciterImage} from '@/components/ReciterImage';
 
@@ -12,18 +12,25 @@ interface ReciterItemProps {
   onPress: (item: Reciter) => void;
   isSelected?: boolean;
   secondaryText?: string;
+  onOptionsPress?: (item: Reciter) => void;
+  onLongPress?: (item: Reciter) => void;
 }
 
 export const ReciterItem: React.FC<ReciterItemProps> = React.memo(
-  ({item, onPress, isSelected, secondaryText}) => {
+  ({item, onPress, isSelected, secondaryText, onOptionsPress, onLongPress}) => {
     const {theme} = useTheme();
     const styles = createStyles(theme);
     const handlePress = React.useCallback(() => onPress(item), [item, onPress]);
+    const handleLongPress = React.useCallback(
+      () => onLongPress?.(item),
+      [item, onLongPress],
+    );
 
     return (
       <Pressable
         style={[styles.reciterItem, isSelected && styles.selectedReciterItem]}
-        onPress={handlePress}>
+        onPress={handlePress}
+        onLongPress={onLongPress ? handleLongPress : undefined}>
         <View
           style={[
             styles.imageContainer,
@@ -45,7 +52,7 @@ export const ReciterItem: React.FC<ReciterItemProps> = React.memo(
                 : item.rewayat[0]?.name || '')}
           </Text>
         </View>
-        {isSelected && (
+        {!onOptionsPress && isSelected && (
           <View style={styles.checkmarkContainer}>
             <MaterialIcons
               name="check"
@@ -53,6 +60,18 @@ export const ReciterItem: React.FC<ReciterItemProps> = React.memo(
               color={theme.colors.primary}
             />
           </View>
+        )}
+        {onOptionsPress && (
+          <Pressable
+            style={styles.optionsZone}
+            onPress={() => onOptionsPress(item)}
+            hitSlop={8}>
+            <Feather
+              name="more-horizontal"
+              size={moderateScale(18)}
+              color={theme.colors.text}
+            />
+          </Pressable>
         )}
       </Pressable>
     );
@@ -107,5 +126,11 @@ const createStyles = (theme: Theme) =>
     },
     checkmarkContainer: {
       marginLeft: moderateScale(8),
+    },
+    optionsZone: {
+      width: moderateScale(44),
+      alignItems: 'center',
+      justifyContent: 'center',
+      alignSelf: 'stretch',
     },
   });

--- a/components/TrackItem.tsx
+++ b/components/TrackItem.tsx
@@ -25,10 +25,12 @@ interface TrackItemProps {
   reciterId: string;
   surahId: string;
   rewayatId?: string;
+  userRecitationId?: string;
   onPress: () => void;
   onPlayPress?: () => void;
   hidePlayButton?: boolean;
   onOptionsPress?: () => void;
+  onLongPress?: () => void;
 }
 
 export const TrackItem: React.FC<TrackItemProps> = React.memo(
@@ -36,10 +38,12 @@ export const TrackItem: React.FC<TrackItemProps> = React.memo(
     reciterId,
     surahId,
     rewayatId,
+    userRecitationId,
     onPress,
     onPlayPress,
     hidePlayButton,
     onOptionsPress,
+    onLongPress,
   }) => {
     const {theme} = useTheme();
     const styles = createStyles(theme);
@@ -83,19 +87,26 @@ export const TrackItem: React.FC<TrackItemProps> = React.memo(
           ? tracks[currentIndex]
           : null;
 
-      if (!reciterId || !currentTrack || !surahId) return false;
+      if (!currentTrack) return false;
+
+      // For upload tracks, match by userRecitationId
+      if (userRecitationId && currentTrack.userRecitationId) {
+        return userRecitationId === currentTrack.userRecitationId;
+      }
+
+      if (!reciterId || !surahId) return false;
 
       const rewayatMatches =
         rewayatId && currentTrack.rewayatId
           ? rewayatId === currentTrack.rewayatId
-          : !rewayatId && !currentTrack.rewayatId; // Match if both are undefined/null
+          : !rewayatId && !currentTrack.rewayatId;
 
       return (
         currentTrack.reciterId === reciterId &&
-        currentTrack.surahId === surahId && // surahId is already string here
+        currentTrack.surahId === surahId &&
         rewayatMatches
       );
-    }, [reciterId, surahId, rewayatId, currentIndex, tracks]);
+    }, [reciterId, surahId, rewayatId, userRecitationId, currentIndex, tracks]);
 
     useEffect(() => {
       let mounted = true;
@@ -141,7 +152,10 @@ export const TrackItem: React.FC<TrackItemProps> = React.memo(
     return (
       <View style={styles.trackItem}>
         {/* Play zone */}
-        <Pressable style={styles.playZone} onPress={onPress}>
+        <Pressable
+          style={styles.playZone}
+          onPress={onPress}
+          onLongPress={onLongPress}>
           <View style={styles.imageContainer}>
             <ReciterImage
               reciterName={reciter?.name || ''}

--- a/components/collection/CollectionStickyHeader.tsx
+++ b/components/collection/CollectionStickyHeader.tsx
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    zIndex: 1,
+    zIndex: 10,
     overflow: 'hidden',
   },
   headerContent: {

--- a/components/playlist-detail/LovedHeader.tsx
+++ b/components/playlist-detail/LovedHeader.tsx
@@ -3,28 +3,18 @@ import {View, Text, Pressable} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
-import {useRouter} from 'expo-router';
 import {Theme} from '@/utils/themeUtils';
-import {PlayIcon, ShuffleIcon, HeartIcon, CheckIcon} from '@/components/Icons';
-import {Feather, Ionicons} from '@expo/vector-icons';
+import {PlayIcon, ShuffleIcon, HeartIcon} from '@/components/Icons';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from 'react-native-reanimated';
-
-const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 interface LovedHeaderProps {
   title: string;
   subtitle: string;
   onPlayPress: () => void;
   onShufflePress: () => void;
-  onDownloadPress: () => void;
+  onOptionsPress: () => void;
   theme: Theme;
-  allDownloaded: boolean;
-  hasNoTracks: boolean;
 }
 
 export const LovedHeader: React.FC<LovedHeaderProps> = ({
@@ -32,73 +22,15 @@ export const LovedHeader: React.FC<LovedHeaderProps> = ({
   subtitle,
   onPlayPress,
   onShufflePress,
-  onDownloadPress,
+  onOptionsPress,
   theme,
-  allDownloaded,
-  hasNoTracks,
 }) => {
   const insets = useSafeAreaInsets();
-  const router = useRouter();
   const styles = createStyles(theme, insets);
-
-  // Animation values for button press feedback
-  const downloadScale = useSharedValue(1);
-  const shuffleScale = useSharedValue(1);
-  const playScale = useSharedValue(1);
-
-  const downloadAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: downloadScale.value}],
-  }));
-
-  const shuffleAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: shuffleScale.value}],
-  }));
-
-  const playAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: playScale.value}],
-  }));
-
-  const handlePressIn = (button: 'download' | 'shuffle' | 'play') => {
-    const scale =
-      button === 'download'
-        ? downloadScale
-        : button === 'shuffle'
-        ? shuffleScale
-        : playScale;
-    scale.value = withSpring(0.92, {
-      damping: 15,
-      stiffness: 300,
-    });
-  };
-
-  const handlePressOut = (button: 'download' | 'shuffle' | 'play') => {
-    const scale =
-      button === 'download'
-        ? downloadScale
-        : button === 'shuffle'
-        ? shuffleScale
-        : playScale;
-    scale.value = withSpring(1, {
-      damping: 15,
-      stiffness: 300,
-    });
-  };
 
   return (
     <View style={styles.headerContainer}>
       <View style={styles.contentArea}>
-        {/* Back Button */}
-        <Pressable
-          style={styles.backButton}
-          onPress={() => router.back()}
-          hitSlop={8}>
-          <Feather
-            name="arrow-left"
-            size={moderateScale(24)}
-            color={theme.colors.text}
-          />
-        </Pressable>
-
         {/* Header Content */}
         <View style={styles.contentContainer}>
           {/* Hero Icon Container */}
@@ -121,68 +53,27 @@ export const LovedHeader: React.FC<LovedHeaderProps> = ({
       </View>
 
       {/* Action Buttons */}
-      <View style={styles.contentWrapper}>
-        <View style={styles.actionButtons}>
-          {/* Download button on the left */}
-          <AnimatedPressable
-            style={[
-              styles.downloadButton,
-              downloadAnimatedStyle,
-              hasNoTracks && styles.disabledButton,
-            ]}
-            onPress={hasNoTracks ? undefined : onDownloadPress}
-            onPressIn={
-              hasNoTracks ? undefined : () => handlePressIn('download')
-            }
-            onPressOut={
-              hasNoTracks ? undefined : () => handlePressOut('download')
-            }
-            disabled={hasNoTracks}>
-            {allDownloaded && !hasNoTracks ? (
-              <CheckIcon
-                color={
-                  hasNoTracks ? theme.colors.textSecondary : theme.colors.text
-                }
-                size={moderateScale(20)}
-              />
-            ) : (
-              <Ionicons
-                name="arrow-down"
-                size={moderateScale(20)}
-                color={
-                  hasNoTracks ? theme.colors.textSecondary : theme.colors.text
-                }
-              />
-            )}
-          </AnimatedPressable>
-
-          {/* Right side buttons */}
-          <View style={styles.rightAlignedButtons}>
-            <AnimatedPressable
-              style={[styles.circleButton, shuffleAnimatedStyle]}
-              onPress={onShufflePress}
-              onPressIn={() => handlePressIn('shuffle')}
-              onPressOut={() => handlePressOut('shuffle')}>
-              <ShuffleIcon color={theme.colors.text} size={moderateScale(20)} />
-            </AnimatedPressable>
-            <AnimatedPressable
-              style={[
-                styles.circleButton,
-                styles.playButton,
-                playAnimatedStyle,
-              ]}
-              onPress={onPlayPress}
-              onPressIn={() => handlePressIn('play')}
-              onPressOut={() => handlePressOut('play')}>
-              <View style={styles.playIconContainer}>
-                <PlayIcon
-                  color={theme.colors.background}
-                  size={moderateScale(16)}
-                />
-              </View>
-            </AnimatedPressable>
+      <View style={styles.actionButtons}>
+        <Pressable style={styles.circleButton} onPress={onOptionsPress}>
+          <Feather
+            name="more-horizontal"
+            size={moderateScale(20)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+        <Pressable
+          style={[styles.circleButton, styles.playButton]}
+          onPress={onPlayPress}>
+          <View style={styles.playIconContainer}>
+            <PlayIcon
+              color={theme.colors.background}
+              size={moderateScale(16)}
+            />
           </View>
-        </View>
+        </Pressable>
+        <Pressable style={styles.circleButton} onPress={onShufflePress}>
+          <ShuffleIcon color={theme.colors.text} size={moderateScale(20)} />
+        </Pressable>
       </View>
     </View>
   );
@@ -198,16 +89,9 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
       width: '100%',
       alignItems: 'center',
       paddingTop: insets.top + moderateScale(40),
-      paddingBottom: moderateScale(30),
+      paddingBottom: moderateScale(10),
       overflow: 'hidden',
       backgroundColor: theme.colors.background,
-    },
-    backButton: {
-      position: 'absolute',
-      top: insets.top + moderateScale(10),
-      left: moderateScale(15),
-      zIndex: 10,
-      padding: moderateScale(8),
     },
     contentContainer: {
       alignItems: 'center',
@@ -245,29 +129,14 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
       textAlign: 'center',
       marginBottom: moderateScale(8),
     },
-    contentWrapper: {
-      paddingHorizontal: moderateScale(16),
-    },
     actionButtons: {
       flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      paddingVertical: moderateScale(5),
-      paddingHorizontal: moderateScale(5),
-    },
-    downloadButton: {
-      width: moderateScale(40),
-      height: moderateScale(40),
       justifyContent: 'center',
       alignItems: 'center',
-      borderRadius: moderateScale(12),
-      backgroundColor: Color(theme.colors.textSecondary).alpha(0.08).toString(),
-      padding: moderateScale(8),
-    },
-    rightAlignedButtons: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: moderateScale(8),
+      paddingTop: moderateScale(4),
+      paddingBottom: moderateScale(12),
+      paddingHorizontal: moderateScale(20),
+      gap: moderateScale(16),
     },
     circleButton: {
       width: moderateScale(42),
@@ -285,8 +154,5 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
     },
     playIconContainer: {
       paddingLeft: moderateScale(4),
-    },
-    disabledButton: {
-      opacity: 0.4,
     },
   });

--- a/components/playlist-detail/PlaylistDetail.tsx
+++ b/components/playlist-detail/PlaylistDetail.tsx
@@ -13,7 +13,8 @@ import {getReciterById, getSurahById} from '@/services/dataService';
 import {Reciter} from '@/data/reciterData';
 import {Surah} from '@/data/surahData';
 import {usePlayerActions} from '@/hooks/usePlayerActions';
-import {createTrack} from '@/utils/track';
+import {createTrack, createUserUploadTrack} from '@/utils/track';
+import {useUploadsStore} from '@/store/uploadsStore';
 import {moderateScale} from 'react-native-size-matters';
 import {PlaylistHeader} from './PlaylistHeader';
 import {SheetManager} from 'react-native-actions-sheet';
@@ -27,6 +28,7 @@ interface PlaylistTrack {
   surahId: string;
   reciterId: string;
   rewayatId?: string;
+  userRecitationId?: string;
   surah?: Surah;
   reciter?: Reciter;
 }
@@ -105,6 +107,7 @@ const PlaylistDetail: React.FC<PlaylistDetailProps> = ({id}) => {
               surahId: item.surahId,
               reciterId: item.reciterId,
               rewayatId: item.rewayatId,
+              userRecitationId: item.userRecitationId,
               surah,
               reciter,
             },
@@ -127,6 +130,13 @@ const PlaylistDetail: React.FC<PlaylistDetailProps> = ({id}) => {
       try {
         const trackPromises = playlistData.map(async item => {
           if (!item.reciter || !item.surah) return null;
+          if (item.track.userRecitationId) {
+            const upload = useUploadsStore
+              .getState()
+              .recitations.find(r => r.id === item.track.userRecitationId);
+            if (upload) return createUserUploadTrack(upload);
+            return null;
+          }
           return await createTrack(
             item.reciter,
             item.surah,
@@ -181,6 +191,13 @@ const PlaylistDetail: React.FC<PlaylistDetailProps> = ({id}) => {
     try {
       const trackPromises = playlistData.map(async item => {
         if (!item.reciter || !item.surah) return null;
+        if (item.track.userRecitationId) {
+          const upload = useUploadsStore
+            .getState()
+            .recitations.find(r => r.id === item.track.userRecitationId);
+          if (upload) return createUserUploadTrack(upload);
+          return null;
+        }
         return await createTrack(
           item.reciter,
           item.surah,
@@ -207,6 +224,13 @@ const PlaylistDetail: React.FC<PlaylistDetailProps> = ({id}) => {
     try {
       const trackPromises = playlistData.map(async item => {
         if (!item.reciter || !item.surah) return null;
+        if (item.track.userRecitationId) {
+          const upload = useUploadsStore
+            .getState()
+            .recitations.find(r => r.id === item.track.userRecitationId);
+          if (upload) return createUserUploadTrack(upload);
+          return null;
+        }
         return await createTrack(
           item.reciter,
           item.surah,
@@ -297,7 +321,16 @@ const PlaylistDetail: React.FC<PlaylistDetailProps> = ({id}) => {
 
   const handleShowTrackOptions = useCallback(
     async (track: PlaylistTrack, reciter: Reciter, surah: Surah) => {
-      const audioTrack = await createTrack(reciter, surah, track.rewayatId);
+      let audioTrack;
+      if (track.userRecitationId) {
+        const upload = useUploadsStore
+          .getState()
+          .recitations.find(r => r.id === track.userRecitationId);
+        if (upload) audioTrack = createUserUploadTrack(upload);
+      }
+      if (!audioTrack) {
+        audioTrack = await createTrack(reciter, surah, track.rewayatId);
+      }
 
       SheetManager.show('surah-options', {
         payload: {
@@ -309,6 +342,7 @@ const PlaylistDetail: React.FC<PlaylistDetailProps> = ({id}) => {
               await addToQueue([audioTrack]);
             }
           },
+          onRemoveFromPlaylist: () => handleRemoveFromPlaylist(track),
         },
       });
     },
@@ -351,9 +385,11 @@ const PlaylistDetail: React.FC<PlaylistDetailProps> = ({id}) => {
         reciterId={track.reciterId}
         surahId={track.surahId}
         rewayatId={track.rewayatId}
+        userRecitationId={track.userRecitationId}
         onPress={() => handleSurahPress(track, reciter, surah)}
         onPlayPress={() => handleSurahPress(track, reciter, surah)}
         onOptionsPress={() => handleShowTrackOptions(track, reciter, surah)}
+        onLongPress={() => handleShowTrackOptions(track, reciter, surah)}
       />
     );
   };

--- a/components/playlist-detail/PlaylistHeader.tsx
+++ b/components/playlist-detail/PlaylistHeader.tsx
@@ -8,13 +8,6 @@ import {useRouter} from 'expo-router';
 import {Theme} from '@/utils/themeUtils';
 import {PlaylistIcon, PlayIcon, ShuffleIcon} from '@/components/Icons';
 import Color from 'color';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from 'react-native-reanimated';
-
-const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 interface PlaylistHeaderProps {
   title: string;
@@ -36,48 +29,6 @@ export const PlaylistHeader: React.FC<PlaylistHeaderProps> = ({
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const styles = createStyles(theme, insets);
-
-  const optionsScale = useSharedValue(1);
-  const shuffleScale = useSharedValue(1);
-  const playScale = useSharedValue(1);
-
-  const optionsAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: optionsScale.value}],
-  }));
-
-  const shuffleAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: shuffleScale.value}],
-  }));
-
-  const playAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: playScale.value}],
-  }));
-
-  const handlePressIn = (button: 'options' | 'shuffle' | 'play') => {
-    const scale =
-      button === 'options'
-        ? optionsScale
-        : button === 'shuffle'
-        ? shuffleScale
-        : playScale;
-    scale.value = withSpring(0.92, {
-      damping: 15,
-      stiffness: 300,
-    });
-  };
-
-  const handlePressOut = (button: 'options' | 'shuffle' | 'play') => {
-    const scale =
-      button === 'options'
-        ? optionsScale
-        : button === 'shuffle'
-        ? shuffleScale
-        : playScale;
-    scale.value = withSpring(1, {
-      damping: 15,
-      stiffness: 300,
-    });
-  };
 
   return (
     <View style={styles.headerContainer}>
@@ -113,48 +64,27 @@ export const PlaylistHeader: React.FC<PlaylistHeaderProps> = ({
       </View>
 
       {/* Action Buttons */}
-      <View style={styles.contentWrapper}>
-        <View style={styles.actionButtons}>
-          {/* Options button on the left */}
-          <AnimatedPressable
-            style={[styles.optionsButton, optionsAnimatedStyle]}
-            onPress={onOptionsPress}
-            onPressIn={() => handlePressIn('options')}
-            onPressOut={() => handlePressOut('options')}>
-            <Feather
-              name="more-horizontal"
-              size={moderateScale(20)}
-              color={theme.colors.text}
+      <View style={styles.actionButtons}>
+        <Pressable style={styles.circleButton} onPress={onOptionsPress}>
+          <Feather
+            name="more-horizontal"
+            size={moderateScale(20)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+        <Pressable
+          style={[styles.circleButton, styles.playButton]}
+          onPress={onPlayPress}>
+          <View style={styles.playIconContainer}>
+            <PlayIcon
+              color={theme.colors.background}
+              size={moderateScale(16)}
             />
-          </AnimatedPressable>
-
-          {/* Right side buttons */}
-          <View style={styles.rightAlignedButtons}>
-            <AnimatedPressable
-              style={[styles.circleButton, shuffleAnimatedStyle]}
-              onPress={onShufflePress}
-              onPressIn={() => handlePressIn('shuffle')}
-              onPressOut={() => handlePressOut('shuffle')}>
-              <ShuffleIcon color={theme.colors.text} size={moderateScale(20)} />
-            </AnimatedPressable>
-            <AnimatedPressable
-              style={[
-                styles.circleButton,
-                styles.playButton,
-                playAnimatedStyle,
-              ]}
-              onPress={onPlayPress}
-              onPressIn={() => handlePressIn('play')}
-              onPressOut={() => handlePressOut('play')}>
-              <View style={styles.playIconContainer}>
-                <PlayIcon
-                  color={theme.colors.background}
-                  size={moderateScale(16)}
-                />
-              </View>
-            </AnimatedPressable>
           </View>
-        </View>
+        </Pressable>
+        <Pressable style={styles.circleButton} onPress={onShufflePress}>
+          <ShuffleIcon color={theme.colors.text} size={moderateScale(20)} />
+        </Pressable>
       </View>
     </View>
   );
@@ -170,7 +100,7 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
       width: '100%',
       alignItems: 'center',
       paddingTop: insets.top + moderateScale(40),
-      paddingBottom: moderateScale(30),
+      paddingBottom: moderateScale(10),
       overflow: 'hidden',
       backgroundColor: theme.colors.background,
     },
@@ -217,29 +147,14 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
       textAlign: 'center',
       marginBottom: moderateScale(8),
     },
-    contentWrapper: {
-      paddingHorizontal: moderateScale(16),
-    },
     actionButtons: {
       flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      paddingVertical: moderateScale(5),
-      paddingHorizontal: moderateScale(5),
-    },
-    optionsButton: {
-      width: moderateScale(40),
-      height: moderateScale(40),
       justifyContent: 'center',
       alignItems: 'center',
-      borderRadius: moderateScale(12),
-      backgroundColor: Color(theme.colors.textSecondary).alpha(0.08).toString(),
-      padding: moderateScale(8),
-    },
-    rightAlignedButtons: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: moderateScale(8),
+      paddingTop: moderateScale(4),
+      paddingBottom: moderateScale(12),
+      paddingHorizontal: moderateScale(20),
+      gap: moderateScale(16),
     },
     circleButton: {
       width: moderateScale(42),

--- a/components/playlist-detail/ReciterDownloadsHeader.tsx
+++ b/components/playlist-detail/ReciterDownloadsHeader.tsx
@@ -8,14 +8,7 @@ import {Theme} from '@/utils/themeUtils';
 import {Feather} from '@expo/vector-icons';
 import {PlayIcon, ShuffleIcon} from '@/components/Icons';
 import {ReciterImage} from '@/components/ReciterImage';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from 'react-native-reanimated';
 import Color from 'color';
-
-const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 interface ReciterDownloadsHeaderProps {
   reciterId: string;
@@ -24,6 +17,7 @@ interface ReciterDownloadsHeaderProps {
   subtitle: string;
   onPlayPress: () => void;
   onShufflePress: () => void;
+  onOptionsPress?: () => void;
   theme: Theme;
 }
 
@@ -34,6 +28,7 @@ export const ReciterDownloadsHeader: React.FC<ReciterDownloadsHeaderProps> = ({
   subtitle,
   onPlayPress,
   onShufflePress,
+  onOptionsPress,
   theme,
 }) => {
   const insets = useSafeAreaInsets();
@@ -42,34 +37,6 @@ export const ReciterDownloadsHeader: React.FC<ReciterDownloadsHeaderProps> = ({
 
   const handleReciterPress = () => {
     router.push(`/reciter/${reciterId}`);
-  };
-
-  // Animation values for button press feedback
-  const shuffleScale = useSharedValue(1);
-  const playScale = useSharedValue(1);
-
-  const shuffleAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: shuffleScale.value}],
-  }));
-
-  const playAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: playScale.value}],
-  }));
-
-  const handlePressIn = (button: 'shuffle' | 'play') => {
-    const scale = button === 'shuffle' ? shuffleScale : playScale;
-    scale.value = withSpring(0.92, {
-      damping: 15,
-      stiffness: 300,
-    });
-  };
-
-  const handlePressOut = (button: 'shuffle' | 'play') => {
-    const scale = button === 'shuffle' ? shuffleScale : playScale;
-    scale.value = withSpring(1, {
-      damping: 15,
-      stiffness: 300,
-    });
   };
 
   return (
@@ -109,38 +76,27 @@ export const ReciterDownloadsHeader: React.FC<ReciterDownloadsHeaderProps> = ({
       </View>
 
       {/* Action Buttons */}
-      <View style={styles.contentWrapper}>
-        <View style={styles.actionButtons}>
-          {/* Spacer for alignment */}
-          <View style={styles.spacer} />
-
-          {/* Right side buttons */}
-          <View style={styles.rightAlignedButtons}>
-            <AnimatedPressable
-              style={[styles.circleButton, shuffleAnimatedStyle]}
-              onPress={onShufflePress}
-              onPressIn={() => handlePressIn('shuffle')}
-              onPressOut={() => handlePressOut('shuffle')}>
-              <ShuffleIcon color={theme.colors.text} size={moderateScale(20)} />
-            </AnimatedPressable>
-            <AnimatedPressable
-              style={[
-                styles.circleButton,
-                styles.playButton,
-                playAnimatedStyle,
-              ]}
-              onPress={onPlayPress}
-              onPressIn={() => handlePressIn('play')}
-              onPressOut={() => handlePressOut('play')}>
-              <View style={styles.playIconContainer}>
-                <PlayIcon
-                  color={theme.colors.background}
-                  size={moderateScale(16)}
-                />
-              </View>
-            </AnimatedPressable>
+      <View style={styles.actionButtons}>
+        <Pressable style={styles.circleButton} onPress={onOptionsPress}>
+          <Feather
+            name="more-horizontal"
+            size={moderateScale(20)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+        <Pressable
+          style={[styles.circleButton, styles.playButton]}
+          onPress={onPlayPress}>
+          <View style={styles.playIconContainer}>
+            <PlayIcon
+              color={theme.colors.background}
+              size={moderateScale(16)}
+            />
           </View>
-        </View>
+        </Pressable>
+        <Pressable style={styles.circleButton} onPress={onShufflePress}>
+          <ShuffleIcon color={theme.colors.text} size={moderateScale(20)} />
+        </Pressable>
       </View>
     </View>
   );
@@ -156,7 +112,7 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
       width: '100%',
       alignItems: 'center',
       paddingTop: insets.top + moderateScale(40),
-      paddingBottom: moderateScale(30),
+      paddingBottom: moderateScale(10),
       overflow: 'hidden',
       backgroundColor: theme.colors.background,
     },
@@ -196,23 +152,14 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
       textAlign: 'center',
       marginBottom: moderateScale(8),
     },
-    contentWrapper: {
-      paddingHorizontal: moderateScale(16),
-    },
     actionButtons: {
       flexDirection: 'row',
-      justifyContent: 'space-between',
+      justifyContent: 'center',
       alignItems: 'center',
-      paddingVertical: moderateScale(5),
-      paddingHorizontal: moderateScale(5),
-    },
-    spacer: {
-      width: moderateScale(40),
-    },
-    rightAlignedButtons: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: moderateScale(8),
+      paddingTop: moderateScale(4),
+      paddingBottom: moderateScale(12),
+      paddingHorizontal: moderateScale(20),
+      gap: moderateScale(16),
     },
     circleButton: {
       width: moderateScale(42),

--- a/components/reciter-downloads/ReciterDownloadsList.tsx
+++ b/components/reciter-downloads/ReciterDownloadsList.tsx
@@ -336,6 +336,33 @@ export const ReciterDownloadsList: React.FC<ReciterDownloadsListProps> = ({
     [handleTrackPress, addToQueue, handleRemoveDownload],
   );
 
+  const handleRemoveAllDownloads = useCallback(() => {
+    SheetManager.show('collection-options', {
+      payload: {
+        title: reciter?.name || 'Downloads',
+        subtitle: `${reciterDownloads.length} ${
+          reciterDownloads.length === 1 ? 'surah' : 'surahs'
+        } downloaded`,
+        options: [
+          {
+            label: 'Remove All Downloads',
+            icon: 'trash-2',
+            destructive: true,
+            onPress: async () => {
+              for (const d of reciterDownloads) {
+                await removeDownload(
+                  d.reciterId,
+                  d.surahId,
+                  d.rewayatId || undefined,
+                );
+              }
+            },
+          },
+        ],
+      },
+    });
+  }, [reciterDownloads, reciter?.name, removeDownload]);
+
   const ListHeaderComponent = useCallback(() => {
     return (
       <ReciterDownloadsHeader
@@ -347,6 +374,7 @@ export const ReciterDownloadsList: React.FC<ReciterDownloadsListProps> = ({
         } downloaded`}
         onPlayPress={handlePlayAll}
         onShufflePress={handleShuffle}
+        onOptionsPress={handleRemoveAllDownloads}
         theme={theme}
       />
     );
@@ -356,6 +384,7 @@ export const ReciterDownloadsList: React.FC<ReciterDownloadsListProps> = ({
     downloadData.length,
     handlePlayAll,
     handleShuffle,
+    handleRemoveAllDownloads,
     theme,
   ]);
 

--- a/components/search/ExploreView.tsx
+++ b/components/search/ExploreView.tsx
@@ -326,14 +326,6 @@ const createStyles = (theme: ReturnType<typeof useTheme>['theme']) =>
     bentoTile: {
       borderRadius: moderateScale(10),
       overflow: 'hidden',
-      elevation: 3,
-      shadowColor: '#000',
-      shadowOffset: {
-        width: 0,
-        height: 2,
-      },
-      shadowOpacity: 0.1,
-      shadowRadius: 4,
     },
     tileButton: {
       flex: 1,

--- a/components/sheets/CollectionOptionsSheet.tsx
+++ b/components/sheets/CollectionOptionsSheet.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import {View, Text, Pressable} from 'react-native';
+import {ScaledSheet, moderateScale} from 'react-native-size-matters';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import ActionSheet, {
+  SheetProps,
+  SheetManager,
+} from 'react-native-actions-sheet';
+import {Feather} from '@expo/vector-icons';
+import Color from 'color';
+
+export const CollectionOptionsSheet = (
+  props: SheetProps<'collection-options'>,
+) => {
+  const {theme} = useTheme();
+  const styles = createStyles(theme);
+
+  const payload = props.payload;
+  const title = payload?.title ?? '';
+  const subtitle = payload?.subtitle;
+  const options = payload?.options ?? [];
+
+  return (
+    <ActionSheet
+      id={props.sheetId}
+      containerStyle={styles.sheetContainer}
+      indicatorStyle={styles.indicator}
+      gestureEnabled={true}>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>{title}</Text>
+          {subtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
+        </View>
+        <View style={styles.optionsGrid}>
+          {options.map((opt, i) => (
+            <Pressable
+              key={i}
+              style={({pressed}) => [
+                opt.destructive ? styles.optionDestructive : styles.option,
+                pressed &&
+                  (opt.destructive
+                    ? styles.optionDestructivePressed
+                    : styles.optionPressed),
+                opt.disabled && styles.optionDisabled,
+              ]}
+              onPress={() => {
+                SheetManager.hide('collection-options');
+                opt.onPress();
+              }}
+              disabled={opt.disabled}>
+              {opt.customIcon || (
+                <Feather
+                  name={opt.icon as any}
+                  size={moderateScale(20)}
+                  color={opt.destructive ? '#ff4444' : theme.colors.text}
+                />
+              )}
+              <Text
+                style={
+                  opt.destructive
+                    ? styles.optionTextDestructive
+                    : styles.optionText
+                }>
+                {opt.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    </ActionSheet>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  ScaledSheet.create({
+    sheetContainer: {
+      backgroundColor: theme.colors.background,
+      borderTopLeftRadius: moderateScale(20),
+      borderTopRightRadius: moderateScale(20),
+      paddingTop: moderateScale(8),
+    },
+    indicator: {
+      backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
+      width: moderateScale(40),
+    },
+    container: {
+      paddingHorizontal: moderateScale(20),
+      paddingBottom: moderateScale(40),
+    },
+    header: {
+      alignItems: 'center',
+      marginTop: moderateScale(8),
+      marginBottom: moderateScale(20),
+      gap: moderateScale(4),
+    },
+    title: {
+      fontSize: moderateScale(20),
+      fontFamily: 'Manrope-Bold',
+      color: theme.colors.text,
+      textAlign: 'center',
+    },
+    subtitle: {
+      fontSize: moderateScale(14),
+      fontFamily: 'Manrope-Medium',
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
+    },
+    optionsGrid: {
+      gap: moderateScale(8),
+    },
+    option: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: moderateScale(16),
+      paddingHorizontal: moderateScale(16),
+      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
+      borderRadius: moderateScale(12),
+    },
+    optionDisabled: {
+      opacity: 0.5,
+    },
+    optionPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+    },
+    optionDestructive: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: moderateScale(16),
+      paddingHorizontal: moderateScale(16),
+      backgroundColor: 'rgba(255, 68, 68, 0.1)',
+      borderRadius: moderateScale(12),
+    },
+    optionDestructivePressed: {
+      backgroundColor: 'rgba(255, 68, 68, 0.18)',
+    },
+    optionText: {
+      flex: 1,
+      fontSize: moderateScale(15),
+      fontFamily: 'Manrope-SemiBold',
+      color: theme.colors.text,
+      marginLeft: moderateScale(12),
+    },
+    optionTextDestructive: {
+      flex: 1,
+      fontSize: moderateScale(15),
+      fontFamily: 'Manrope-SemiBold',
+      color: '#ff4444',
+      marginLeft: moderateScale(12),
+    },
+  });

--- a/components/sheets/SelectPlaylistSheet.tsx
+++ b/components/sheets/SelectPlaylistSheet.tsx
@@ -28,6 +28,7 @@ export const SelectPlaylistSheet = (props: SheetProps<'select-playlist'>) => {
   const surah = payload?.surah;
   const reciterId = payload?.reciterId ?? '';
   const rewayatId = payload?.rewayatId;
+  const userRecitationId = payload?.userRecitationId;
 
   // Calculate loved state
   const isLovedState = reciterId
@@ -50,6 +51,7 @@ export const SelectPlaylistSheet = (props: SheetProps<'select-playlist'>) => {
           surah.id.toString(),
           reciterId,
           rewayatId,
+          userRecitationId,
         );
 
         console.log(`Added ${surah.name} to playlist`);
@@ -59,7 +61,7 @@ export const SelectPlaylistSheet = (props: SheetProps<'select-playlist'>) => {
         Alert.alert('Error', 'Failed to add surah to playlist');
       }
     },
-    [surah, reciterId, rewayatId, addToPlaylist, handleClose],
+    [surah, reciterId, rewayatId, userRecitationId, addToPlaylist, handleClose],
   );
 
   // Get existing playlist colors for unique color selection
@@ -89,6 +91,7 @@ export const SelectPlaylistSheet = (props: SheetProps<'select-playlist'>) => {
           surah.id.toString(),
           reciterId,
           rewayatId,
+          userRecitationId,
         );
 
         console.log(
@@ -114,8 +117,13 @@ export const SelectPlaylistSheet = (props: SheetProps<'select-playlist'>) => {
 
   const handleToggleLoved = useCallback(() => {
     if (!reciterId || !surah) return;
-    toggleLoved(reciterId, surah.id.toString(), rewayatId || '');
-  }, [reciterId, surah, rewayatId, toggleLoved]);
+    toggleLoved(
+      reciterId,
+      surah.id.toString(),
+      rewayatId || '',
+      userRecitationId,
+    );
+  }, [reciterId, surah, rewayatId, userRecitationId, toggleLoved]);
 
   if (!surah) {
     return null;

--- a/components/sheets/SurahOptionsSheet.tsx
+++ b/components/sheets/SurahOptionsSheet.tsx
@@ -71,6 +71,7 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
   const reciterId = payload?.reciterId;
   const rewayatId = payload?.rewayatId;
   const onAddToQueue = payload?.onAddToQueue;
+  const onRemoveFromPlaylist = payload?.onRemoveFromPlaylist;
 
   const surahId = surah?.id?.toString() ?? '';
   const currentSurahInfo = surah ? surahInfo[surah.id] : null;
@@ -216,6 +217,11 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
     setDownloadProgress,
     downloadId,
   ]);
+
+  const handleRemoveFromPlaylist = useCallback(() => {
+    handleClose();
+    onRemoveFromPlaylist?.();
+  }, [onRemoveFromPlaylist, handleClose]);
 
   const handleAddToPlaylist = useCallback(() => {
     if (!reciterId || !surah) return;
@@ -411,6 +417,27 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
               />
               <Text style={styles.optionText}>Learn About Surah</Text>
             </TouchableOpacity>
+
+            {onRemoveFromPlaylist && (
+              <TouchableOpacity
+                style={[
+                  styles.optionDestructive,
+                  pressedOption === 'remove' && styles.optionDestructivePressed,
+                ]}
+                onPress={handleRemoveFromPlaylist}
+                onPressIn={() => setPressedOption('remove')}
+                onPressOut={() => setPressedOption(null)}
+                activeOpacity={1}>
+                <Feather
+                  name="minus-circle"
+                  size={moderateScale(20)}
+                  color="#ff4444"
+                />
+                <Text style={styles.optionTextDestructive}>
+                  Remove from Playlist
+                </Text>
+              </TouchableOpacity>
+            )}
           </View>
         </View>
       )}
@@ -484,6 +511,24 @@ const createStyles = (theme: Theme) =>
     },
     rotatedIcon: {
       transform: [{rotate: '180deg'}],
+    },
+    optionDestructive: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: moderateScale(16),
+      paddingHorizontal: moderateScale(16),
+      backgroundColor: 'rgba(255, 68, 68, 0.1)',
+      borderRadius: moderateScale(12),
+    },
+    optionDestructivePressed: {
+      backgroundColor: 'rgba(255, 68, 68, 0.18)',
+    },
+    optionTextDestructive: {
+      flex: 1,
+      fontSize: moderateScale(15),
+      fontFamily: 'Manrope-SemiBold',
+      color: '#ff4444',
+      marginLeft: moderateScale(12),
     },
     // Surah Info styles
     headerContainer: {

--- a/components/sheets/UploadOptionsSheet.tsx
+++ b/components/sheets/UploadOptionsSheet.tsx
@@ -1,18 +1,55 @@
-import React, {useCallback, useState} from 'react';
-import {View, Text, Pressable, Alert} from 'react-native';
+import React, {useCallback, useState, useMemo} from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  Alert,
+  useWindowDimensions,
+  Dimensions,
+} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
-import {QueueIcon, PlayIcon} from '@/components/Icons';
+import {QueueIcon, HeartIcon, PlayIcon} from '@/components/Icons';
 import ActionSheet, {
   SheetProps,
   SheetManager,
+  ScrollView,
 } from 'react-native-actions-sheet';
 import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {useUploadsStore, getCustomReciterName} from '@/store/uploadsStore';
 import {getSurahById, getReciterName} from '@/services/dataService';
+import {useLoved} from '@/hooks/useLoved';
 import type {UploadedRecitation} from '@/types/uploads';
+import RenderHtml, {
+  MixedStyleDeclaration,
+  RenderHTMLProps,
+  defaultSystemFonts,
+} from 'react-native-render-html';
+
+const surahInfo = require('@/data/surahInfo.json');
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+
+const renderHtmlDefaultProps: Partial<RenderHTMLProps> = {
+  enableExperimentalMarginCollapsing: true,
+  enableExperimentalGhostLinesPrevention: true,
+  enableExperimentalBRCollapsing: true,
+  allowedStyles: [],
+  enableCSSInlineProcessing: true,
+  systemFonts: [
+    ...defaultSystemFonts,
+    'Manrope-Regular',
+    'Manrope-Medium',
+    'Manrope-Bold',
+  ],
+  baseStyle: {
+    color: 'inherit',
+    fontSize: 'inherit',
+    fontFamily: 'Manrope-Regular',
+  },
+};
 
 function stripExtension(filename: string): string {
   return filename.replace(/\.[^/.]+$/, '');
@@ -68,21 +105,66 @@ function getDisplaySubtitle(item: UploadedRecitation): string {
     parts.push(`${mins}:${secs.toString().padStart(2, '0')}`);
   }
 
-  return parts.join(' · ');
+  return parts.join(' \u00B7 ');
 }
 
 export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
   const {theme} = useTheme();
   const styles = createStyles(theme);
-  const [pressedOption, setPressedOption] = useState<string | null>(null);
+  const {width} = useWindowDimensions();
+  const [showSurahInfo, setShowSurahInfo] = useState(false);
 
   const {deleteRecitation} = useUploadsStore();
+  const {isLovedWithRewayat, toggleLoved} = useLoved();
 
   const payload = props.payload;
   const recitation = payload?.recitation;
   const reciterId = payload?.reciterId;
   const onPlay = payload?.onPlay;
   const onAddToQueue = payload?.onAddToQueue;
+
+  const surahNumber = recitation?.surahNumber;
+  const surah = surahNumber ? getSurahById(surahNumber) : null;
+  const surahId = surah?.id?.toString() ?? '';
+  const currentSurahInfo = surah ? surahInfo[surah.id] : null;
+  const isSurahType = recitation?.type === 'surah' && !!surah;
+  const hasSurah = !!surah;
+  const hasReciter = !!reciterId;
+
+  const isLovedState =
+    hasSurah && hasReciter
+      ? isLovedWithRewayat(reciterId!, surahId, '')
+      : false;
+
+  const tagsStyles = useMemo(
+    () => ({
+      div: {
+        color: theme.colors.text,
+        fontSize: moderateScale(16),
+        fontFamily: 'Manrope-Regular',
+        lineHeight: moderateScale(24),
+      } as MixedStyleDeclaration,
+      p: {
+        marginBottom: moderateScale(16),
+      } as MixedStyleDeclaration,
+      a: {
+        color: theme.colors.primary,
+        textDecorationLine: 'underline',
+      } as MixedStyleDeclaration,
+      li: {
+        marginBottom: moderateScale(8),
+      } as MixedStyleDeclaration,
+      ul: {
+        marginBottom: moderateScale(16),
+        paddingLeft: moderateScale(16),
+      } as MixedStyleDeclaration,
+      ol: {
+        marginBottom: moderateScale(16),
+        paddingLeft: moderateScale(16),
+      } as MixedStyleDeclaration,
+    }),
+    [theme.colors.text, theme.colors.primary],
+  );
 
   const handleClose = useCallback(() => {
     SheetManager.hide('upload-options');
@@ -108,6 +190,27 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
     onAddToQueue?.();
   }, [onAddToQueue, handleClose]);
 
+  const handleToggleLove = useCallback(() => {
+    if (!reciterId || !surahId) return;
+    toggleLoved(reciterId, surahId, '', recitation?.id);
+  }, [reciterId, surahId, toggleLoved, recitation?.id]);
+
+  const handleAddToPlaylist = useCallback(() => {
+    if (!reciterId || !surah) return;
+    SheetManager.show('select-playlist', {
+      payload: {
+        surah,
+        reciterId,
+        rewayatId: undefined,
+        userRecitationId: recitation?.id,
+      },
+    });
+  }, [reciterId, surah, recitation?.id]);
+
+  const handleViewInfo = useCallback(() => {
+    setShowSurahInfo(true);
+  }, []);
+
   const handleDelete = useCallback(() => {
     if (!recitation) return;
     const title = getDisplayTitle(recitation);
@@ -128,6 +231,12 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
     );
   }, [recitation, handleClose, deleteRecitation]);
 
+  const handleSheetChange = useCallback((index: number) => {
+    if (index === -1) {
+      setShowSurahInfo(false);
+    }
+  }, []);
+
   if (!recitation) {
     return null;
   }
@@ -138,73 +247,160 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
   return (
     <ActionSheet
       id={props.sheetId}
-      containerStyle={styles.sheetContainer}
+      containerStyle={[
+        styles.sheetContainer,
+        showSurahInfo && styles.sheetContainerExpanded,
+      ]}
       indicatorStyle={styles.indicator}
-      gestureEnabled={true}>
-      <View style={styles.container}>
-        <View style={styles.header}>
-          <Text style={styles.title} numberOfLines={1}>
-            {title}
-          </Text>
-          {subtitle ? (
-            <Text style={styles.subtitle} numberOfLines={1}>
-              {subtitle}
-            </Text>
-          ) : null}
-        </View>
-
-        <View style={styles.optionsGrid}>
-          <Pressable
-            style={({pressed}) => [
-              styles.option,
-              pressed && styles.optionPressed,
-            ]}
-            onPress={handlePlay}>
-            <PlayIcon color={theme.colors.text} size={moderateScale(20)} />
-            <Text style={styles.optionText}>Play Now</Text>
-          </Pressable>
-
-          <Pressable
-            style={({pressed}) => [
-              styles.option,
-              pressed && styles.optionPressed,
-            ]}
-            onPress={handleOrganize}>
-            <Feather
-              name="sliders"
-              size={moderateScale(20)}
-              color={theme.colors.text}
-            />
-            <Text style={styles.optionText}>Edit Details</Text>
-          </Pressable>
-
-          <Pressable
-            style={({pressed}) => [
-              styles.option,
-              pressed && styles.optionPressed,
-            ]}
-            onPress={handleAddToQueue}>
-            <View style={styles.rotatedIcon}>
-              <QueueIcon
-                color={theme.colors.text}
-                size={moderateScale(20)}
-                filled={true}
-              />
+      gestureEnabled={true}
+      onChange={handleSheetChange}>
+      {showSurahInfo ? (
+        <>
+          <View style={styles.headerContainer}>
+            <Text style={styles.headerTitle}>About {surah?.name}</Text>
+          </View>
+          <ScrollView
+            style={styles.scrollView}
+            showsVerticalScrollIndicator={false}
+            bounces={true}>
+            <View style={styles.infoContent}>
+              <View style={styles.surahInfoHeader}>
+                <Text style={styles.surahInfoName}>{surah?.name}</Text>
+                <Text style={styles.surahInfoTranslation}>
+                  {surah?.translated_name_english}
+                </Text>
+              </View>
+              {currentSurahInfo && (
+                <RenderHtml
+                  {...renderHtmlDefaultProps}
+                  contentWidth={width - moderateScale(72)}
+                  source={{html: `<div>${currentSurahInfo.text}</div>`}}
+                  tagsStyles={tagsStyles}
+                />
+              )}
             </View>
-            <Text style={styles.optionText}>Add to Queue</Text>
-          </Pressable>
+          </ScrollView>
+        </>
+      ) : (
+        <View style={styles.container}>
+          <View style={styles.header}>
+            <Text style={styles.title} numberOfLines={1}>
+              {title}
+            </Text>
+            {subtitle ? (
+              <Text style={styles.subtitle} numberOfLines={1}>
+                {subtitle}
+              </Text>
+            ) : null}
+          </View>
 
-          <Pressable
-            style={({pressed}) => [
-              styles.optionDestructive,
-              pressed && styles.optionDestructivePressed,
-            ]}
-            onPress={handleDelete}>
-            <Feather name="trash-2" size={moderateScale(20)} color="#ff4444" />
-            <Text style={styles.optionTextDestructive}>Delete</Text>
-          </Pressable>
+          <View style={styles.optionsGrid}>
+            <Pressable
+              style={({pressed}) => [
+                styles.option,
+                pressed && styles.optionPressed,
+              ]}
+              onPress={handlePlay}>
+              <PlayIcon color={theme.colors.text} size={moderateScale(20)} />
+              <Text style={styles.optionText}>Play Now</Text>
+            </Pressable>
+
+            <Pressable
+              style={({pressed}) => [
+                styles.option,
+                pressed && styles.optionPressed,
+              ]}
+              onPress={handleOrganize}>
+              <Feather
+                name="sliders"
+                size={moderateScale(20)}
+                color={theme.colors.text}
+              />
+              <Text style={styles.optionText}>Edit Details</Text>
+            </Pressable>
+
+            <Pressable
+              style={({pressed}) => [
+                styles.option,
+                pressed && styles.optionPressed,
+              ]}
+              onPress={handleAddToQueue}>
+              <View style={styles.rotatedIcon}>
+                <QueueIcon
+                  color={theme.colors.text}
+                  size={moderateScale(20)}
+                  filled={true}
+                />
+              </View>
+              <Text style={styles.optionText}>Add to Queue</Text>
+            </Pressable>
+
+            {hasSurah && hasReciter && (
+              <Pressable
+                style={({pressed}) => [
+                  styles.option,
+                  pressed && styles.optionPressed,
+                ]}
+                onPress={handleToggleLove}>
+                <HeartIcon
+                  color={theme.colors.text}
+                  size={moderateScale(20)}
+                  filled={isLovedState}
+                />
+                <Text style={styles.optionText}>
+                  {isLovedState ? 'Remove from Loved' : 'Add to Loved'}
+                </Text>
+              </Pressable>
+            )}
+
+            {hasSurah && hasReciter && (
+              <Pressable
+                style={({pressed}) => [
+                  styles.option,
+                  pressed && styles.optionPressed,
+                ]}
+                onPress={handleAddToPlaylist}>
+                <Feather
+                  name="plus-circle"
+                  size={moderateScale(20)}
+                  color={theme.colors.text}
+                />
+                <Text style={styles.optionText}>Add to Collection</Text>
+              </Pressable>
+            )}
+
+            {hasSurah && (
+              <Pressable
+                style={({pressed}) => [
+                  styles.option,
+                  pressed && styles.optionPressed,
+                ]}
+                onPress={handleViewInfo}>
+                <Feather
+                  name="info"
+                  size={moderateScale(20)}
+                  color={theme.colors.text}
+                />
+                <Text style={styles.optionText}>Learn About Surah</Text>
+              </Pressable>
+            )}
+
+            <Pressable
+              style={({pressed}) => [
+                styles.optionDestructive,
+                pressed && styles.optionDestructivePressed,
+              ]}
+              onPress={handleDelete}>
+              <Feather
+                name="trash-2"
+                size={moderateScale(20)}
+                color="#ff4444"
+              />
+              <Text style={styles.optionTextDestructive}>Delete</Text>
+            </Pressable>
+          </View>
         </View>
-      </View>
+      )}
     </ActionSheet>
   );
 };
@@ -216,6 +412,9 @@ const createStyles = (theme: Theme) =>
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
+    },
+    sheetContainerExpanded: {
+      height: SCREEN_HEIGHT * 0.85,
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
@@ -284,5 +483,41 @@ const createStyles = (theme: Theme) =>
     },
     rotatedIcon: {
       transform: [{rotate: '180deg'}],
+    },
+    headerContainer: {
+      alignItems: 'center',
+      paddingVertical: moderateScale(16),
+      borderBottomWidth: 1,
+      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+    },
+    headerTitle: {
+      fontSize: moderateScale(18),
+      fontFamily: 'Manrope-Bold',
+      color: theme.colors.text,
+    },
+    scrollView: {
+      flex: 1,
+    },
+    infoContent: {
+      paddingHorizontal: moderateScale(20),
+      paddingBottom: moderateScale(40),
+    },
+    surahInfoHeader: {
+      alignItems: 'center',
+      marginVertical: moderateScale(16),
+      gap: moderateScale(4),
+    },
+    surahInfoName: {
+      fontSize: moderateScale(24),
+      fontFamily: 'Manrope-Bold',
+      color: theme.colors.text,
+      textAlign: 'center',
+    },
+    surahInfoTranslation: {
+      fontSize: moderateScale(16),
+      fontFamily: 'Manrope-Medium',
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
+      marginBottom: moderateScale(16),
     },
   });

--- a/components/sheets/sheets.tsx
+++ b/components/sheets/sheets.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {SheetDefinition, registerSheet} from 'react-native-actions-sheet';
 import {Surah} from '@/data/surahData';
 import type {RewayatStyle} from '@/types/reciter';
@@ -23,6 +24,7 @@ import {DownloadOptionsSheet} from './DownloadOptionsSheet';
 import {UploadOptionsSheet} from './UploadOptionsSheet';
 import {AddToCollectionSheet} from './AddToCollectionSheet';
 import {AmbientSoundsSheet} from './AmbientSoundsSheet';
+import {CollectionOptionsSheet} from './CollectionOptionsSheet';
 
 // Register all sheets
 registerSheet('surah-options', SurahOptionsSheet);
@@ -43,6 +45,7 @@ registerSheet('download-options', DownloadOptionsSheet);
 registerSheet('upload-options', UploadOptionsSheet);
 registerSheet('add-to-collection', AddToCollectionSheet);
 registerSheet('ambient-sounds', AmbientSoundsSheet);
+registerSheet('collection-options', CollectionOptionsSheet);
 
 // Type definitions for payloads
 declare module 'react-native-actions-sheet' {
@@ -53,6 +56,7 @@ declare module 'react-native-actions-sheet' {
         reciterId?: string;
         rewayatId?: string;
         onAddToQueue?: (surah: Surah) => Promise<void>;
+        onRemoveFromPlaylist?: () => void;
       };
     }>;
     'rewayat-info': SheetDefinition<{
@@ -74,6 +78,7 @@ declare module 'react-native-actions-sheet' {
         surah: Surah;
         reciterId: string;
         rewayatId?: string;
+        userRecitationId?: string;
       };
     }>;
     'playlist-context': SheetDefinition<{
@@ -157,6 +162,20 @@ declare module 'react-native-actions-sheet' {
     }>;
     'add-to-collection': SheetDefinition;
     'ambient-sounds': SheetDefinition;
+    'collection-options': SheetDefinition<{
+      payload: {
+        title: string;
+        subtitle?: string;
+        options: Array<{
+          label: string;
+          icon: string;
+          onPress: () => void;
+          destructive?: boolean;
+          disabled?: boolean;
+          customIcon?: React.ReactNode;
+        }>;
+      };
+    }>;
   }
 }
 

--- a/hooks/useLoved.ts
+++ b/hooks/useLoved.ts
@@ -8,6 +8,7 @@ interface UseLoved {
     surahId: string;
     rewayatId: string;
     timestamp: number;
+    userRecitationId?: string;
   }>;
   isLoved: (reciterId: string, surahId: string | number) => boolean;
   isLovedWithRewayat: (
@@ -19,9 +20,11 @@ interface UseLoved {
     reciterId: string,
     surahId: string | number,
     rewayatId: string,
+    userRecitationId?: string,
   ) => void;
   isTrackLoved: (track: Track) => boolean;
   toggleTrackLoved: (track: Track) => void;
+  unloveAll: () => void;
 }
 
 export const useLoved = (): UseLoved => {
@@ -30,6 +33,7 @@ export const useLoved = (): UseLoved => {
     toggleLoved: toggleLovedBase,
     isLoved: isLovedBase,
     isLovedWithRewayat: isLovedWithRewayatBase,
+    clearLoved: clearLovedBase,
   } = useLovedStore();
 
   const isLoved = useCallback(
@@ -47,8 +51,18 @@ export const useLoved = (): UseLoved => {
   );
 
   const toggleLoved = useCallback(
-    (reciterId: string, surahId: string | number, rewayatId: string) => {
-      toggleLovedBase(reciterId, surahId.toString(), rewayatId);
+    (
+      reciterId: string,
+      surahId: string | number,
+      rewayatId: string,
+      userRecitationId?: string,
+    ) => {
+      toggleLovedBase(
+        reciterId,
+        surahId.toString(),
+        rewayatId,
+        userRecitationId,
+      );
     },
     [toggleLovedBase],
   );
@@ -71,6 +85,10 @@ export const useLoved = (): UseLoved => {
     [toggleLoved],
   );
 
+  const unloveAll = useCallback(() => {
+    clearLovedBase();
+  }, [clearLovedBase]);
+
   return {
     lovedTracks,
     isLoved,
@@ -78,5 +96,6 @@ export const useLoved = (): UseLoved => {
     toggleLoved,
     isTrackLoved,
     toggleTrackLoved,
+    unloveAll,
   };
 };

--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -8,8 +8,6 @@ type BrowseSortOption = 'asc' | 'desc' | 'revelation';
 type ReciterProfileViewMode = 'card' | 'list';
 type ReciterProfileSortOption = 'asc' | 'desc' | 'revelation'; // Add revelation option
 
-type CollectionViewMode = 'grid' | 'list';
-
 interface SettingsState {
   askEveryTime: boolean;
   setAskEveryTime: (value: boolean) => void;
@@ -28,9 +26,6 @@ interface SettingsState {
   setReciterProfileViewMode: (mode: ReciterProfileViewMode) => void;
   reciterProfileSortOption: ReciterProfileSortOption;
   setReciterProfileSortOption: (option: ReciterProfileSortOption) => void;
-  // Collection settings
-  collectionViewMode: CollectionViewMode;
-  setCollectionViewMode: (mode: CollectionViewMode) => void;
   // Onboarding tracking
   recitersViewOpenCount: number;
   incrementRecitersViewOpenCount: () => void;
@@ -66,9 +61,6 @@ export const useSettings = create<SettingsState>()(
       reciterProfileSortOption: 'asc' as ReciterProfileSortOption, // Default to ascending sort
       setReciterProfileSortOption: (option: ReciterProfileSortOption) =>
         set({reciterProfileSortOption: option}),
-      collectionViewMode: 'grid' as CollectionViewMode, // Default to grid view
-      setCollectionViewMode: (mode: CollectionViewMode) =>
-        set({collectionViewMode: mode}),
       recitersViewOpenCount: 0,
       incrementRecitersViewOpenCount: () =>
         set(state => ({

--- a/services/database/DatabaseService.ts
+++ b/services/database/DatabaseService.ts
@@ -18,6 +18,7 @@ export interface PlaylistItem {
   rewayatId?: string;
   orderIndex: number;
   addedAt: number;
+  userRecitationId?: string;
 }
 
 // Database row types
@@ -39,6 +40,7 @@ interface PlaylistItemRow {
   rewayat_id: string | null;
   order_index: number;
   added_at: number;
+  user_recitation_id: string | null;
 }
 
 interface MaxOrderRow {
@@ -107,9 +109,18 @@ class DatabaseService {
       );
     `);
 
+    // Migration: add user_recitation_id column if it doesn't exist
+    try {
+      await this.db.execAsync(
+        `ALTER TABLE playlist_items ADD COLUMN user_recitation_id TEXT;`,
+      );
+    } catch {
+      // Column already exists
+    }
+
     // Create indexes for better performance
     await this.db.execAsync(`
-      CREATE INDEX IF NOT EXISTS idx_playlist_items_playlist_id 
+      CREATE INDEX IF NOT EXISTS idx_playlist_items_playlist_id
       ON playlist_items(playlist_id);
     `);
 
@@ -274,8 +285,8 @@ class DatabaseService {
     const db = this.db;
     await db.withTransactionAsync(async () => {
       await db.runAsync(
-        `INSERT INTO playlist_items (id, playlist_id, surah_id, reciter_id, rewayat_id, order_index, added_at) 
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO playlist_items (id, playlist_id, surah_id, reciter_id, rewayat_id, order_index, added_at, user_recitation_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           item.id,
           item.playlistId,
@@ -284,6 +295,7 @@ class DatabaseService {
           item.rewayatId || null,
           item.orderIndex,
           item.addedAt,
+          item.userRecitationId || null,
         ],
       );
     });
@@ -305,6 +317,7 @@ class DatabaseService {
       rewayatId: item.rewayat_id || undefined,
       orderIndex: item.order_index,
       addedAt: item.added_at,
+      userRecitationId: item.user_recitation_id || undefined,
     }));
   }
 

--- a/services/player/store/lovedStore.ts
+++ b/services/player/store/lovedStore.ts
@@ -9,6 +9,7 @@ export interface LovedTrack {
   surahId: string;
   rewayatId: string;
   timestamp: number;
+  userRecitationId?: string;
 }
 
 interface LovedTracksState {
@@ -20,7 +21,12 @@ interface LovedTracksState {
   lastSynced: number | null;
 
   // Actions
-  toggleLoved: (reciterId: string, surahId: string, rewayatId: string) => void;
+  toggleLoved: (
+    reciterId: string,
+    surahId: string,
+    rewayatId: string,
+    userRecitationId?: string,
+  ) => void;
   isLoved: (reciterId: string, surahId: string) => boolean;
   isLovedWithRewayat: (
     reciterId: string,
@@ -47,7 +53,12 @@ export const useLovedStore = create<LovedTracksState>()(
       lastSynced: null,
 
       // Core actions
-      toggleLoved: (reciterId: string, surahId: string, rewayatId: string) => {
+      toggleLoved: (
+        reciterId: string,
+        surahId: string,
+        rewayatId: string,
+        userRecitationId?: string,
+      ) => {
         set(state => {
           // Check if a track exists with either the new format (with rewayatId)
           // or the old format (without rewayatId)
@@ -68,7 +79,13 @@ export const useLovedStore = create<LovedTracksState>()(
           } else {
             // Add to the beginning so most recent is first
             newTracks = [
-              {reciterId, surahId, rewayatId, timestamp: Date.now()},
+              {
+                reciterId,
+                surahId,
+                rewayatId,
+                timestamp: Date.now(),
+                userRecitationId,
+              },
               ...state.tracks,
             ];
           }

--- a/services/playlist/PlaylistService.ts
+++ b/services/playlist/PlaylistService.ts
@@ -64,6 +64,7 @@ class PlaylistService {
     surahId: string,
     reciterId: string,
     rewayatId?: string,
+    userRecitationId?: string,
   ): Promise<void> {
     await this.initialize();
 
@@ -87,6 +88,7 @@ class PlaylistService {
       rewayatId,
       orderIndex,
       addedAt: Date.now(),
+      userRecitationId,
     };
 
     // Wrap both operations in a single transaction

--- a/store/playlistsStore.ts
+++ b/store/playlistsStore.ts
@@ -31,6 +31,7 @@ interface PlaylistsState {
     surahId: string,
     reciterId: string,
     rewayatId?: string,
+    userRecitationId?: string,
   ) => Promise<void>;
   removeFromPlaylist: (itemId: string) => Promise<void>;
   reorderPlaylistItems: (
@@ -168,6 +169,7 @@ export const usePlaylistsStore = create<PlaylistsState>((set, get) => ({
     surahId: string,
     reciterId: string,
     rewayatId?: string,
+    userRecitationId?: string,
   ) => {
     try {
       set({error: null});
@@ -176,6 +178,7 @@ export const usePlaylistsStore = create<PlaylistsState>((set, get) => ({
         surahId,
         reciterId,
         rewayatId,
+        userRecitationId,
       );
       // Refresh to update item counts
       await get().loadPlaylists();

--- a/store/uploadsStore.ts
+++ b/store/uploadsStore.ts
@@ -30,6 +30,7 @@ interface UploadsState {
   ) => Promise<UploadedRecitation[]>;
   updateTags: (id: string, tags: Partial<UploadedRecitation>) => Promise<void>;
   deleteRecitation: (id: string) => Promise<void>;
+  deleteAllRecitations: () => Promise<void>;
   refreshRecitations: () => Promise<void>;
 
   // Custom reciters
@@ -150,6 +151,22 @@ export const useUploadsStore = create<UploadsState>((set, get) => ({
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to delete recitation';
+      set({error: errorMessage});
+      throw err;
+    }
+  },
+
+  deleteAllRecitations: async () => {
+    try {
+      set({error: null});
+      const {recitations} = get();
+      for (const r of recitations) {
+        await uploadsService.deleteRecitation(r.id);
+      }
+      set({recitations: [], totalCount: 0});
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to delete all recitations';
       set({error: errorMessage});
       throw err;
     }


### PR DESCRIPTION
## Summary
- **Upload now-playing indicator**: Added `userRecitationId` prop to TrackItem so upload tracks correctly show the now-playing animation in Loved and Playlist screens (previously failed due to rewayatId mismatch)
- **Extended upload options**: Relaxed UploadOptionsSheet gates from `isSurahType` to `hasSurah` — uploads tagged with reciter + surah but type !== 'surah' now show Love, Add to Collection, and Learn About Surah options
- **Remove from Playlist**: Added destructive "Remove from Playlist" option to SurahOptionsSheet, wired from PlaylistDetail via `onRemoveFromPlaylist` callback — only appears in playlist context
- Collection enhancements: redesigned tabs, sticky headers, collection options sheets

## Test plan
- [ ] Play an uploaded recitation from the Loved screen → TrackItem should show GradientText + NowPlayingIndicator
- [ ] Same test from a Playlist detail screen
- [ ] Upload a recitation tagged with reciter + surah but type 'other' → open options → Love and Add to Collection should appear
- [ ] Untagged upload (no reciter/surah) → Love and Collection should remain hidden
- [ ] Open a playlist → tap options on a track → "Remove from Playlist" appears → tap it → track removed
- [ ] Options from reciter profile / loved screen / downloads should NOT show "Remove from Playlist"

🤖 Generated with [Claude Code](https://claude.com/claude-code)