### PR TITLE
Add Go to Reciter option to Upload & Surah sheets

### DIFF
--- a/components/reciter-profile/ReciterProfile.tsx
+++ b/components/reciter-profile/ReciterProfile.tsx
@@ -751,6 +751,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                 reciterId: currentReciterId,
                 rewayatId: selectedRewayat?.id,
                 onAddToQueue: handleAddToQueue,
+                hideGoToReciter: true,
               },
             })
           }
@@ -791,7 +792,8 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
             {/* between action buttons and tab bar when the header is not collapsed */}
             <View
               onLayout={e => setCollapsibleHeight(e.nativeEvent.layout.height)}
-              style={{marginBottom: -stickyTitleHeight}}>
+              style={{marginBottom: -stickyTitleHeight, zIndex: 11}}
+              pointerEvents="box-none">
               <ReciterHeader
                 reciter={reciter}
                 showSearch={showSearch}
@@ -812,7 +814,8 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
             {/* Inner View has opaque background for the actual tab bar + controls */}
             <View
               onLayout={e => setStickyHeight(e.nativeEvent.layout.height)}
-              style={{paddingTop: stickyTitleHeight}}>
+              style={{paddingTop: stickyTitleHeight}}
+              pointerEvents="box-none">
               <View style={{backgroundColor: theme.colors.background}}>
                 {tabs.length > 0 && (
                   <RewayatTabBar
@@ -973,6 +976,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                                 reciterId: currentReciterId,
                                 rewayatId: tab.id,
                                 onAddToQueue: handleAddToQueue,
+                                hideGoToReciter: true,
                               },
                             })
                           }

--- a/components/sheets/SurahOptionsSheet.tsx
+++ b/components/sheets/SurahOptionsSheet.tsx
@@ -9,7 +9,7 @@ import {
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
-import {QueueIcon, HeartIcon, CheckIcon} from '@/components/Icons';
+import {QueueIcon, HeartIcon, CheckIcon, ProfileIcon} from '@/components/Icons';
 import ActionSheet, {
   SheetProps,
   SheetManager,
@@ -17,6 +17,7 @@ import ActionSheet, {
 } from 'react-native-actions-sheet';
 import {Feather, Ionicons} from '@expo/vector-icons';
 import {useLoved} from '@/hooks/useLoved';
+import {useReciterNavigation} from '@/hooks/useReciterNavigation';
 import {
   useDownloadActions,
   useDownloadProgress,
@@ -85,6 +86,8 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
         : '__none__',
     [reciterId, surahId, rewayatId],
   );
+
+  const {navigateToReciterProfile} = useReciterNavigation();
 
   // These expensive hooks now only run when sheet is actually open
   const {isLoved, isLovedWithRewayat, toggleLoved} = useLoved();
@@ -217,6 +220,13 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
     setDownloadProgress,
     downloadId,
   ]);
