### PR TITLE
perf(android): player performance + gesture fixes

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -157,6 +157,7 @@ module.exports = {
         },
       ],
       './withAndroidSigning.js',
+      './withLargeHeap.js',
       './withIOSTeam.js',
     ],
   },

--- a/app/(tabs)/(a.home)/_layout.tsx
+++ b/app/(tabs)/(a.home)/_layout.tsx
@@ -2,7 +2,7 @@ import {Stack} from 'expo-router';
 
 export default function HomeLayout() {
   return (
-    <Stack screenOptions={{headerShown: false}}>
+    <Stack screenOptions={{headerShown: false, freezeOnBlur: true}}>
       <Stack.Screen name="index" options={{headerShown: false}} />
       <Stack.Screen name="reciter/[id]" options={{headerShown: false}} />
       <Stack.Screen name="reciter/browse" options={{headerShown: false}} />

--- a/app/(tabs)/(a.home)/index.tsx
+++ b/app/(tabs)/(a.home)/index.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useCallback} from 'react';
 import {
   View,
-  TouchableOpacity,
+  Pressable,
   ScrollView,
   StyleSheet,
   Platform,
@@ -139,8 +139,7 @@ const Header = React.memo(
               onSelect={handleToggle}
             />
           </View>
-          <TouchableOpacity
-            activeOpacity={0.7}
+          <Pressable
             style={headerStyles.settingsButton}
             onPress={handleSettingsPress}>
             <AntDesign
@@ -148,7 +147,7 @@ const Header = React.memo(
               size={moderateScale(20)}
               color={theme.colors.textSecondary}
             />
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </Animated.View>
     );

--- a/app/(tabs)/(c.collection)/_layout.tsx
+++ b/app/(tabs)/(c.collection)/_layout.tsx
@@ -6,6 +6,7 @@ export default function CollectionLayout() {
     <Stack
       screenOptions={{
         headerShown: false,
+        freezeOnBlur: true,
       }}>
       <Stack.Screen name="index" />
       <Stack.Screen name="reciter/[id]" />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,6 +15,7 @@ import {
   Platform,
   StatusBar as RNStatusBar,
   Appearance,
+  InteractionManager,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {ThemeProvider} from '@react-navigation/native';
@@ -31,7 +32,7 @@ import {
   configureReanimatedLogger,
   ReanimatedLogLevel,
 } from 'react-native-reanimated';
-import {preloadTajweedDataWithTimeout} from '@/utils/tajweedLoader';
+import {preloadTajweedData} from '@/utils/tajweedLoader';
 import {appInitializer} from '@/services/AppInitializer';
 import {ExpoAudioProvider} from '@/services/audio';
 import {expoAudioService} from '@/services/audio/ExpoAudioService';
@@ -63,7 +64,6 @@ SystemUI.setBackgroundColorAsync(
 export default function RootLayout() {
   const [appIsReady, setAppIsReady] = useState(false);
   const [isPlayerReady, setIsPlayerReady] = useState(false);
-  const [isTajweedLoading, setIsTajweedLoading] = useState(false);
   const [setupError, setSetupError] = useState<Error | null>(null);
   const router = useRouter();
   const initializationRef = useRef(false);
@@ -128,29 +128,20 @@ export default function RootLayout() {
     resetOnBackground: true,
   });
 
-  // Preload Tajweed data once when the app starts
+  // Background initialization: SQLite services + deferred tajweed preload
   useEffect(() => {
-    if (!isTajweedLoading) {
-      setIsTajweedLoading(true);
+    // SQLite services (non-blocking)
+    appInitializer
+      .initialize()
+      .catch(err =>
+        console.error('[App] Failed to initialize SQLite services:', err),
+      );
+
+    // Tajweed data — defer until after first frame + interactions complete
+    InteractionManager.runAfterInteractions(() => {
       if (__DEV__) console.log('[App] Preloading tajweed data...');
-      preloadTajweedDataWithTimeout();
-    }
-  }, [isTajweedLoading]);
-
-  // Initialize all SQLite-based services in the background
-  useEffect(() => {
-    const initializeServices = async () => {
-      try {
-        if (__DEV__) console.log('[App] Initializing SQLite services...');
-        await appInitializer.initialize();
-        if (__DEV__)
-          console.log('[App] SQLite services initialized successfully');
-      } catch (error) {
-        console.error('[App] Failed to initialize SQLite services:', error);
-      }
-    };
-
-    initializeServices();
+      preloadTajweedData();
+    });
   }, []);
 
   const onLayoutRootView = useCallback(async () => {
@@ -217,20 +208,10 @@ export default function RootLayout() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Handle navigation after initialization
-  useEffect(() => {
-    if (!appIsReady || !fontsLoaded || !isPlayerReady || fontError) {
-      return;
-    }
-  }, [appIsReady, fontsLoaded, fontError, isPlayerReady, router]);
-
-  // Set native root view background to match theme (prevents white flash during transitions)
+  // Set native root view background + configure Android navigation bar to match theme
   useEffect(() => {
     SystemUI.setBackgroundColorAsync(theme.colors.background);
-  }, [theme.colors.background]);
 
-  // Configure Android navigation bar to match theme
-  useEffect(() => {
     async function setupNavigationBar() {
       if (Platform.OS === 'android') {
         try {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -46,6 +46,9 @@ configureReanimatedLogger({
   strict: false,
 });
 
+// Cache for expo-navigation-bar module (Android only)
+let NavigationBarModule: any = null;
+
 // Prevent the splash screen from auto-hiding
 SplashScreen.preventAutoHideAsync().catch(() => {
   /* reloading the app might trigger some race conditions, ignore them */
@@ -231,19 +234,21 @@ export default function RootLayout() {
     async function setupNavigationBar() {
       if (Platform.OS === 'android') {
         try {
-          const NavigationBar = await import('expo-navigation-bar').then(
-            module => module.default,
-          );
+          if (!NavigationBarModule) {
+            NavigationBarModule = await import('expo-navigation-bar').then(
+              module => module.default,
+            );
+            RNStatusBar.setTranslucent(true);
+          }
 
-          if (NavigationBar) {
-            await NavigationBar.setBackgroundColorAsync(
+          if (NavigationBarModule) {
+            await NavigationBarModule.setBackgroundColorAsync(
               theme.colors.background,
             );
-            await NavigationBar.setButtonStyleAsync(
+            await NavigationBarModule.setButtonStyleAsync(
               isDarkMode ? 'light' : 'dark',
             );
           }
-          RNStatusBar.setTranslucent(true);
         } catch (error) {
           if (__DEV__)
             console.warn(

--- a/components/BottomSheetModal.tsx
+++ b/components/BottomSheetModal.tsx
@@ -110,7 +110,7 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
       enablePanDownToClose={true}
       enableDynamicSizing={false}
       handleComponent={CustomHandle}
-      enableContentPanningGesture={Platform.OS === 'ios'}
+      enableContentPanningGesture
       onClose={onClose}
       style={{
         zIndex: 3000,

--- a/components/BottomTabBar.tsx
+++ b/components/BottomTabBar.tsx
@@ -114,7 +114,7 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({
   const insets = useSafeAreaInsets();
   const iconSize = moderateScale(26, 0.2);
 
-  const bottomPadding = Platform.OS === 'ios' ? insets.bottom : 0;
+  const bottomPadding = insets.bottom;
 
   const styles = useMemo(
     () =>

--- a/components/browse/BrowseReciterCard.tsx
+++ b/components/browse/BrowseReciterCard.tsx
@@ -128,15 +128,17 @@ const BrowseReciterCard = React.memo(
 
     const handlePressIn = () => {
       scale.value = withSpring(0.95, {
-        damping: 15,
-        stiffness: 300,
+        damping: 20,
+        stiffness: 400,
+        mass: 0.5,
       });
     };
 
     const handlePressOut = () => {
       scale.value = withSpring(1, {
-        damping: 15,
-        stiffness: 300,
+        damping: 20,
+        stiffness: 400,
+        mass: 0.5,
       });
     };
 

--- a/components/cards/CircularReciterCard.tsx
+++ b/components/cards/CircularReciterCard.tsx
@@ -56,15 +56,17 @@ export const CircularReciterCard: React.FC<CircularReciterCardProps> = ({
 
   const handlePressIn = () => {
     scale.value = withSpring(0.92, {
-      damping: 15,
-      stiffness: 300,
+      damping: 20,
+      stiffness: 400,
+      mass: 0.5,
     });
   };
 
   const handlePressOut = () => {
     scale.value = withSpring(1, {
-      damping: 15,
-      stiffness: 300,
+      damping: 20,
+      stiffness: 400,
+      mass: 0.5,
     });
   };
 

--- a/components/cards/RecentReciterCard.tsx
+++ b/components/cards/RecentReciterCard.tsx
@@ -104,15 +104,17 @@ export const RecentReciterCard = ({
 
   const handlePressIn = () => {
     scale.value = withSpring(0.95, {
-      damping: 15,
-      stiffness: 300,
+      damping: 20,
+      stiffness: 400,
+      mass: 0.5,
     });
   };
 
   const handlePressOut = () => {
     scale.value = withSpring(1, {
-      damping: 15,
-      stiffness: 300,
+      damping: 20,
+      stiffness: 400,
+      mass: 0.5,
     });
   };
 

--- a/components/cards/RewayatCard.tsx
+++ b/components/cards/RewayatCard.tsx
@@ -35,11 +35,11 @@ function RewayatCard({
   }));
 
   const handlePressIn = () => {
-    scale.value = withSpring(0.95, {damping: 15, stiffness: 400});
+    scale.value = withSpring(0.95, {damping: 20, stiffness: 400, mass: 0.5});
   };
 
   const handlePressOut = () => {
-    scale.value = withSpring(1, {damping: 15, stiffness: 400});
+    scale.value = withSpring(1, {damping: 20, stiffness: 400, mass: 0.5});
   };
 
   const styles = useMemo(() => createStyles(theme), [theme]);

--- a/components/hero/RandomRecitationHero.tsx
+++ b/components/hero/RandomRecitationHero.tsx
@@ -87,15 +87,17 @@ export function RandomRecitationHero({
 
   const handlePressIn = () => {
     scale.value = withSpring(0.98, {
-      damping: 15,
-      stiffness: 300,
+      damping: 20,
+      stiffness: 400,
+      mass: 0.5,
     });
   };
 
   const handlePressOut = () => {
     scale.value = withSpring(1, {
-      damping: 15,
-      stiffness: 300,
+      damping: 20,
+      stiffness: 400,
+      mass: 0.5,
     });
   };
 

--- a/components/hero/ScrollingReciters.tsx
+++ b/components/hero/ScrollingReciters.tsx
@@ -434,15 +434,17 @@ export const ScrollingHero = React.memo(
 
     const handlePressIn = () => {
       scale.value = withSpring(0.98, {
-        damping: 15,
-        stiffness: 300,
+        damping: 20,
+        stiffness: 400,
+        mass: 0.5,
       });
     };
 
     const handlePressOut = () => {
       scale.value = withSpring(1, {
-        damping: 15,
-        stiffness: 300,
+        damping: 20,
+        stiffness: 400,
+        mass: 0.5,
       });
     };
 

--- a/components/hero/SurahsHero.tsx
+++ b/components/hero/SurahsHero.tsx
@@ -63,15 +63,17 @@ export const SurahHeroSection = ({
 
   const handlePressIn = () => {
     scale.value = withSpring(0.97, {
-      damping: 15,
-      stiffness: 300,
+      damping: 20,
+      stiffness: 400,
+      mass: 0.5,
     });
   };
 
   const handlePressOut = () => {
     scale.value = withSpring(1, {
-      damping: 15,
-      stiffness: 300,
+      damping: 20,
+      stiffness: 400,
+      mass: 0.5,
     });
   };
 

--- a/components/hero/SurahsHero.tsx
+++ b/components/hero/SurahsHero.tsx
@@ -158,21 +158,21 @@ const createStyles = (theme: Theme) =>
       flex: 1,
     },
     topSection: {
-      marginBottom: moderateScale(6),
+      marginBottom: moderateScale(3),
       alignItems: 'center',
     },
     bottomSection: {
       alignItems: 'center',
     },
     heroGlyph: {
-      fontSize: moderateScale(36),
+      fontSize: moderateScale(30),
       fontFamily: 'SurahNames',
       color: theme.colors.text,
       textShadowColor: 'rgba(0, 0, 0, 0.2)',
       textShadowOffset: {width: 0, height: 1},
       textShadowRadius: 4,
       textAlign: 'center',
-      marginTop: moderateScale(2),
+      marginTop: 0,
     },
     topRow: {
       flexDirection: 'row',
@@ -202,7 +202,7 @@ const createStyles = (theme: Theme) =>
       fontSize: moderateScale(11),
       fontFamily: 'Manrope-Medium',
       color: theme.colors.textSecondary,
-      marginBottom: moderateScale(6),
+      marginBottom: moderateScale(3),
       textAlign: 'center',
     },
     statsRow: {

--- a/components/modals/BaseModal.tsx
+++ b/components/modals/BaseModal.tsx
@@ -94,7 +94,7 @@ export const BaseModal: React.FC<BaseModalProps> = ({
       onChange={onChange}
       style={styles.modal}
       handleComponent={CustomHandle}
-      enableContentPanningGesture={Platform.OS === 'ios'}
+      enableContentPanningGesture
       backgroundStyle={[
         styles.background,
         {backgroundColor: theme.colors.backgroundSecondary},

--- a/components/player/v2/FloatingPlayer/PlayButton.tsx
+++ b/components/player/v2/FloatingPlayer/PlayButton.tsx
@@ -42,7 +42,7 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
     <Pressable
       onPress={handlePress}
       disabled={disabled}
-      style={({pressed}) => [styles.button, {opacity: pressed ? 0.7 : 1}]}>
+      style={styles.button}>
       {optimisticIsPlaying ? (
         <PauseIcon color={theme.colors.text} size={moderateScale(24)} />
       ) : (

--- a/components/player/v2/FloatingPlayer/index.tsx
+++ b/components/player/v2/FloatingPlayer/index.tsx
@@ -243,10 +243,7 @@ export const FloatingPlayer: React.FC = React.memo(function FloatingPlayer() {
             <View style={styles.rightControls}>
               <Pressable
                 onPress={handleLovePress}
-                style={({pressed}) => [
-                  styles.loveButton,
-                  {opacity: pressed ? 0.7 : 1},
-                ]}>
+                style={styles.loveButton}>
                 <Animated.View style={heartAnimatedStyle}>
                   <HeartIcon
                     color={isTrackLoved(currentTrack) ? 'red' : textColor}
@@ -305,10 +302,7 @@ export const FloatingPlayer: React.FC = React.memo(function FloatingPlayer() {
             <View style={styles.rightControls}>
               <Pressable
                 onPress={handleLovePress}
-                style={({pressed}) => [
-                  styles.loveButton,
-                  {opacity: pressed ? 0.7 : 1},
-                ]}>
+                style={styles.loveButton}>
                 <Animated.View style={heartAnimatedStyle}>
                   <HeartIcon
                     color={isTrackLoved(currentTrack) ? 'red' : textColor}

--- a/components/player/v2/PlayerContent/QueueList.tsx
+++ b/components/player/v2/PlayerContent/QueueList.tsx
@@ -1,15 +1,9 @@
 import React from 'react';
-import {
-  View,
-  Text,
-  Pressable,
-  StyleSheet,
-  ScrollView,
-  Platform,
-} from 'react-native';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {Feather} from '@expo/vector-icons';
 import {useTheme} from '@/hooks/useTheme';
+import {BottomSheetScrollView} from '@gorhom/bottom-sheet';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {MaterialCommunityIcons} from '@expo/vector-icons';
 import {TrackItem} from '@/components/TrackItem';
@@ -248,15 +242,12 @@ export const QueueList: React.FC<QueueListProps> = ({
 
   return (
     <View style={styles.container}>
-      <ScrollView
+      <BottomSheetScrollView
         style={styles.list}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
         bounces={true}
-        overScrollMode="never"
-        nestedScrollEnabled={Platform.OS === 'android'}
-        disableScrollViewPanResponder={Platform.OS === 'android'}
-        scrollEventThrottle={16}>
+        overScrollMode="never">
         {/* Header */}
         <View style={[styles.header, {borderBottomColor: theme.colors.border}]}>
           <View style={styles.headerLeft}>
@@ -299,7 +290,7 @@ export const QueueList: React.FC<QueueListProps> = ({
             </Pressable>
           </View>
         ))}
-      </ScrollView>
+      </BottomSheetScrollView>
     </View>
   );
 };

--- a/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
+++ b/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useCallback, useState, useEffect, useRef} from 'react';
+import React, {memo, useCallback, useState} from 'react';
 import {StyleSheet, Pressable, Text, View} from 'react-native';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {Verse} from '@/types/quran';
@@ -6,19 +6,24 @@ import Color from 'color';
 import FormattedTextRenderer from '@/components/utils/FormattedText';
 import {Ionicons} from '@expo/vector-icons';
 import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
+import {useTajweedStore} from '@/store/tajweedStore';
 
-// ---> Load Indopak JSON data
+// ---> Lazy-load Indopak JSON data (1.7MB — only loaded when Indopak font is selected)
 interface IndopakNastaleeqData {
   [verseKey: string]: {text: string};
 }
 let indopakNastaleeqDataCache: IndopakNastaleeqData | null = null;
-try {
-  indopakNastaleeqDataCache = require('@/data/IndopakNastaleeq.json');
-  console.log('[VerseItem] IndopakNastaleeq data pre-cached');
-} catch (error) {
-  console.error('[VerseItem] Error pre-caching Indopak data:', error);
+function getIndopakData(): IndopakNastaleeqData | null {
+  if (!indopakNastaleeqDataCache) {
+    try {
+      indopakNastaleeqDataCache = require('@/data/IndopakNastaleeq.json');
+    } catch (error) {
+      console.error('[VerseItem] Error loading Indopak data:', error);
+    }
+  }
+  return indopakNastaleeqDataCache;
 }
-// <--- End Load Indopak JSON data
+// <--- End Indopak lazy loader
 
 // Define colors for Tajweed rules (adjust these as needed)
 const tajweedColors: {[key: string]: string} = {
@@ -78,8 +83,12 @@ interface SaheehData {
   [verseKey: string]: SaheehFootnoteEntry;
 }
 
+// Load Saheeh data at module scope (require() is cached — zero cost since QuranView already loaded it)
+const saheehDataForFootnotes =
+  require('@/data/SaheehInternational.translation-with-footnote-tags.json') as SaheehData;
+
 interface VerseItemProps {
-  verse: Verse & {processedTajweedAyahData?: ProcessedTajweedWord[]}; // Combine Verse and optional processed data
+  verse: Verse & {translation?: string; transliteration?: string};
   onPress: () => void;
   textColor: string;
   borderColor: string;
@@ -88,8 +97,6 @@ interface VerseItemProps {
   transliterationFontSize: number;
   translationFontSize: number;
   arabicFontSize: number;
-  // Remove legacy tajweedAyahData prop if it exists
-  processedTajweedAyahData?: ProcessedTajweedWord[]; // Keep this prop as it's now passed from QuranView
 }
 
 /**
@@ -103,7 +110,7 @@ TajweedSegment.displayName = 'TajweedSegment';
 
 export const VerseItem = memo<VerseItemProps>(
   ({
-    verse, // Contains processedTajweedAyahData if available
+    verse,
     onPress,
     textColor,
     borderColor,
@@ -112,7 +119,6 @@ export const VerseItem = memo<VerseItemProps>(
     transliterationFontSize: propTransliterationFontSize,
     translationFontSize: propTranslationFontSize,
     arabicFontSize: propArabicFontSize,
-    // processedTajweedAyahData prop is now part of the verse object
   }) => {
     // Get settings from the store
     const {
@@ -124,6 +130,12 @@ export const VerseItem = memo<VerseItemProps>(
       transliterationFontSize: storeTransliterationFontSize,
       arabicFontFamily,
     } = useMushafSettingsStore();
+
+    // Fetch tajweed data directly from store — granular selector means only
+    // the ~10 visible VerseItems re-render when tajweed finishes loading
+    const processedTajweedAyahData = useTajweedStore(
+      s => s.indexedTajweedData?.[verse.verse_key],
+    );
 
     // Use prop values if provided, otherwise use store values
     const showTranslation =
@@ -149,30 +161,11 @@ export const VerseItem = memo<VerseItemProps>(
     const [activeFootnote, setActiveFootnote] = useState<FootnoteData | null>(
       null,
     );
-    // Cache for the Saheeh International data
-    const saheehDataCache = useRef<SaheehData | null>(null);
-    const [isSaheehDataLoaded, setIsSaheehDataLoaded] = useState(false);
-
-    // Load Saheeh International data once
-    useEffect(() => {
-      if (!saheehDataCache.current) {
-        try {
-          saheehDataCache.current = require('@/data/SaheehInternational.translation-with-footnote-tags.json');
-          setIsSaheehDataLoaded(true);
-          console.log('[VerseItem] Saheeh International data loaded.');
-        } catch (error) {
-          console.error(
-            '[VerseItem] Failed to load Saheeh International data:',
-            error,
-          );
-        }
-      }
-    }, []);
 
     const bgColor = Color(textColor).alpha(0.08).toString();
     const footnoteBgColor = Color(textColor).alpha(0.1).toString();
 
-    // Handle footnote press - now uses cached data
+    // Handle footnote press - uses module-scope cached data
     const handleFootnotePress = useCallback(
       (footnoteId: string, footnoteNumber: string) => {
         // If tapping the same footnote again, close it
@@ -180,45 +173,11 @@ export const VerseItem = memo<VerseItemProps>(
           setActiveFootnote(null);
           return;
         }
-        console.log(
-          `[Footnote Press] Verse Key: ${verse.verse_key}, Footnote ID: ${footnoteId}, Number: ${footnoteNumber}`,
-        );
 
-        if (!isSaheehDataLoaded || !saheehDataCache.current) {
-          console.error(
-            '[VerseItem] Saheeh data not loaded yet when trying to access footnote.',
-          );
-          setActiveFootnote({
-            id: footnoteId,
-            number: footnoteNumber,
-            content: 'Error: Footnote data not ready',
-          });
-          return;
-        }
+        const verseData = saheehDataForFootnotes[verse.verse_key];
 
-        const verseData = saheehDataCache.current[verse.verse_key];
-        console.log(
-          '[Footnote Press] Found verseData:',
-          verseData ? 'Yes' : 'No',
-        );
-
-        // --- Start: Additional Logging ---
-        if (verseData) {
-          console.log('[Footnote Press] Inspecting verseData:', verseData);
-          console.log('[Footnote Press] Inspecting verseData.f:', verseData.f);
-          console.log(
-            `[Footnote Press] Keys in verseData.f: ${
-              verseData.f ? Object.keys(verseData.f).join(', ') : 'N/A'
-            }`,
-          );
-        }
-        // --- End: Additional Logging ---
-        if (verseData && verseData.f) {
+        if (verseData?.f) {
           const footnoteContent = verseData.f[footnoteId];
-          console.log(
-            `[Footnote Press] Found footnoteContent for ID ${footnoteId}:`,
-            footnoteContent ? 'Yes' : 'No',
-          );
 
           if (footnoteContent) {
             setActiveFootnote({
@@ -227,9 +186,6 @@ export const VerseItem = memo<VerseItemProps>(
               content: footnoteContent,
             });
           } else {
-            console.warn(
-              `Footnote content for ID ${footnoteId} in verse ${verse.verse_key} not found in footnotes object.`,
-            );
             setActiveFootnote({
               id: footnoteId,
               number: footnoteNumber,
@@ -237,9 +193,6 @@ export const VerseItem = memo<VerseItemProps>(
             });
           }
         } else {
-          console.warn(
-            `Footnotes object (f) not found for verse ${verse.verse_key}.`,
-          );
           setActiveFootnote({
             id: footnoteId,
             number: footnoteNumber,
@@ -247,7 +200,7 @@ export const VerseItem = memo<VerseItemProps>(
           });
         }
       },
-      [verse.verse_key, isSaheehDataLoaded, activeFootnote],
+      [verse.verse_key, activeFootnote],
     );
 
     // Close the footnote display
@@ -255,41 +208,44 @@ export const VerseItem = memo<VerseItemProps>(
       setActiveFootnote(null);
     }, []);
 
-    // Access processed data from the verse object
-    const processedTajweedAyahData = verse.processedTajweedAyahData;
-
     // --- Build Tajweed Nodes (Only if QPC and data available) ---
     const tajweedNodes =
       isQPCSelected && processedTajweedAyahData
-        ? processedTajweedAyahData.flatMap((wordData, wordIndex) => {
-            const segments = wordData.segments.map((segment, segIndex) => {
-              // Apply color based on showTajweed state from store
-              const color =
-                showTajweed && segment.rule
-                  ? tajweedColors[segment.rule] || textColor // Tajweed color or default
-                  : textColor; // Default color if tajweed off or no rule
-              return (
-                <TajweedSegment
-                  key={`${wordData.location}-${wordIndex}-${segIndex}`}
-                  text={segment.text}
-                  color={color}
-                />
-              );
-            });
-            // Add space between words
-            if (wordIndex < processedTajweedAyahData.length - 1) {
-              segments.push(<Text key={`${wordData.location}-space`}> </Text>);
-            }
-            return segments;
-          })
+        ? (processedTajweedAyahData as ProcessedTajweedWord[]).flatMap(
+            (wordData, wordIndex) => {
+              const segments = wordData.segments.map((segment, segIndex) => {
+                // Apply color based on showTajweed state from store
+                const color =
+                  showTajweed && segment.rule
+                    ? tajweedColors[segment.rule] || textColor // Tajweed color or default
+                    : textColor; // Default color if tajweed off or no rule
+                return (
+                  <TajweedSegment
+                    key={`${wordData.location}-${wordIndex}-${segIndex}`}
+                    text={segment.text}
+                    color={color}
+                  />
+                );
+              });
+              // Add space between words
+              if (
+                wordIndex <
+                (processedTajweedAyahData as ProcessedTajweedWord[]).length - 1
+              ) {
+                segments.push(
+                  <Text key={`${wordData.location}-space`}> </Text>,
+                );
+              }
+              return segments;
+            },
+          )
         : null;
     // --- End Building Nodes ---
 
-    // ---> Get Indopak text if applicable
-    const indopakText =
-      isIndopakSelected && indopakNastaleeqDataCache
-        ? indopakNastaleeqDataCache[verse.verse_key]?.text
-        : null;
+    // ---> Get Indopak text if applicable (lazy-loaded)
+    const indopakText = isIndopakSelected
+      ? getIndopakData()?.[verse.verse_key]?.text
+      : null;
     // <--- End Get Indopak text
 
     return (

--- a/components/player/v2/PlayerContent/QuranView/index.tsx
+++ b/components/player/v2/PlayerContent/QuranView/index.tsx
@@ -1,15 +1,15 @@
-import React, {useCallback, useRef, useEffect, useState} from 'react';
-import {View, Text, Platform, StyleSheet} from 'react-native';
+import React, {useCallback, useRef, useEffect} from 'react';
+import {View, Text, StyleSheet} from 'react-native';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Surah, QuranData, Verse} from '@/types/quran';
 import {VerseItem} from './VerseItem';
-import {useTajweedStore} from '@/store/tajweedStore';
 import {
   LegendList,
   LegendListRef,
   LegendListRenderItemProps,
 } from '@legendapp/list';
+import {useBottomSheetScrollableCreator} from '@gorhom/bottom-sheet';
 
 // Import data with type safety - move outside component to load only once
 const quranData = require('@/data/quran.json') as QuranData;
@@ -26,8 +26,6 @@ const saheehDataCache =
     string,
     SaheehEntry
   >;
-const transliterationDataCache =
-  require('@/data/transliteration.json') as TransliterationData;
 
 // Define transliteration data type
 interface TransliterationVerse {
@@ -38,26 +36,23 @@ interface TransliterationData {
   [verseKey: string]: TransliterationVerse;
 }
 
+const transliterationDataCache =
+  require('@/data/transliteration.json') as TransliterationData;
+
 // Enhanced verse type including translations and transliterations
 interface EnhancedVerse extends Verse {
   translation?: string;
   transliteration?: string;
 }
 
-// Type for processed tajweed data
-interface ProcessedTajweedWord {
-  word_index: number;
-  location: string;
-  segments: {
-    text: string;
-    rule: string | null;
-  }[];
-}
-
-// Verse type including tajweed data
-type VerseWithTajweed = EnhancedVerse & {
-  processedTajweedAyahData?: ProcessedTajweedWord[];
-};
+// Pre-index verses by surah at module scope (one-time O(6236) cost, then O(1) per lookup)
+const versesBySurah: Record<number, Verse[]> = {};
+Object.values(quranData).forEach(verse => {
+  (versesBySurah[verse.surah_number] ??= []).push(verse);
+});
+Object.values(versesBySurah).forEach(arr =>
+  arr.sort((a, b) => a.ayah_number - b.ayah_number),
+);
 
 interface QuranViewProps {
   currentSurah: number;
@@ -81,62 +76,39 @@ export const QuranView: React.FC<QuranViewProps> = ({
 }) => {
   const {theme} = useTheme();
   const listRef = useRef<LegendListRef>(null);
+  const renderScrollComponent = useBottomSheetScrollableCreator();
   const surah = surahData.find(s => s.id === currentSurah);
-  const [transliterationMap] = useState(transliterationDataCache || {});
-  const [isTransliterationLoaded] = useState(!!transliterationDataCache);
 
-  // Use the tajweed store with indexed data for O(1) lookups
-  const {indexedTajweedData} = useTajweedStore();
-
-  // Memoize the getVersesForSurah function to avoid useMemo dependency issues
+  // Memoize the getVersesForSurah function — no tajweed dependency
   const getVersesForSurahMemo = useCallback(() => {
-    if (!quranData) {
-      console.error('Quran data is not properly loaded');
+    const surahVerses = versesBySurah[currentSurah];
+    if (!surahVerses) {
       return [];
     }
 
     try {
-      const verses = Object.values(quranData)
-        .filter(verse => verse.surah_number === currentSurah)
-        .sort((a, b) => a.ayah_number - b.ayah_number);
-
-      // Map verses and attach translation/transliteration if loaded
-      return verses.map(verse => {
+      return surahVerses.map(verse => {
         const verseKey = `${verse.surah_number}:${verse.ayah_number}`;
-        // Always use Saheeh translation (with footnote tags)
         let translationText = '';
-        if (saheehDataCache && saheehDataCache[verseKey]?.t) {
+        if (saheehDataCache?.[verseKey]?.t) {
           translationText = saheehDataCache[verseKey].t;
         }
         let transliterationText = '';
-
-        // Add transliteration if data is loaded
-        if (isTransliterationLoaded && transliterationMap[verseKey]) {
-          transliterationText = transliterationMap[verseKey].t;
+        if (transliterationDataCache?.[verseKey]) {
+          transliterationText = transliterationDataCache[verseKey].t;
         }
-
-        // --- Attach pre-processed tajweed data directly ---
-        const processedTajweedAyahData = indexedTajweedData
-          ? indexedTajweedData[verseKey]
-          : undefined;
 
         return {
           ...verse,
           translation: translationText,
           transliteration: transliterationText,
-          processedTajweedAyahData,
         };
       });
     } catch (error) {
       console.error('Error processing verses:', error);
       return [];
     }
-  }, [
-    currentSurah,
-    transliterationMap,
-    isTransliterationLoaded,
-    indexedTajweedData,
-  ]);
+  }, [currentSurah]);
 
   // Get verses data
   const verses = getVersesForSurahMemo();
@@ -160,7 +132,7 @@ export const QuranView: React.FC<QuranViewProps> = ({
 
   // Render the verse items (optimized with LegendList)
   const renderItem = useCallback(
-    ({item}: LegendListRenderItemProps<VerseWithTajweed>) => {
+    ({item}: LegendListRenderItemProps<EnhancedVerse>) => {
       return (
         <VerseItem
           verse={item}
@@ -172,7 +144,6 @@ export const QuranView: React.FC<QuranViewProps> = ({
           transliterationFontSize={transliterationFontSize}
           translationFontSize={translationFontSize}
           arabicFontSize={arabicFontSize}
-          processedTajweedAyahData={item.processedTajweedAyahData}
         />
       );
     },
@@ -189,10 +160,7 @@ export const QuranView: React.FC<QuranViewProps> = ({
   );
 
   // Key extractor for items
-  const keyExtractor = useCallback(
-    (item: VerseWithTajweed) => item.verse_key,
-    [],
-  );
+  const keyExtractor = useCallback((item: EnhancedVerse) => item.verse_key, []);
 
   if (!surah || !verses.length) {
     return null;
@@ -208,13 +176,12 @@ export const QuranView: React.FC<QuranViewProps> = ({
         ListHeaderComponent={renderHeader}
         style={styles.list}
         contentContainerStyle={styles.scrollContent}
+        renderScrollComponent={renderScrollComponent}
         showsVerticalScrollIndicator={false}
         bounces={true}
         overScrollMode="never"
-        nestedScrollEnabled={Platform.OS === 'android'}
-        disableScrollViewPanResponder={Platform.OS === 'android'}
-        recycleItems={true} // Enable item recycling for better performance
-        estimatedItemSize={150} // Estimate average item height for better initial rendering
+        recycleItems={true}
+        estimatedItemSize={150}
       />
     </View>
   );

--- a/components/player/v2/PlayerContent/TrackInfo.tsx
+++ b/components/player/v2/PlayerContent/TrackInfo.tsx
@@ -96,10 +96,7 @@ export const TrackInfo = () => {
     <View style={styles.container}>
       <View style={styles.trackContainer}>
         <Pressable
-          style={({pressed}) => [
-            styles.trackInfoTouchable,
-            {opacity: pressed && !isUploadWithoutReciter ? 0.7 : 1},
-          ]}
+          style={styles.trackInfoTouchable}
           onPress={handleReciterPress}>
           <View style={styles.imageContainer}>
             {isUploadWithoutArtwork ? (

--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -91,6 +91,7 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
       <View style={styles.viewsContainer}>
         {/* QuranView or UploadPlaceholder */}
         <View
+          pointerEvents={showQueue ? 'none' : 'auto'}
           style={[
             styles.viewWrapper,
             showQueue ? styles.hidden : styles.visible,
@@ -111,6 +112,7 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
         </View>
         {/* QueueList */}
         <View
+          pointerEvents={showQueue ? 'auto' : 'none'}
           style={[
             styles.viewWrapper,
             showQueue ? styles.visible : styles.hidden,
@@ -166,12 +168,10 @@ const styles = StyleSheet.create({
     paddingTop: moderateScale(10),
   },
   visible: {
-    display: 'flex',
     opacity: 1,
     zIndex: 1,
   },
   hidden: {
-    display: 'none',
     opacity: 0,
     zIndex: 0,
   },

--- a/components/player/v2/PlayerSheet.tsx
+++ b/components/player/v2/PlayerSheet.tsx
@@ -256,7 +256,7 @@ export const PlayerSheet = () => {
         index={currentIndex}
         animateOnMount={false}
         handleComponent={CustomHandle}
-        enableContentPanningGesture={Platform.OS === 'ios'}
+        enableContentPanningGesture
         style={styles.sheet}
         backgroundStyle={[
           styles.background,

--- a/components/sheets/sheets.tsx
+++ b/components/sheets/sheets.tsx
@@ -1,51 +1,106 @@
-import React from 'react';
+import React, {Suspense} from 'react';
+import {View} from 'react-native';
 import {SheetDefinition, registerSheet} from 'react-native-actions-sheet';
 import {Surah} from '@/data/surahData';
 import type {RewayatStyle} from '@/types/reciter';
 import type {Dhikr} from '@/types/adhkar';
 import type {UploadedRecitation} from '@/types/uploads';
 
-// Import sheet components
-import {SurahOptionsSheet} from './SurahOptionsSheet';
-import {RewayatInfoSheet} from './RewayatInfoSheet';
-import {FavoriteRecitersSheet} from './FavoriteRecitersSheet';
-import {SelectReciterSheet} from './SelectReciterSheet';
-import {SelectPlaylistSheet} from './SelectPlaylistSheet';
-import {CreatePlaylistSheet} from './CreatePlaylistSheet';
-import {PlaylistContextSheet} from './PlaylistContextSheet';
-import {PlayerOptionsSheet} from './PlayerOptionsSheet';
-import {PlaybackSpeedSheet} from './PlaybackSpeedSheet';
-import {SleepTimerSheet} from './SleepTimerSheet';
-import {MushafLayoutSheet} from './MushafLayoutSheet';
-import {AdhkarLayoutSheet} from './AdhkarLayoutSheet';
-import {AdhkarCopyOptionsSheet} from './AdhkarCopyOptionsSheet';
-import {OrganizeRecitationSheet} from './OrganizeRecitationSheet';
-import {DownloadOptionsSheet} from './DownloadOptionsSheet';
-import {UploadOptionsSheet} from './UploadOptionsSheet';
-import {AddToCollectionSheet} from './AddToCollectionSheet';
-import {AmbientSoundsSheet} from './AmbientSoundsSheet';
-import {CollectionOptionsSheet} from './CollectionOptionsSheet';
+/**
+ * Wraps a lazy-imported sheet component in React.lazy + Suspense.
+ * Metro defers module *evaluation* until the dynamic import() resolves,
+ * so none of these sheets (or their dependency trees) execute at startup.
+ */
+function lazySheet(
+  importFn: () => Promise<any>,
+  exportName: string,
+): React.FC<any> {
+  const LazyComponent = React.lazy(() =>
+    importFn().then(mod => ({default: mod[exportName]})),
+  );
+  return (props: any) => (
+    <Suspense fallback={<View />}>
+      <LazyComponent {...props} />
+    </Suspense>
+  );
+}
 
-// Register all sheets
-registerSheet('surah-options', SurahOptionsSheet);
-registerSheet('rewayat-info', RewayatInfoSheet);
-registerSheet('favorite-reciters', FavoriteRecitersSheet);
-registerSheet('select-reciter', SelectReciterSheet);
-registerSheet('select-playlist', SelectPlaylistSheet);
-registerSheet('create-playlist', CreatePlaylistSheet);
-registerSheet('playlist-context', PlaylistContextSheet);
-registerSheet('player-options', PlayerOptionsSheet);
-registerSheet('playback-speed', PlaybackSpeedSheet);
-registerSheet('sleep-timer', SleepTimerSheet);
-registerSheet('mushaf-layout', MushafLayoutSheet);
-registerSheet('adhkar-layout', AdhkarLayoutSheet);
-registerSheet('adhkar-copy-options', AdhkarCopyOptionsSheet);
-registerSheet('organize-recitation', OrganizeRecitationSheet);
-registerSheet('download-options', DownloadOptionsSheet);
-registerSheet('upload-options', UploadOptionsSheet);
-registerSheet('add-to-collection', AddToCollectionSheet);
-registerSheet('ambient-sounds', AmbientSoundsSheet);
-registerSheet('collection-options', CollectionOptionsSheet);
+// Register all sheets with lazy imports
+registerSheet(
+  'surah-options',
+  lazySheet(() => import('./SurahOptionsSheet'), 'SurahOptionsSheet'),
+);
+registerSheet(
+  'favorite-reciters',
+  lazySheet(() => import('./FavoriteRecitersSheet'), 'FavoriteRecitersSheet'),
+);
+registerSheet(
+  'select-reciter',
+  lazySheet(() => import('./SelectReciterSheet'), 'SelectReciterSheet'),
+);
+registerSheet(
+  'select-playlist',
+  lazySheet(() => import('./SelectPlaylistSheet'), 'SelectPlaylistSheet'),
+);
+registerSheet(
+  'create-playlist',
+  lazySheet(() => import('./CreatePlaylistSheet'), 'CreatePlaylistSheet'),
+);
+registerSheet(
+  'playlist-context',
+  lazySheet(() => import('./PlaylistContextSheet'), 'PlaylistContextSheet'),
+);
+registerSheet(
+  'player-options',
+  lazySheet(() => import('./PlayerOptionsSheet'), 'PlayerOptionsSheet'),
+);
+registerSheet(
+  'playback-speed',
+  lazySheet(() => import('./PlaybackSpeedSheet'), 'PlaybackSpeedSheet'),
+);
+registerSheet(
+  'sleep-timer',
+  lazySheet(() => import('./SleepTimerSheet'), 'SleepTimerSheet'),
+);
+registerSheet(
+  'mushaf-layout',
+  lazySheet(() => import('./MushafLayoutSheet'), 'MushafLayoutSheet'),
+);
+registerSheet(
+  'adhkar-layout',
+  lazySheet(() => import('./AdhkarLayoutSheet'), 'AdhkarLayoutSheet'),
+);
+registerSheet(
+  'adhkar-copy-options',
+  lazySheet(() => import('./AdhkarCopyOptionsSheet'), 'AdhkarCopyOptionsSheet'),
+);
+registerSheet(
+  'organize-recitation',
+  lazySheet(
+    () => import('./OrganizeRecitationSheet'),
+    'OrganizeRecitationSheet',
+  ),
+);
+registerSheet(
+  'download-options',
+  lazySheet(() => import('./DownloadOptionsSheet'), 'DownloadOptionsSheet'),
+);
+registerSheet(
+  'upload-options',
+  lazySheet(() => import('./UploadOptionsSheet'), 'UploadOptionsSheet'),
+);
+registerSheet(
+  'add-to-collection',
+  lazySheet(() => import('./AddToCollectionSheet'), 'AddToCollectionSheet'),
+);
+registerSheet(
+  'ambient-sounds',
+  lazySheet(() => import('./AmbientSoundsSheet'), 'AmbientSoundsSheet'),
+);
+registerSheet(
+  'collection-options',
+  lazySheet(() => import('./CollectionOptionsSheet'), 'CollectionOptionsSheet'),
+);
 
 // Type definitions for payloads
 declare module 'react-native-actions-sheet' {

--- a/components/sheets/sheets.tsx
+++ b/components/sheets/sheets.tsx
@@ -1,106 +1,51 @@
-import React, {Suspense} from 'react';
-import {View} from 'react-native';
+import React from 'react';
 import {SheetDefinition, registerSheet} from 'react-native-actions-sheet';
 import {Surah} from '@/data/surahData';
 import type {RewayatStyle} from '@/types/reciter';
 import type {Dhikr} from '@/types/adhkar';
 import type {UploadedRecitation} from '@/types/uploads';
 
-/**
- * Wraps a lazy-imported sheet component in React.lazy + Suspense.
- * Metro defers module *evaluation* until the dynamic import() resolves,
- * so none of these sheets (or their dependency trees) execute at startup.
- */
-function lazySheet(
-  importFn: () => Promise<any>,
-  exportName: string,
-): React.FC<any> {
-  const LazyComponent = React.lazy(() =>
-    importFn().then(mod => ({default: mod[exportName]})),
-  );
-  return (props: any) => (
-    <Suspense fallback={<View />}>
-      <LazyComponent {...props} />
-    </Suspense>
-  );
-}
+// Import sheet components
+import {SurahOptionsSheet} from './SurahOptionsSheet';
+import {RewayatInfoSheet} from './RewayatInfoSheet';
+import {FavoriteRecitersSheet} from './FavoriteRecitersSheet';
+import {SelectReciterSheet} from './SelectReciterSheet';
+import {SelectPlaylistSheet} from './SelectPlaylistSheet';
+import {CreatePlaylistSheet} from './CreatePlaylistSheet';
+import {PlaylistContextSheet} from './PlaylistContextSheet';
+import {PlayerOptionsSheet} from './PlayerOptionsSheet';
+import {PlaybackSpeedSheet} from './PlaybackSpeedSheet';
+import {SleepTimerSheet} from './SleepTimerSheet';
+import {MushafLayoutSheet} from './MushafLayoutSheet';
+import {AdhkarLayoutSheet} from './AdhkarLayoutSheet';
+import {AdhkarCopyOptionsSheet} from './AdhkarCopyOptionsSheet';
+import {OrganizeRecitationSheet} from './OrganizeRecitationSheet';
+import {DownloadOptionsSheet} from './DownloadOptionsSheet';
+import {UploadOptionsSheet} from './UploadOptionsSheet';
+import {AddToCollectionSheet} from './AddToCollectionSheet';
+import {AmbientSoundsSheet} from './AmbientSoundsSheet';
+import {CollectionOptionsSheet} from './CollectionOptionsSheet';
 
-// Register all sheets with lazy imports
-registerSheet(
-  'surah-options',
-  lazySheet(() => import('./SurahOptionsSheet'), 'SurahOptionsSheet'),
-);
-registerSheet(
-  'favorite-reciters',
-  lazySheet(() => import('./FavoriteRecitersSheet'), 'FavoriteRecitersSheet'),
-);
-registerSheet(
-  'select-reciter',
-  lazySheet(() => import('./SelectReciterSheet'), 'SelectReciterSheet'),
-);
-registerSheet(
-  'select-playlist',
-  lazySheet(() => import('./SelectPlaylistSheet'), 'SelectPlaylistSheet'),
-);
-registerSheet(
-  'create-playlist',
-  lazySheet(() => import('./CreatePlaylistSheet'), 'CreatePlaylistSheet'),
-);
-registerSheet(
-  'playlist-context',
-  lazySheet(() => import('./PlaylistContextSheet'), 'PlaylistContextSheet'),
-);
-registerSheet(
-  'player-options',
-  lazySheet(() => import('./PlayerOptionsSheet'), 'PlayerOptionsSheet'),
-);
-registerSheet(
-  'playback-speed',
-  lazySheet(() => import('./PlaybackSpeedSheet'), 'PlaybackSpeedSheet'),
-);
-registerSheet(
-  'sleep-timer',
-  lazySheet(() => import('./SleepTimerSheet'), 'SleepTimerSheet'),
-);
-registerSheet(
-  'mushaf-layout',
-  lazySheet(() => import('./MushafLayoutSheet'), 'MushafLayoutSheet'),
-);
-registerSheet(
-  'adhkar-layout',
-  lazySheet(() => import('./AdhkarLayoutSheet'), 'AdhkarLayoutSheet'),
-);
-registerSheet(
-  'adhkar-copy-options',
-  lazySheet(() => import('./AdhkarCopyOptionsSheet'), 'AdhkarCopyOptionsSheet'),
-);
-registerSheet(
-  'organize-recitation',
-  lazySheet(
-    () => import('./OrganizeRecitationSheet'),
-    'OrganizeRecitationSheet',
-  ),
-);
-registerSheet(
-  'download-options',
-  lazySheet(() => import('./DownloadOptionsSheet'), 'DownloadOptionsSheet'),
-);
-registerSheet(
-  'upload-options',
-  lazySheet(() => import('./UploadOptionsSheet'), 'UploadOptionsSheet'),
-);
-registerSheet(
-  'add-to-collection',
-  lazySheet(() => import('./AddToCollectionSheet'), 'AddToCollectionSheet'),
-);
-registerSheet(
-  'ambient-sounds',
-  lazySheet(() => import('./AmbientSoundsSheet'), 'AmbientSoundsSheet'),
-);
-registerSheet(
-  'collection-options',
-  lazySheet(() => import('./CollectionOptionsSheet'), 'CollectionOptionsSheet'),
-);
+// Register all sheets
+registerSheet('surah-options', SurahOptionsSheet);
+registerSheet('rewayat-info', RewayatInfoSheet);
+registerSheet('favorite-reciters', FavoriteRecitersSheet);
+registerSheet('select-reciter', SelectReciterSheet);
+registerSheet('select-playlist', SelectPlaylistSheet);
+registerSheet('create-playlist', CreatePlaylistSheet);
+registerSheet('playlist-context', PlaylistContextSheet);
+registerSheet('player-options', PlayerOptionsSheet);
+registerSheet('playback-speed', PlaybackSpeedSheet);
+registerSheet('sleep-timer', SleepTimerSheet);
+registerSheet('mushaf-layout', MushafLayoutSheet);
+registerSheet('adhkar-layout', AdhkarLayoutSheet);
+registerSheet('adhkar-copy-options', AdhkarCopyOptionsSheet);
+registerSheet('organize-recitation', OrganizeRecitationSheet);
+registerSheet('download-options', DownloadOptionsSheet);
+registerSheet('upload-options', UploadOptionsSheet);
+registerSheet('add-to-collection', AddToCollectionSheet);
+registerSheet('ambient-sounds', AmbientSoundsSheet);
+registerSheet('collection-options', CollectionOptionsSheet);
 
 // Type definitions for payloads
 declare module 'react-native-actions-sheet' {

--- a/docs/android-perf/00-tracker.md
+++ b/docs/android-perf/00-tracker.md
@@ -1,0 +1,49 @@
+# Android Performance Improvement — Master Tracker
+
+**Source audit:** `docs/android-performance-audit.md`
+**Execution order:** Phase 3 → Phase 2 → Phase 1 → Phase 4 → Phase 5 → Phase 6
+
+---
+
+## Phase Status
+
+| Phase | Name | Status | Branch | Commit | Impact Summary |
+|-------|------|--------|--------|--------|----------------|
+| 3 | Android Config Quick Wins | **DONE** | `perf/android-config-phase3` | — | `largeHeap` enabled, nav bar import cached, audit corrected (New Arch + Hermes already on) |
+| 2 | Startup Declutter | PENDING | — | — | Lazy sheet registration, deferred init, consolidated useEffects |
+| 1 | Data Loading Revolution | PENDING | — | — | Move large JSON to SQLite, lazy tajweed, pre-built Fuse index |
+| 4 | Sheet & Navigation Smoothness | PENDING | — | — | Fix Android sheet gestures, screen transitions, PlayerSheet optimization |
+| 5 | List & Rendering Polish | PENDING | — | — | getItemLayout, replace LinearGradient, Pressable migration, memo audit |
+| 6 | Memory & Long-Session Stability | PENDING | — | — | Memory monitoring, store audit, cache limits, profiler validation |
+
+---
+
+## Cumulative File Changes
+
+### Phase 3
+
+| File | Action | Description |
+|------|--------|-------------|
+| `withLargeHeap.js` | CREATED | Expo config plugin — sets `android:largeHeap="true"` via `withAndroidManifest` |
+| `app.config.js` | MODIFIED | Registered `withLargeHeap.js` in plugins array |
+| `app/_layout.tsx` | MODIFIED | Cached `expo-navigation-bar` module at module level; import runs once, reused on theme changes |
+| `docs/android-performance-audit.md` | MODIFIED | Corrected: New Architecture and Hermes already enabled; downgraded config severity 7→5 |
+| `docs/android-perf/00-tracker.md` | CREATED | This file — master tracker |
+| `docs/android-perf/phase-3-handoff.md` | CREATED | Phase 3 handoff with context for Phase 2 |
+
+---
+
+## How to Start a New Phase
+
+Tell Claude: *"Read `docs/android-perf/00-tracker.md` and `docs/android-perf/phase-N-handoff.md` — we're starting Phase X"*
+
+Claude will read both documents, understand the full state, and pick up the next phase with zero knowledge loss.
+
+---
+
+## Context
+
+- **App:** Bayaan — React Native/Expo Quran audio app
+- **Problem:** Android performance lags behind iOS due to compounding issues (28MB bundled JSON, eager initialization, missing config)
+- **Key files:** `app/_layout.tsx` (root layout), `services/AppInitializer.ts` (startup), `components/sheets/sheets.tsx` (sheet registration), `data/reciterData.ts` (reciters JSON)
+- **Already confirmed enabled:** New Architecture (`gradle.properties:38`), Hermes (`gradle.properties:42`)

--- a/docs/android-perf/00-tracker.md
+++ b/docs/android-perf/00-tracker.md
@@ -10,7 +10,7 @@
 | Phase | Name | Status | Branch | Commit | Impact Summary |
 |-------|------|--------|--------|--------|----------------|
 | 3 | Android Config Quick Wins | **DONE** | `perf/android-config-phase3` | — | `largeHeap` enabled, nav bar import cached, audit corrected (New Arch + Hermes already on) |
-| 2 | Startup Declutter | PENDING | — | — | Lazy sheet registration, deferred init, consolidated useEffects |
+| 2 | Startup Declutter | **DONE** | `perf/android-config-phase3` | — | Lazy sheet registration (18 sheets), deferred tajweed via InteractionManager, consolidated root effects (9→6), removed dead code |
 | 1 | Data Loading Revolution | PENDING | — | — | Move large JSON to SQLite, lazy tajweed, pre-built Fuse index |
 | 4 | Sheet & Navigation Smoothness | PENDING | — | — | Fix Android sheet gestures, screen transitions, PlayerSheet optimization |
 | 5 | List & Rendering Polish | PENDING | — | — | getItemLayout, replace LinearGradient, Pressable migration, memo audit |
@@ -30,6 +30,16 @@
 | `docs/android-performance-audit.md` | MODIFIED | Corrected: New Architecture and Hermes already enabled; downgraded config severity 7→5 |
 | `docs/android-perf/00-tracker.md` | CREATED | This file — master tracker |
 | `docs/android-perf/phase-3-handoff.md` | CREATED | Phase 3 handoff with context for Phase 2 |
+
+### Phase 2
+
+| File | Action | Description |
+|------|--------|-------------|
+| `components/sheets/sheets.tsx` | MODIFIED | Replaced 19 eager imports with React.lazy + Suspense wrappers; removed dead RewayatInfoSheet registration |
+| `app/_layout.tsx` | MODIFIED | Removed dead navigation effect, merged theme sync effects, merged background init effects, added InteractionManager, removed isTajweedLoading state (9→6 useEffects) |
+| `utils/tajweedLoader.ts` | MODIFIED | Removed setTimeout wrapper and async variant, made preloadTajweedData synchronous (caller handles deferral) |
+| `docs/android-perf/00-tracker.md` | MODIFIED | Updated Phase 2 status to DONE |
+| `docs/android-perf/phase-2-handoff.md` | CREATED | Phase 2 handoff with context for Phase 1 |
 
 ---
 

--- a/docs/android-perf/phase-2-handoff.md
+++ b/docs/android-perf/phase-2-handoff.md
@@ -1,0 +1,68 @@
+# Phase 2 Handoff — Startup Declutter
+
+**Status:** DONE
+**Branch:** `perf/android-config-phase3` (combined with Phase 3)
+
+---
+
+## What Was Done
+
+### 1. Lazy-loaded all sheet components (`components/sheets/sheets.tsx`)
+
+- Replaced 19 eager `import` statements with `React.lazy()` + `Suspense` wrappers
+- Created a `lazySheet()` helper that wraps each sheet in `React.lazy` + `Suspense` with an empty `<View />` fallback
+- Removed `RewayatInfoSheet` registration — 0 usages of `SheetManager.show('rewayat-info')` found in the codebase (dead code). Type declaration kept for safety.
+- All TypeScript type declarations preserved (compile-time only, zero runtime cost)
+
+**How it works in React Native:** Metro bundles all modules into a single file but `import()` defers module *evaluation* until called. On first sheet open, `require()` evaluates the module synchronously (imperceptible since sheet is animating open). Subsequent opens use the cached module.
+
+**Heaviest sheets deferred:** OrganizeRecitationSheet (1,204 lines), SurahOptionsSheet (570 lines), PlayerOptionsSheet (549 lines) — all pull in data services, hooks, and component libraries.
+
+### 2. Consolidated root layout effects (`app/_layout.tsx`)
+
+- **Removed dead effect:** The "navigation handler" effect (lines 221-225) had an empty body — only an early return that did nothing.
+- **Merged theme sync effects:** `SystemUI.setBackgroundColorAsync` and Android nav bar setup merged into a single effect with `[theme.colors.background, isDarkMode]` dependency.
+- **Merged background init effects:** Tajweed preload and SQLite services init merged into a single `[]` effect.
+- **Removed `isTajweedLoading` state:** Was only used as a run-once guard; `[]` dependency handles this naturally.
+- **Added `InteractionManager` import** from `react-native`.
+- **Net result:** 9 useEffects → 6. Removed 1 `useState`.
+
+### 3. Replaced `setTimeout` with `InteractionManager` in tajweed loader (`utils/tajweedLoader.ts`)
+
+- Removed `preloadTajweedDataWithTimeout()` entirely (the `setTimeout(100ms)` variant)
+- Made `preloadTajweedData()` synchronous — it does the heavy work directly when called
+- The deferral responsibility moved to the caller (`_layout.tsx` wraps call in `InteractionManager.runAfterInteractions`)
+- Removed the old async variant that used dynamic `import()` (unnecessary since `require()` in Metro is synchronous)
+
+**Why InteractionManager over setTimeout:** `setTimeout(100ms)` is an arbitrary delay that may still collide with user interaction. `InteractionManager.runAfterInteractions()` is React Native's built-in mechanism to defer work until after animations, gestures, and transitions are complete — it guarantees the first frame is painted before the heavy 8.3MB JSON parse begins.
+
+---
+
+## Patterns Established
+
+1. **`lazySheet()` helper** — reusable pattern for any future sheet registrations. Just add a new `registerSheet()` call with the helper.
+2. **InteractionManager for heavy deferred work** — use `InteractionManager.runAfterInteractions()` instead of `setTimeout` for deferring non-critical startup work.
+3. **Caller-controlled deferral** — utility functions do work synchronously; the caller decides *when* to invoke them. Cleaner separation of concerns.
+
+---
+
+## What's Left for Phase 1
+
+Phase 1 (Data Loading Revolution) focuses on the **biggest remaining bottleneck**: large JSON data files.
+
+Key targets:
+- Move 20MB+ reciters JSON to SQLite for on-demand queries instead of full parse
+- Pre-build Fuse.js search indices at build time instead of runtime
+- Tajweed data is now properly deferred (Phase 2), but could be moved to SQLite for even better memory usage (Phase 1 scope)
+
+---
+
+## Verification Checklist
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npx prettier --check` passes on modified files
+- [ ] App launches on Android — no crash, no white screen
+- [ ] Open every sheet type at least once — all render correctly
+- [ ] Toggle light/dark theme — nav bar still updates
+- [ ] Audio playback still works
+- [ ] iOS still works (no regressions)

--- a/docs/android-perf/phase-3-handoff.md
+++ b/docs/android-perf/phase-3-handoff.md
@@ -1,0 +1,110 @@
+# Phase 3 Handoff — Android Config Quick Wins
+
+**Status:** DONE
+**Branch:** `perf/android-config-phase3`
+
+---
+
+## Changes Made
+
+### 1. `withLargeHeap.js` (CREATED)
+
+Expo config plugin that sets `android:largeHeap="true"` on the `<application>` tag in AndroidManifest.xml.
+
+- Uses `withAndroidManifest` from `@expo/config-plugins` (safe API, not `withDangerousMod`)
+- Follows the project's existing plugin pattern (`withAndroidSigning.js`, `withIOSTeam.js`)
+- **Why:** The app loads 28MB+ of bundled JSON. `largeHeap` increases available heap from ~128-256MB to ~256-512MB on Android, reducing GC pressure and OOM risk on mid-range devices.
+
+### 2. `app.config.js` (MODIFIED)
+
+Added `'./withLargeHeap.js'` to the plugins array between `withAndroidSigning.js` and `withIOSTeam.js`.
+
+### 3. `app/_layout.tsx` (MODIFIED)
+
+Cached the `expo-navigation-bar` dynamic import at module level.
+
+**Before:** Every theme change triggered `await import('expo-navigation-bar')`, creating a new promise chain each time. `RNStatusBar.setTranslucent(true)` also ran repeatedly.
+
+**After:** A module-level `let NavigationBarModule: any = null` caches the import. The first theme change triggers the dynamic import and sets `setTranslucent(true)`. All subsequent theme changes reuse the cached module directly — only `setBackgroundColorAsync` and `setButtonStyleAsync` run.
+
+**Pattern established:** Module-level caching for lazy-loaded platform modules. Phase 2 can reuse this pattern for other deferred imports.
+
+### 4. `docs/android-performance-audit.md` (MODIFIED)
+
+Corrected inaccuracies found during investigation:
+
+- **Executive summary:** Removed "no New Architecture" and "no explicit Hermes" — both are already enabled
+- **"Missing Android Configuration" section:** Downgraded severity from 7/10 to 5/10. Marked items 2 (New Architecture) and 3 (Hermes) as ~~RESOLVED~~ with locations (`gradle.properties:38` and `:42`)
+- **Phase 3 remediation plan:** Marked New Architecture evaluation and Hermes optimization as already done
+
+---
+
+## Items Confirmed Already Done (No Action Needed)
+
+| Item | Location | Value |
+|------|----------|-------|
+| New Architecture (Fabric + TurboModules) | `android/gradle.properties:38` | `newArchEnabled=true` |
+| Hermes JS engine | `android/gradle.properties:42` | `hermesEnabled=true` |
+
+---
+
+## Items Not Addressed (Out of Scope for Phase 3)
+
+| Item | Why Skipped | Which Phase |
+|------|-------------|-------------|
+| React Compiler | Disabled due to Zustand subscription issues — needs investigation | Phase 3 (future revisit) |
+| ProGuard/R8 flags | Low impact relative to other phases; Expo handles R8 in release builds by default | Phase 6 |
+
+---
+
+## Testing Checklist
+
+- [ ] `expo prebuild --platform android --clean` succeeds
+- [ ] `android/app/src/main/AndroidManifest.xml` contains `android:largeHeap="true"`
+- [ ] `npx tsc --noEmit` passes
+- [ ] App launches on Android without crashing
+- [ ] Toggle light/dark theme 5+ times — nav bar updates correctly, no lag
+- [ ] Navigate through all tabs
+- [ ] Open the player sheet, open several action sheets
+- [ ] Audio playback works
+- [ ] iOS still launches and works (config plugin is Android-only)
+
+---
+
+## Context for Phase 2 — Startup Declutter
+
+### What Phase 2 Should Do
+
+Per the audit (`docs/android-performance-audit.md`, Phase 2 section):
+
+1. **Lazy-register action sheets** — Replace the eager import of all 17 sheets in `components/sheets/sheets.tsx` with dynamic `import()` calls. Register each sheet only when first shown.
+2. **Defer non-visible initialization** — Move tajweed, adhkar, uploads, and Fuse.js initialization to `InteractionManager.runAfterInteractions()` so they run after the first frame.
+3. **Consolidate root layout useEffects** — Merge the 8 `useEffect` hooks in `app/_layout.tsx` into 2-3 logical groups.
+
+### Key Files for Phase 2
+
+| File | Why |
+|------|-----|
+| `components/sheets/sheets.tsx` | All 17 sheet registrations — make them lazy |
+| `app/_layout.tsx` | 8 useEffects to consolidate; already has the nav bar caching pattern from Phase 3 |
+| `services/AppInitializer.ts` | Startup orchestrator — may need to defer non-critical services |
+| `utils/tajweedLoader.ts` | Tajweed preload — should use `InteractionManager.runAfterInteractions()` |
+| `components/search/SearchView.tsx` | Fuse.js initialization — consider deferring |
+
+### Patterns from Phase 3 to Reuse
+
+- **Module-level caching:** The `let NavigationBarModule: any = null` pattern in `app/_layout.tsx` works well for caching dynamic imports. Use the same approach for lazy sheet registration.
+- **Config plugin style:** If any Phase 2 changes need native config, follow the `withLargeHeap.js` pattern (use typed Expo config-plugins APIs, not `withDangerousMod`).
+
+---
+
+## All Files Touched
+
+| File | Action |
+|------|--------|
+| `withLargeHeap.js` | CREATED |
+| `app.config.js` | MODIFIED |
+| `app/_layout.tsx` | MODIFIED |
+| `docs/android-performance-audit.md` | MODIFIED |
+| `docs/android-perf/00-tracker.md` | CREATED |
+| `docs/android-perf/phase-3-handoff.md` | CREATED |

--- a/docs/android-performance-audit.md
+++ b/docs/android-performance-audit.md
@@ -1,0 +1,388 @@
+# Android Performance Audit — Bayaan
+
+**Date:** February 2026
+**Scope:** Mounting/unmounting jank, sheet navigation lag, bundled data loading, general Android weakness
+**Methodology:** 6 parallel investigation agents analyzed sheets, data loading, mount/unmount patterns, Android config, navigation architecture, and lists/images/animations
+
+---
+
+## Executive Summary
+
+Android performance lags behind iOS due to a compounding set of issues, not any single root cause. The three biggest offenders are:
+
+1. **28MB of bundled JSON parsed on the JS thread** — Hermes is slower at JSON deserialization than JSC, and the app loads massive Quran data files synchronously
+2. **Eager initialization of everything** — 17 action sheets, 7+ providers, 8 useEffects in the root layout, and multiple services all compete for the JS thread at startup
+3. **Missing Android-specific optimizations** — no `largeHeap`, sheet gesture handling disabled on Android (New Architecture and Hermes are already enabled in `android/gradle.properties`)
+
+---
+
+## Detailed Findings
+
+### CRITICAL — Bundled Data Loading (Severity: 10/10)
+
+The `data/` directory contains **28MB of JSON files** that are bundled into the app:
+
+| File | Size | When Loaded |
+|------|------|-------------|
+| `QPC Hafs Tajweed 2.json` | **8.3MB** | App startup (setTimeout 100ms) |
+| `QPC V4 2.json` | **5.2MB** | On demand (Mushaf view) |
+| `quran-translation.json` | 3.2MB | On demand |
+| `quran.json` | 1.8MB | On demand |
+| `IndopakNastaleeq.json` | 1.6MB | On demand |
+| `englishwbwtransliteration.json` | 1.5MB | On demand |
+| `SaheehInternational...` | 1.2MB | On demand |
+| `clear-quran-translation.json` | 1.2MB | On demand |
+| `transliteration.json` | 1.1MB | On demand |
+| `surahInfo.json` | 928KB | On demand |
+| `reciters.json` | **492KB** | **App startup (import)** |
+| `adhkar.json` | 449KB | On demand |
+
+**The Critical Path:**
+
+1. **`reciters.json` (492KB)** is loaded via static `import` in `data/reciterData.ts` — this is a synchronous require that blocks the JS thread during module evaluation. Every file that imports `RECITERS` triggers this parse. It's imported by **20+ files**.
+
+2. **`QPC Hafs Tajweed 2.json` (8.3MB)** is loaded via `require()` in `utils/tajweedLoader.ts:188` inside a `setTimeout(100ms)`. While the 100ms defer helps slightly, the `require()` call itself is **synchronous and blocks the entire JS thread** while Hermes parses 8.3MB of JSON. After parsing, the app then iterates every entry, runs regex processing (`processTajweedWord`), and builds indexed lookup tables. This can freeze the UI for **1-3 seconds on mid-range Android devices**.
+
+3. **`surahData.ts`** is an inline TypeScript array (114 entries, ~30KB) — this is fine, but it's imported everywhere.
+
+**Why this hurts Android more than iOS:**
+- Hermes JSON parsing is measurably slower than JSC for large payloads
+- Android devices generally have slower I/O for reading from the app bundle
+- The single-threaded JS execution model means all JSON parsing blocks UI renders
+
+**Files:**
+- `data/reciterData.ts:1` — `import recitersData from './reciters.json'`
+- `utils/tajweedLoader.ts:184-224` — `preloadTajweedDataWithTimeout()`
+- `app/_layout.tsx:129-135` — triggers tajweed preload on mount
+
+---
+
+### CRITICAL — Eager Sheet Registration (Severity: 8/10)
+
+**`components/sheets/sheets.tsx`** eagerly imports and registers all 17 action sheets at app startup:
+
+```
+import {SurahOptionsSheet} from './SurahOptionsSheet';
+import {RewayatInfoSheet} from './RewayatInfoSheet';
+import {FavoriteRecitersSheet} from './FavoriteRecitersSheet';
+// ... 14 more imports
+```
+
+This file is imported as a side-effect in `app/_layout.tsx:29`:
+```
+import '@/components/sheets/sheets';
+```
+
+**Impact:** All 17 sheet component modules and their entire dependency trees are evaluated during initial module loading. Each sheet imports its own hooks, store selectors, and component libraries. This adds significant JS evaluation time before the first frame.
+
+Additionally, some sheets contain heavy content:
+- `SelectReciterSheet` — renders the full reciter list with search (imports RECITERS)
+- `FavoriteRecitersSheet` — also imports RECITERS
+- `OrganizeRecitationSheet` — imports RECITERS and SURAHS
+- `AddToCollectionSheet` — contains its own sheet manager calls
+
+**Files:**
+- `components/sheets/sheets.tsx:1-46` — all 17 registrations
+- `app/_layout.tsx:29` — side-effect import
+
+---
+
+### HIGH — Root Layout Initialization Overload (Severity: 8/10)
+
+`app/_layout.tsx` is the app's entry point and it does **too much work simultaneously**:
+
+**8 useEffect hooks running on mount:**
+1. Deferred font loading (7 Arabic/Quran fonts)
+2. Tajweed data preload (triggers 8.3MB JSON parse)
+3. AppInitializer (SQLite DB + 7 services)
+4. `onLayoutRootView` (splash screen hiding)
+5. expo-audio service initialization + store pre-warming
+6. Navigation readiness check
+7. SystemUI background color
+8. Android navigation bar configuration (**dynamic import of `expo-navigation-bar`**)
+
+**7-level provider nesting:**
+```
+ErrorBoundary
+  ThemeProvider
+    SafeAreaProvider
+      ExpoAudioProvider
+        GestureHandlerRootView
+          SheetProvider
+            Stack
+```
+
+**Problem:** On mount, the root layout triggers font loading, tajweed parsing, SQLite initialization, audio service setup, store hydration, AND 17 sheet module evaluations — all competing for the same JS thread. On Android, this creates a visible freeze after splash screen dismissal.
+
+The **dynamic import of expo-navigation-bar** (`app/_layout.tsx:234`) runs on every theme change on Android, adding latency to theme switches.
+
+**Files:**
+- `app/_layout.tsx:60-375`
+- `services/AppInitializer.ts:68-139`
+
+---
+
+### HIGH — Sheet Gesture Handling Disabled on Android (Severity: 7/10)
+
+All three `@gorhom/bottom-sheet` usage sites disable `enableContentPanningGesture` on Android:
+
+```typescript
+enableContentPanningGesture={Platform.OS === 'ios'}
+```
+
+**Found in:**
+- `components/player/v2/PlayerSheet.tsx:259`
+- `components/BottomSheetModal.tsx:113`
+- `components/modals/BaseModal.tsx:97`
+
+This means on Android, content inside bottom sheets **cannot be scrolled by gestures starting on the content area** — the user can only drag the handle. This creates a noticeably worse UX on Android and makes sheet interaction feel broken/unresponsive.
+
+This was likely added as a workaround for gesture conflicts, but it's a blanket disable rather than a proper fix.
+
+---
+
+### MEDIUM — Missing Android Configuration (Severity: 5/10)
+
+`app.config.js` is missing some Android-specific optimizations:
+
+1. **No `largeHeap: true`** — With 28MB of bundled JSON data plus runtime data structures, the app should request large heap allocation on Android. Without it, the app runs under tighter memory constraints, increasing GC pressure and potential OOM crashes.
+
+2. ~~**New Architecture**~~ — **RESOLVED.** `newArchEnabled=true` is already set in `android/gradle.properties:38`.
+
+3. ~~**Hermes engine**~~ — **RESOLVED.** `hermesEnabled=true` is already set in `android/gradle.properties:42`.
+
+4. **React Compiler disabled** — There's a comment: `// React Compiler disabled - causes performance issues with Zustand subscriptions`. This means the app misses out on automatic memoization that would particularly help Android.
+
+5. **No ProGuard/R8 optimization flags** in the Expo config.
+
+**Files:**
+- `app.config.js:87-96` — Android section
+
+---
+
+### MEDIUM — Fuse.js Search Initialization (Severity: 6/10)
+
+`components/search/SearchView.tsx` creates two separate Fuse.js indices when the search tab first mounts:
+
+1. **Reciter Fuse** — Indexes all reciters with multiple weighted keys (name, translated_name, rewayat names)
+2. **Surah Fuse** — Indexes all 114 surahs with weighted keys
+
+This initialization happens in a `useEffect` with `[]` dependency, meaning it runs every time the search screen mounts. On Android, building the Fuse index for ~200+ reciters with nested rewayat data causes a visible pause.
+
+The search tab uses `lazy: true` in the tab config, so this only happens on first navigation to search — but when it does, it's noticeable.
+
+**Files:**
+- `components/search/SearchView.tsx:121-138` — Fuse instance creation
+
+---
+
+### MEDIUM — No `getItemLayout` on Lists (Severity: 6/10)
+
+The main `SurahsView` SectionList (`components/SurahsView.tsx:397-413`) has good config:
+- `initialNumToRender={25}`
+- `maxToRenderPerBatch={10}`
+- `windowSize={5}`
+- `removeClippedSubviews={true}`
+
+But it's **missing `getItemLayout`**, which means React Native must measure every list item asynchronously. For the 114+ items in the surah list (plus Juz headers in some modes), this causes:
+- Scroll position jumps
+- Blank cells during fast scrolling
+- Extra layout passes on Android (which is slower at async measurement than iOS)
+
+The card view mode creates variable-height rows, making `getItemLayout` harder, but the list view mode has consistent heights and should use it.
+
+**Files:**
+- `components/SurahsView.tsx:397-413`
+
+---
+
+### MEDIUM — LinearGradient in List Items (Severity: 5/10)
+
+Juz header items in `SurahsView` render **two `LinearGradient` components** each (`components/SurahsView.tsx:178-208`). `expo-linear-gradient` uses native views, and creating/destroying these during scroll in a virtualized list adds overhead on Android, where native view creation is more expensive than iOS.
+
+**Files:**
+- `components/SurahsView.tsx:178-208` — Juz header with 2x LinearGradient
+
+---
+
+### MEDIUM — AppInitializer Sequential Critical Path (Severity: 5/10)
+
+`services/AppInitializer.ts` runs critical services **sequentially** and non-critical in parallel:
+
+**Sequential (critical):**
+1. Database initialization (SQLite)
+2. Playlist Service initialization
+
+**Parallel (non-critical):**
+3. Audio Configuration
+4. Playlists Data loading
+5. Adhkar Service
+6. Adhkar Store Data
+7. Uploads Service + recitations + custom reciters + orphan cleanup
+
+The sequential portion blocks app readiness. Database init on Android is typically 200-500ms slower than iOS due to SQLite performance differences.
+
+**Files:**
+- `services/AppInitializer.ts:79-136`
+
+---
+
+### LOW — TouchableOpacity Still Used (Severity: 3/10)
+
+Despite CLAUDE.md explicitly stating "Use `Pressable` instead of `TouchableOpacity`", `TouchableOpacity` is still used in several places:
+- `components/SurahsView.tsx:258,292,326,362` — sort buttons and view mode toggle
+- Various other components
+
+The opacity animation on press uses the JS thread on Android, while `Pressable` can use native press handling.
+
+---
+
+### LOW — `Color()` Calls in Render (Severity: 3/10)
+
+Multiple components call `Color(theme.colors.text).alpha(0.05).toString()` inside render methods or inline styles. While individually cheap, these create new string objects on every render.
+
+**Found in:**
+- `components/SurahsView.tsx:189,262,299,330`
+- `components/player/v2/PlayerSheet.tsx:242`
+
+---
+
+## Architecture Diagram — Current Problem
+
+```
+App Launch (Android)
+├── Module Evaluation (BLOCKING)
+│   ├── reciters.json parse (492KB) ← blocks all imports of RECITERS
+│   ├── 17 sheet modules + their dependency trees
+│   └── All data/* module requires
+├── Root Layout Mount
+│   ├── useEffect #1: Font loading (7 Arabic fonts)
+│   ├── useEffect #2: Tajweed preload → setTimeout(100ms) → require(8.3MB JSON) ← HUGE FREEZE
+│   ├── useEffect #3: AppInitializer (SQLite + 7 services)
+│   ├── useEffect #4: expo-audio init + store pre-warming
+│   ├── useEffect #5: Navigation readiness
+│   ├── useEffect #6: SystemUI color
+│   ├── useEffect #7: Android nav bar (dynamic import!)
+│   └── useEffect #8: Share intent handling
+├── Provider Tree (7 levels)
+├── Tab Layout Mount
+│   └── Home tab (lazy=true, good)
+│       └── SurahsView mounts → SectionList with 114+ items, no getItemLayout
+└── First Frame Rendered (LATE on Android)
+```
+
+---
+
+## Multi-Phase Remediation Plan
+
+### Phase 1: Data Loading Revolution (Highest Impact)
+**Goal:** Eliminate JS thread blocking from bundled data
+**Expected Impact:** 40-60% improvement in startup and mount/unmount responsiveness
+
+1. **Move large JSON data to SQLite** — Instead of bundling `QPC Hafs Tajweed 2.json` (8.3MB), `QPC V4 2.json` (5.2MB), and other Quran text data as JSON, pre-process them into a SQLite database that ships with the app. SQLite reads are paginated, lazy, and don't block the JS thread for the entire dataset.
+
+2. **Lazy-load tajweed data per-surah** — Instead of parsing all 8.3MB at startup, load tajweed data only for the currently viewed surah. Use the SQLite approach: `SELECT * FROM tajweed WHERE surah = ?`.
+
+3. **Chunk the tajweed processing** — If SQLite migration is too large for Phase 1, at minimum use `InteractionManager.runAfterInteractions()` combined with chunked processing (process 100 entries per frame using `requestAnimationFrame` or `setImmediate`).
+
+4. **Pre-build the Fuse.js index** — Generate the Fuse index at build time (via a script) and ship the serialized index instead of building it at runtime.
+
+---
+
+### Phase 2: Startup Declutter (High Impact)
+**Goal:** Reduce work competing for the JS thread during app initialization
+**Expected Impact:** 20-30% improvement in time-to-interactive
+
+1. **Lazy-register action sheets** — Replace the eager import of all 17 sheets in `sheets.tsx` with dynamic `import()` calls. Register each sheet only when it's first shown. Most users never open most sheets in a single session.
+
+2. **Cache the `expo-navigation-bar` module** — The Android nav bar setup dynamically imports `expo-navigation-bar` on every theme change. Import it once at the top level (with `Platform.OS === 'android'` guard) and cache the reference.
+
+3. **Defer non-visible initialization** — Move tajweed, adhkar, uploads, and Fuse.js initialization to `InteractionManager.runAfterInteractions()` so they run after the first frame is painted.
+
+4. **Consolidate root layout useEffects** — Merge the 8 useEffect hooks into 2-3 logical groups (critical init, deferred init, theme sync) to reduce the number of effect scheduling overhead.
+
+---
+
+### Phase 3: Android-Specific Configuration (Medium Impact)
+**Goal:** Enable Android platform optimizations
+**Expected Impact:** 15-25% general performance improvement
+
+1. **Enable `largeHeap: true`** in `app.config.js` under `android`:
+   ```js
+   android: {
+     ...existing,
+     largeHeap: true,
+   }
+   ```
+
+2. ~~**Evaluate New Architecture**~~ — **Already enabled.** `newArchEnabled=true` in `android/gradle.properties:38`. No action needed.
+
+3. **Investigate React Compiler compatibility** — The comment says it was disabled due to Zustand issues. Research if newer Zustand versions or the `useStore` pattern with explicit selectors resolves this. The compiler's auto-memoization would significantly help Android.
+
+4. ~~**Explicit Hermes optimizations**~~ — **Already enabled.** `hermesEnabled=true` in `android/gradle.properties:42`. No action needed.
+
+---
+
+### Phase 4: Sheet & Navigation Smoothness (Medium Impact)
+**Goal:** Fix sheet interaction UX and navigation transitions on Android
+**Expected Impact:** Noticeable UX improvement, eliminates "broken feel"
+
+1. **Fix `enableContentPanningGesture` on Android** — Instead of disabling it entirely, use proper gesture conflict resolution. Options:
+   - Use `simultaneousHandlers` to allow both sheet and content gestures
+   - Use `BottomSheetScrollView`/`BottomSheetFlatList` from `@gorhom/bottom-sheet` inside sheet content
+   - Test per-sheet — some sheets may work fine with the gesture enabled
+
+2. **Add screen transition optimization** — The root Stack uses `animation: 'fade'` which is good, but ensure all nested navigators also use native-driver animations. Consider `animation: 'none'` for tab switches if they're already lazy-loaded.
+
+3. **Add `freezeOnBlur` verification** — Already set on tabs (good), but verify it's working by checking that off-screen tabs truly don't re-render.
+
+4. **Optimize PlayerSheet** — The player bottom sheet (`@gorhom/bottom-sheet`) renders `PlayerContent` eagerly. Consider rendering a placeholder when the sheet is at index -1 (hidden).
+
+---
+
+### Phase 5: List & Rendering Polish (Lower Impact, High Polish)
+**Goal:** Smooth scrolling and eliminate frame drops in lists
+**Expected Impact:** 10-15% improvement in scroll performance
+
+1. **Add `getItemLayout` to SurahsView** in list mode (fixed height items). This eliminates async measurement and enables instant scroll-to-index.
+
+2. **Replace LinearGradient in Juz headers** — Use a simpler View with opacity gradient or a cached static image for the decorative lines. Native view creation for each header in a virtualized list is expensive.
+
+3. **Replace remaining TouchableOpacity** with Pressable across all components.
+
+4. **Memoize `Color()` computations** — Move `Color(theme.colors.text).alpha(X).toString()` into `useMemo` or compute them once in the theme object.
+
+5. **Add `recyclingKey` to expo-image** in list contexts to enable image recycling on Android.
+
+6. **Audit and add `React.memo`** to frequently re-rendered list item components (SurahItem, SurahCard, ReciterItem).
+
+---
+
+### Phase 6: Memory & Long-Session Stability (Maintenance)
+**Goal:** Prevent performance degradation over time
+**Expected Impact:** Prevents crashes and slowdowns in extended sessions
+
+1. **Implement memory monitoring** — Add a dev-mode memory usage display to catch leaks early.
+
+2. **Audit Zustand store sizes** — Check if stores accumulate stale data over time (recently played, search history, etc.).
+
+3. **Configure expo-image cache limits** — Set explicit cache size limits for Android to prevent memory pressure from accumulated images.
+
+4. **Test with Android profiler** — Use Android Studio's CPU and Memory profiler with a release build to validate improvements from each phase.
+
+---
+
+## Priority Matrix
+
+| Phase | Impact | Effort | Do First? |
+|-------|--------|--------|-----------|
+| Phase 1: Data Loading | Very High | High | YES |
+| Phase 2: Startup Declutter | High | Medium | YES |
+| Phase 3: Android Config | Medium | Low | YES (quick wins) |
+| Phase 4: Sheet & Nav | Medium | Medium | After 1-3 |
+| Phase 5: List Polish | Medium-Low | Low | After 1-3 |
+| Phase 6: Memory | Low (preventive) | Low | Ongoing |
+
+**Recommended order:** Phase 3 (quick config wins) → Phase 2 (startup declutter) → Phase 1 (data revolution) → Phase 4 → Phase 5 → Phase 6
+
+Phase 3 is listed first because `largeHeap` and config changes are one-line fixes with immediate benefit. Phase 2's lazy sheet loading is medium effort with high payoff. Phase 1 is the most impactful but requires the most work (SQLite migration for Quran data).

--- a/docs/features/verse-interactions.md
+++ b/docs/features/verse-interactions.md
@@ -1,0 +1,459 @@
+# Feature: Verse-Level Interactions
+
+**Status:** Architecture Complete, Implementation Pending
+**Priority:** High
+**Complexity:** High
+**Created:** 2026-02-10
+
+## Overview
+
+Verse-level interactions enable users to bookmark, annotate, highlight, copy, share, and read tafseer for individual Quran verses (ayahs). This builds a shared architecture that both the existing list view and a future mushaf (page) view can use seamlessly.
+
+Currently, all Bayaan features (loved tracks, downloads, playlists) operate at the **surah level**. The `handleVersePress` stub in `PlayerContent/index.tsx` only logs to console. This feature introduces the first ayah-level interaction layer.
+
+### Motivation
+
+A mushaf (page) view with individual ayah selection is being built separately. By building the shared verse interaction architecture now using the existing list view, we ensure the mushaf view plugs into the same system when it lands.
+
+## Feature Scope
+
+### Included (v1)
+
+| Feature | Description |
+|---------|-------------|
+| Bookmark | Toggle bookmark on any verse |
+| Note | Add/edit/delete a text note on any verse |
+| Highlight | Apply one of 6 highlight colors to a verse |
+| Copy | Copy verse text with configurable options |
+| Share | Share verse text via system share sheet |
+| Translation | View verse translation (Saheeh International, Clear Quran) |
+| Tafseer | Read tafseer from Quran.com API (Ibn Kathir default) |
+
+### Deferred
+
+| Feature | Reason |
+|---------|--------|
+| Play-from-verse | Blocked on ayah-level timestamp data |
+| Repeat verse | Blocked on ayah-level timestamp data |
+| Bookmark folders | v1 uses flat list; folders added later based on usage |
+
+### Selection UX
+
+- **Long-press** to select a verse (opens action sheet)
+- **Tap** reserved for future play-from-verse
+
+## Architecture
+
+### Layer Overview
+
+```
+Types (verse-annotations.ts)
+  ↓
+SQLite Database (VerseAnnotationDatabaseService.ts)
+  ↓
+Service Layer (VerseAnnotationService.ts)
+  ↓
+Zustand Stores (verseSelectionStore.ts, verseAnnotationsStore.ts)
+  ↓
+Hooks (useVerseSelection, useVerseAnnotations, useVerseActions)
+  ↓
+UI (VerseItem, QuranView, Bottom Sheets)
+```
+
+Both the list view and future mushaf view read/write to the same stores and service layer.
+
+---
+
+## 1. Types — `types/verse-annotations.ts`
+
+```typescript
+export type HighlightColor = 'yellow' | 'green' | 'blue' | 'pink' | 'orange' | 'purple';
+
+export const HIGHLIGHT_COLORS: Record<HighlightColor, string> = {
+  yellow: '#FFF3B0',
+  green: '#B8F0C0',
+  blue: '#B0D4FF',
+  pink: '#FFB0D4',
+  orange: '#FFD4B0',
+  purple: '#D4B0FF',
+};
+
+export interface VerseBookmark {
+  id: string;
+  verseKey: string;        // "2:255"
+  surahNumber: number;
+  ayahNumber: number;
+  createdAt: number;
+}
+
+export interface VerseNote {
+  id: string;
+  verseKey: string;
+  surahNumber: number;
+  ayahNumber: number;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface VerseHighlight {
+  id: string;
+  verseKey: string;
+  surahNumber: number;
+  ayahNumber: number;
+  color: HighlightColor;
+  createdAt: number;
+}
+```
+
+---
+
+## 2. Database — `services/database/VerseAnnotationDatabaseService.ts`
+
+Follows the existing `DatabaseService.ts` singleton pattern (private `db`, `initPromise`, WAL mode).
+
+**Database file:** `verse-annotations.db` (separate from main app DB)
+
+### Schema
+
+```sql
+bookmarks (
+  id TEXT PRIMARY KEY,
+  verse_key TEXT NOT NULL UNIQUE,
+  surah_number INTEGER NOT NULL,
+  ayah_number INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+)
+-- Index: idx_bookmarks_surah ON bookmarks(surah_number)
+
+notes (
+  id TEXT PRIMARY KEY,
+  verse_key TEXT NOT NULL UNIQUE,
+  surah_number INTEGER NOT NULL,
+  ayah_number INTEGER NOT NULL,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+)
+-- Index: idx_notes_surah ON notes(surah_number)
+
+highlights (
+  id TEXT PRIMARY KEY,
+  verse_key TEXT NOT NULL UNIQUE,
+  surah_number INTEGER NOT NULL,
+  ayah_number INTEGER NOT NULL,
+  color TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+)
+-- Index: idx_highlights_surah ON highlights(surah_number)
+```
+
+### Key Decisions
+
+- **UNIQUE on `verse_key`** for all tables — one bookmark/note/highlight per verse
+- **`surah_number` indexed** for efficient per-surah batch queries
+- **Separate DB file** follows existing pattern of isolated databases per domain
+
+---
+
+## 3. Service Layer — `services/verse-annotations/VerseAnnotationService.ts`
+
+Thin service wrapping the database. Exported as singleton `verseAnnotationService`.
+
+### Methods
+
+| Category | Method | Return |
+|----------|--------|--------|
+| Init | `initialize()` | `Promise<void>` |
+| Bookmarks | `toggleBookmark(verseKey, surahNum, ayahNum)` | `Promise<boolean>` (true = added) |
+| Bookmarks | `getBookmark(verseKey)` | `Promise<VerseBookmark \| null>` |
+| Bookmarks | `getAllBookmarks()` | `Promise<VerseBookmark[]>` |
+| Bookmarks | `getBookmarksBySurah(surahNum)` | `Promise<VerseBookmark[]>` |
+| Notes | `upsertNote(verseKey, surahNum, ayahNum, content)` | `Promise<VerseNote>` |
+| Notes | `getNote(verseKey)` | `Promise<VerseNote \| null>` |
+| Notes | `deleteNote(verseKey)` | `Promise<void>` |
+| Notes | `getNotesBySurah(surahNum)` | `Promise<VerseNote[]>` |
+| Highlights | `setHighlight(verseKey, surahNum, ayahNum, color)` | `Promise<VerseHighlight>` |
+| Highlights | `removeHighlight(verseKey)` | `Promise<void>` |
+| Highlights | `getHighlightsBySurah(surahNum)` | `Promise<VerseHighlight[]>` |
+| Batch | `getAnnotationsForSurah(surahNum)` | `Promise<{ bookmarks[], notes[], highlights[] }>` |
+
+### AppInitializer Registration
+
+Registered at priority 7, non-critical:
+
+```typescript
+appInitializer.registerService({
+  name: 'Verse Annotations',
+  priority: 7,
+  critical: false,
+  initialize: async () => {
+    await verseAnnotationService.initialize();
+  },
+});
+```
+
+---
+
+## 4. State Management
+
+### 4a. `store/verseSelectionStore.ts` — Ephemeral UI State
+
+Not persisted. Both list view and future mushaf view share this store.
+
+```typescript
+interface VerseSelectionState {
+  selectedVerseKey: string | null;
+  selectedSurahNumber: number | null;
+  selectedAyahNumber: number | null;
+  selectVerse(verseKey: string, surahNumber: number, ayahNumber: number): void;
+  clearSelection(): void;
+}
+```
+
+### 4b. `store/verseAnnotationsStore.ts` — Cached Annotations from SQLite
+
+```typescript
+interface VerseAnnotationsState {
+  loadedSurah: number | null;
+  bookmarkedVerseKeys: Set<string>;          // O(1) lookup
+  notedVerseKeys: Set<string>;               // O(1) lookup
+  highlights: Record<string, HighlightColor>; // verseKey -> color
+  loading: boolean;
+
+  // Load all annotations for a surah (called on surah change)
+  loadAnnotationsForSurah(surahNumber: number): Promise<void>;
+
+  // Mutations (optimistic update + async SQLite write)
+  toggleBookmark(verseKey: string, surahNumber: number, ayahNumber: number): Promise<boolean>;
+  upsertNote(verseKey: string, surahNumber: number, ayahNumber: number, content: string): Promise<void>;
+  deleteNote(verseKey: string): Promise<void>;
+  setHighlight(verseKey: string, surahNumber: number, ayahNumber: number, color: HighlightColor): Promise<void>;
+  removeHighlight(verseKey: string): Promise<void>;
+
+  // Query helpers (used in renderItem)
+  isBookmarked(verseKey: string): boolean;
+  hasNote(verseKey: string): boolean;
+  getHighlightColor(verseKey: string): HighlightColor | null;
+}
+```
+
+### Sync Strategy
+
+- **On surah change:** Single batch query `getAnnotationsForSurah()` populates Sets/Records
+- **On mutation:** Optimistic update to Zustand (instant UI) + async SQLite write
+- **No startup pre-loading:** Loads on-demand when the player opens a surah
+
+---
+
+## 5. Hooks
+
+### `hooks/useVerseSelection.ts`
+
+Thin wrapper over `verseSelectionStore`. Returns `selectedVerseKey`, `selectVerse`, `clearSelection`, `isSelected(verseKey)`.
+
+### `hooks/useVerseActions.ts`
+
+Zero-re-render action-only hook (follows `usePlayerActions` pattern). Returns memoized functions: `toggleBookmark`, `upsertNote`, `deleteNote`, `setHighlight`, `removeHighlight`, `showActionsSheet`.
+
+### `hooks/useVerseAnnotations.ts`
+
+Used by QuranView. Takes `surahNumber`, calls `loadAnnotationsForSurah` on change, returns `isBookmarked`, `hasNote`, `getHighlightColor` functions.
+
+---
+
+## 6. UI Components
+
+### 6a. VerseItem Changes
+
+**File:** `components/player/v2/PlayerContent/QuranView/VerseItem.tsx`
+
+New props added to `VerseItemProps`:
+
+```typescript
+isSelected: boolean;
+highlightColor: string | null;  // hex from HIGHLIGHT_COLORS
+hasBookmark: boolean;
+hasNote: boolean;
+onLongPress: () => void;
+```
+
+Visual changes:
+- `isSelected` — subtle background tint + left border accent
+- `highlightColor` — applied as background on the Arabic text container
+- `hasBookmark` / `hasNote` — small indicator icons next to the verse pill
+- `onLongPress` wired to the `Pressable` component
+
+Existing `onPress` remains as a stub, reserved for future play-from-verse.
+
+### 6b. QuranView Changes
+
+**File:** `components/player/v2/PlayerContent/QuranView/index.tsx`
+
+- Subscribe to `useVerseSelection` and `useVerseAnnotations(currentSurah)`
+- Call `loadAnnotationsForSurah` when `currentSurah` changes
+- Pass annotation props to each VerseItem in `renderItem`
+- `onLongPress` calls `selectVerse()` + `SheetManager.show('verse-actions', { payload })`
+
+### 6c. PlayerContent Changes
+
+**File:** `components/player/v2/PlayerContent/index.tsx`
+
+- Wire `clearSelection` to fire when surah changes or player closes
+
+### 6d. Bottom Sheets
+
+All lazy-loaded via `react-native-actions-sheet`:
+
+| Sheet | File | Purpose |
+|-------|------|---------|
+| `verse-actions` | `VerseActionsSheet.tsx` | Main action grid |
+| `verse-highlight` | `VerseHighlightSheet.tsx` | Color picker (6 circles) |
+| `verse-note` | `VerseNoteSheet.tsx` | TextInput with Save/Delete |
+| `verse-copy` | `VerseCopySheet.tsx` | Checkbox copy options |
+| `verse-tafseer` | `VerseTafseerSheet.tsx` | Scrollable tafseer content |
+| `verse-translation` | `VerseTranslationSheet.tsx` | Translation picker |
+
+**VerseActionsSheet layout** (follows `SurahOptionsSheet` options grid pattern):
+
+```
+Header: "Al-Baqarah 2:255"
+─────────────────────────────────
+[Bookmark]  Bookmark     [Highlight]  Highlight
+[Note]      Add Note     [Copy]       Copy
+[Share]     Share         [Book]       Translation
+[Tafseer]   Tafseer
+```
+
+- Actions that complete instantly (bookmark toggle, share) close the sheet
+- Actions needing sub-sheets (highlight, note, copy, translation, tafseer) open the sub-sheet
+
+**Share** uses React Native's `Share.share()`:
+
+```
+{arabic text}
+
+{translation}
+
+— Quran {surah}:{ayah}
+```
+
+All sheets registered in `components/sheets/sheets.tsx` using `lazySheet` + type declarations.
+
+---
+
+## 7. Tafseer Integration — Quran.com API
+
+**Endpoint:** `GET https://api.quran.com/api/v4/tafsirs/{tafsir_id}/by_ayah/{verse_key}`
+
+Example: `GET /api/v4/tafsirs/en-tafisr-ibn-kathir/by_ayah/2:255`
+
+### Implementation (VerseTafseerSheet.tsx)
+
+- Fetches tafseer on sheet open (loading spinner)
+- Caches responses in memory (`Map<string, TafseerResponse>`) to avoid re-fetching during session
+- Renders HTML content using `react-native-render-html` (already in the project)
+- No SQLite caching (read-only reference data)
+- v1 defaults to Ibn Kathir; tafsir source picker is a future enhancement
+
+---
+
+## 8. File Structure
+
+### New Files
+
+```
+types/
+  verse-annotations.ts
+
+services/
+  database/
+    VerseAnnotationDatabaseService.ts
+  verse-annotations/
+    VerseAnnotationService.ts
+
+store/
+  verseSelectionStore.ts
+  verseAnnotationsStore.ts
+
+hooks/
+  useVerseSelection.ts
+  useVerseActions.ts
+  useVerseAnnotations.ts
+
+components/
+  sheets/
+    VerseActionsSheet.tsx
+    VerseHighlightSheet.tsx
+    VerseNoteSheet.tsx
+    VerseCopySheet.tsx
+    VerseTafseerSheet.tsx
+    VerseTranslationSheet.tsx
+```
+
+### Modified Files
+
+```
+components/player/v2/PlayerContent/QuranView/VerseItem.tsx  — new props, visual states, onLongPress
+components/player/v2/PlayerContent/QuranView/index.tsx      — wire selection + annotations
+components/player/v2/PlayerContent/index.tsx                — clear selection on surah change
+components/sheets/sheets.tsx                                — register 6 new sheets + types
+services/AppInitializer.ts                                  — register verse annotations service
+```
+
+---
+
+## 9. Implementation Order
+
+### Step 1: Foundation
+
+1. Create `types/verse-annotations.ts`
+2. Create `VerseAnnotationDatabaseService` (SQLite)
+3. Create `VerseAnnotationService` (singleton)
+4. Register in `AppInitializer`
+5. Create `verseSelectionStore`
+6. Create `verseAnnotationsStore`
+
+### Step 2: Selection UX
+
+1. Create `useVerseSelection` hook
+2. Create `useVerseAnnotations` hook
+3. Create `useVerseActions` hook
+4. Update `VerseItem` with selection/annotation props
+5. Update `QuranView` to wire stores
+6. Update `PlayerContent` to clear selection on surah change
+
+### Step 3: Actions Sheet
+
+1. Create `VerseActionsSheet` (main grid)
+2. Register all sheets in `sheets.tsx`
+
+### Step 4: Features
+
+1. Copy (`VerseCopySheet`)
+2. Bookmark toggle
+3. Highlight (`VerseHighlightSheet`)
+4. Notes (`VerseNoteSheet`)
+5. Share (inline `Share.share()`)
+6. Translation picker (`VerseTranslationSheet`)
+7. Tafseer (`VerseTafseerSheet` + Quran.com API)
+
+### Step 5: Polish
+
+1. Bookmark/note indicators in `VerseItem`
+2. Prettier + TypeScript checks
+
+---
+
+## 10. Performance Considerations
+
+- **VerseItem** is already `React.memo()`. New props are primitives — only 2 items re-render per selection change (old + new)
+- **Annotation lookups** use `Set.has()` and `Record` access — O(1) in the render path
+- **Per-surah loading** keeps memory bounded regardless of total annotations
+- **Optimistic updates** give instant visual feedback; SQLite writes are async
+- **LegendList recycling** works correctly since annotation props are per-item in `renderItem`
+- **Lazy-loaded sheets** add zero cost to startup
+
+---
+
+*Created: 2026-02-10*

--- a/services/audio/LockScreenService.ts
+++ b/services/audio/LockScreenService.ts
@@ -201,7 +201,7 @@ class LockScreenService {
       // Re-sync metadata when duration becomes known (was 0, now real)
       if (currentTrack && playback.duration > 0 && this.lastDuration === 0) {
         this.lastDuration = playback.duration;
-        this.syncMetadata(currentTrack);
+        this.syncMetadata(currentTrack, playback.duration);
       }
 
       // Update playback state when it changes
@@ -212,17 +212,21 @@ class LockScreenService {
     });
   }
 
-  private syncMetadata(track: {
-    title: string;
-    artist: string;
-    artwork?: string;
-    duration?: number;
-  }): void {
+  private syncMetadata(
+    track: {
+      title: string;
+      artist: string;
+      artwork?: string;
+      duration?: number;
+    },
+    durationOverride?: number,
+  ): void {
     updateMetadata({
       title: track.title,
       artist: track.artist,
       artwork: track.artwork ? {uri: track.artwork} : undefined,
-      duration: track.duration ?? expoAudioService.getDuration(),
+      duration:
+        durationOverride || track.duration || expoAudioService.getDuration(),
     }).catch(error => {
       if (__DEV__)
         console.warn('[LockScreenService] Failed to update metadata:', error);

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -14,7 +14,5 @@ export const TOTAL_BOTTOM_PADDING = FLOATING_PLAYER_HEIGHT;
 
 // Calculate the position from the bottom for the floating player based on tab bar height and insets
 export const getFloatingPlayerBottomPosition = (bottomInset = 0): number => {
-  // Only apply insets on iOS as Android handles this differently
-  const insetToApply = Platform.OS === 'ios' ? bottomInset : 0;
-  return TAB_BAR_HEIGHT + insetToApply + FLOATING_PLAYER_BOTTOM_MARGIN;
+  return TAB_BAR_HEIGHT + bottomInset + FLOATING_PLAYER_BOTTOM_MARGIN;
 };

--- a/utils/tajweedLoader.ts
+++ b/utils/tajweedLoader.ts
@@ -106,11 +106,10 @@ function createIndexedTajweedData(
 }
 
 /**
- * Preloads tajweed data in the background.
- * This function should be called early in the app lifecycle.
- * @returns Promise that resolves when data is loaded
+ * Preloads and processes tajweed data synchronously.
+ * The caller is responsible for deferral (e.g. InteractionManager.runAfterInteractions).
  */
-export const preloadTajweedData = async (): Promise<void> => {
+export const preloadTajweedData = (): void => {
   const {
     setTajweedData,
     setProcessedTajweedData,
@@ -119,17 +118,15 @@ export const preloadTajweedData = async (): Promise<void> => {
     setError,
   } = useTajweedStore.getState();
 
-  try {
-    setIsLoading(true);
-    console.log('[TajweedLoader] Starting tajweed data load...');
+  setIsLoading(true);
+  if (__DEV__) console.log('[TajweedLoader] Starting tajweed data load...');
 
-    // Using dynamic import instead of require to avoid blocking UI thread
-    // Note: For React Native, you may need to ensure this works with your bundler
-    const tajweedModule = await import('@/data/QPC Hafs Tajweed 2.json');
-    const rawTajweedData = tajweedModule.default as TajweedData;
+  try {
+    const rawTajweedData =
+      require('@/data/QPC Hafs Tajweed 2.json') as TajweedData;
 
     // Process the data to pre-parse the tajweed words
-    console.log('[TajweedLoader] Pre-processing tajweed data...');
+    if (__DEV__) console.log('[TajweedLoader] Pre-processing tajweed data...');
     const processed: ProcessedTajweedData = {};
 
     Object.entries(rawTajweedData).forEach(([key, word]) => {
@@ -141,7 +138,7 @@ export const preloadTajweedData = async (): Promise<void> => {
     });
 
     // Create indexed lookup table for O(1) verse access
-    console.log('[TajweedLoader] Creating indexed lookup...');
+    if (__DEV__) console.log('[TajweedLoader] Creating indexed lookup...');
     const indexedData = createIndexedTajweedData(processed);
 
     // Store all data forms
@@ -149,9 +146,10 @@ export const preloadTajweedData = async (): Promise<void> => {
     setProcessedTajweedData(processed);
     setIndexedTajweedData(indexedData);
 
-    console.log(
-      '[TajweedLoader] Tajweed data preloaded and processed successfully',
-    );
+    if (__DEV__)
+      console.log(
+        '[TajweedLoader] Tajweed data preloaded and processed successfully',
+      );
   } catch (error) {
     console.error('[TajweedLoader] Error preloading tajweed data:', error);
     setError(
@@ -162,64 +160,4 @@ export const preloadTajweedData = async (): Promise<void> => {
   } finally {
     setIsLoading(false);
   }
-};
-
-/**
- * Alternative implementation using a separate thread with setTimeout
- * Use this if dynamic import doesn't work well in React Native
- */
-export const preloadTajweedDataWithTimeout = (): void => {
-  const {
-    setTajweedData,
-    setProcessedTajweedData,
-    setIndexedTajweedData,
-    setIsLoading,
-    setError,
-  } = useTajweedStore.getState();
-
-  setIsLoading(true);
-  console.log('[TajweedLoader] Starting tajweed data load with timeout...');
-
-  // Use setTimeout to move the heavy loading off the main thread
-  setTimeout(() => {
-    try {
-      // This still blocks, but at least it's deferred
-      const rawTajweedData =
-        require('@/data/QPC Hafs Tajweed 2.json') as TajweedData;
-
-      // Process the data to pre-parse the tajweed words
-      console.log('[TajweedLoader] Pre-processing tajweed data...');
-      const processed: ProcessedTajweedData = {};
-
-      Object.entries(rawTajweedData).forEach(([key, word]) => {
-        processed[key] = {
-          word_index: word.word_index,
-          location: word.location,
-          segments: processTajweedWord(word.text),
-        };
-      });
-
-      // Create indexed lookup table for O(1) verse access
-      console.log('[TajweedLoader] Creating indexed lookup...');
-      const indexedData = createIndexedTajweedData(processed);
-
-      // Store all data forms
-      setTajweedData(rawTajweedData);
-      setProcessedTajweedData(processed);
-      setIndexedTajweedData(indexedData);
-
-      console.log(
-        '[TajweedLoader] Tajweed data preloaded and processed successfully',
-      );
-    } catch (error) {
-      console.error('[TajweedLoader] Error preloading tajweed data:', error);
-      setError(
-        error instanceof Error
-          ? error.message
-          : 'Unknown error loading tajweed data',
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  }, 100); // Small delay to let the UI render first
 };

--- a/withLargeHeap.js
+++ b/withLargeHeap.js
@@ -1,0 +1,13 @@
+const {withAndroidManifest} = require('@expo/config-plugins');
+
+const withLargeHeap = config => {
+  return withAndroidManifest(config, async config => {
+    const mainApplication = config.modResults.manifest.application?.[0];
+    if (mainApplication?.$) {
+      mainApplication.$['android:largeHeap'] = 'true';
+    }
+    return config;
+  });
+};
+
+module.exports = withLargeHeap;


### PR DESCRIPTION
## Summary
- **Zero-lag QuranView**: Pre-index all 6,236 verses by surah at module scope (O(1) lookup), decouple tajweed from verse computation so loading tajweed data doesn't trigger full-list re-renders, lazy-load Indopak font data (1.7MB saved for QPC users)
- **Instant Queue/Quran toggle**: Replace `display: 'none'` with `opacity: 0` + `pointerEvents` prop so LegendList keeps its measurements intact
- **Fix all action sheets**: Revert broken `React.lazy` sheet registration — `react-native-actions-sheet` requires synchronous components for its imperative ref system
- **Cross-platform gesture fixes**: Enable `enableContentPanningGesture` on Android for BottomSheet, BaseModal, and PlayerSheet; use `BottomSheetScrollView` in QueueList
- **Navigation perf**: Add `freezeOnBlur` to Home and Collection stack navigators
- **Android bottom insets, lock-screen progress bar, spring animation normalization** (prior commits on branch)

## Test plan
- [ ] Open player sheet — verses appear instantly, no flicker
- [ ] Toggle Queue ↔ Quran — instant, no layout recalc
- [ ] Change surah (next/prev track) — verses update immediately
- [ ] Tajweed colors appear when data loads (no full-list flicker)
- [ ] Tap footnote superscript numbers — footnote panel shows correctly
- [ ] Test both QPC and Indopak font families
- [ ] Open mushaf layout sheet, playback speed sheet, sleep timer sheet, ambient sounds sheet — all work
- [ ] Test scrolling in player sheet on Android (gestures work properly)
- [ ] Verify bottom insets look correct on Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)