+
+  const handleGoToReciter = useCallback(() => {
+    handleClose();
+    if (reciterId) {
+      navigateToReciterProfile(reciterId);
+    }
+  }, [handleClose, reciterId, navigateToReciterProfile]);
 
   const handleRemoveFromPlaylist = useCallback(() => {
     handleClose();
@@ -400,6 +410,25 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
                 Add to Collection
               </Text>
             </TouchableOpacity>
+
+            {reciterId && !payload?.hideGoToReciter && (
+              <TouchableOpacity
+                style={[
+                  styles.option,
+                  pressedOption === 'reciter' && styles.optionPressed,
+                ]}
+                onPress={handleGoToReciter}
+                onPressIn={() => setPressedOption('reciter')}
+                onPressOut={() => setPressedOption(null)}
+                activeOpacity={1}>
+                <ProfileIcon
+                  color={theme.colors.text}
+                  size={moderateScale(20)}
+                  filled={false}
+                />
+                <Text style={styles.optionText}>Go to Reciter</Text>
+              </TouchableOpacity>
+            )}
 
             <TouchableOpacity
               style={[

--- a/components/sheets/UploadOptionsSheet.tsx
+++ b/components/sheets/UploadOptionsSheet.tsx
@@ -10,7 +10,7 @@ import {
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
-import {QueueIcon, HeartIcon, PlayIcon} from '@/components/Icons';
+import {QueueIcon, HeartIcon, PlayIcon, ProfileIcon} from '@/components/Icons';
 import ActionSheet, {
   SheetProps,
   SheetManager,
@@ -21,6 +21,7 @@ import Color from 'color';
 import {useUploadsStore, getCustomReciterName} from '@/store/uploadsStore';
 import {getSurahById, getReciterName} from '@/services/dataService';
 import {useLoved} from '@/hooks/useLoved';
+import {useReciterNavigation} from '@/hooks/useReciterNavigation';
 import type {UploadedRecitation} from '@/types/uploads';
 import RenderHtml, {
   MixedStyleDeclaration,
@@ -116,6 +117,7 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
 
   const {deleteRecitation} = useUploadsStore();
   const {isLovedWithRewayat, toggleLoved} = useLoved();
+  const {navigateToReciterProfile} = useReciterNavigation();
 
   const payload = props.payload;
   const recitation = payload?.recitation;
@@ -206,6 +208,13 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
       },
     });
   }, [reciterId, surah, recitation?.id]);
+
+  const handleGoToReciter = useCallback(() => {
+    handleClose();
+    if (reciterId) {
+      navigateToReciterProfile(reciterId);
+    }
+  }, [handleClose, reciterId, navigateToReciterProfile]);
 
   const handleViewInfo = useCallback(() => {
     setShowSurahInfo(true);
@@ -366,6 +375,22 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
                   color={theme.colors.text}
                 />
                 <Text style={styles.optionText}>Add to Collection</Text>
+              </Pressable>
+            )}
+
+            {hasReciter && (
+              <Pressable
+                style={({pressed}) => [
+                  styles.option,
+                  pressed && styles.optionPressed,
+                ]}
+                onPress={handleGoToReciter}>
+                <ProfileIcon
+                  color={theme.colors.text}
+                  size={moderateScale(20)}
+                  filled={false}
+                />
+                <Text style={styles.optionText}>Go to Reciter</Text>
               </Pressable>
             )}
 

--- a/components/sheets/sheets.tsx
+++ b/components/sheets/sheets.tsx
@@ -57,6 +57,7 @@ declare module 'react-native-actions-sheet' {
         rewayatId?: string;
         onAddToQueue?: (surah: Surah) => Promise<void>;
         onRemoveFromPlaylist?: () => void;
+        hideGoToReciter?: boolean;
       };
     }>;
     'rewayat-info': SheetDefinition<{


### PR DESCRIPTION
## Summary
- Added "Go to Reciter" option to `UploadOptionsSheet` (visible when item has a system reciter)
- Added "Go to Reciter" option to `SurahOptionsSheet` (visible when reciterId exists)
- Added `hideGoToReciter` payload flag to suppress the option on `ReciterProfile` where it's redundant
- Reuses existing `useReciterNavigation` hook and `ProfileIcon`, matching `PlayerOptionsSheet` pattern

## Test plan
- [ ] Uploads screen: open options on a tagged upload with system reciter → "Go to Reciter" appears; tap → navigates to reciter profile
- [ ] Uploads screen: open options on upload with custom reciter → "Go to Reciter" does NOT appear
- [ ] Loved screen: open track options → "Go to Reciter" appears; tap → navigates
- [ ] Playlist detail: open track options → "Go to Reciter" appears; tap → navigates
- [ ] Reciter profile: open surah options → "Go to Reciter" does NOT appear
- [ ] Player options sheet: existing "Go to Reciter" still works (no changes)
- [ ] `npx tsc --noEmit` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)