### PR TITLE
fix(player): restore content panning and pan-to-dismiss on TrackInfo

### DIFF
--- a/components/player/v2/PlayerContent/TrackInfo.tsx
+++ b/components/player/v2/PlayerContent/TrackInfo.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useEffect, useState} from 'react';
-import {View, Text, Pressable, StyleSheet} from 'react-native';
+import {View, Text, StyleSheet} from 'react-native';
+import {Pressable} from 'react-native-gesture-handler';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {usePlayerActions} from '@/hooks/usePlayerActions';

--- a/components/player/v2/PlayerSheet.tsx
+++ b/components/player/v2/PlayerSheet.tsx
@@ -9,30 +9,16 @@ import {usePlayerActions} from '@/hooks/usePlayerActions';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {useTheme} from '@/hooks/useTheme';
 import PlayerContent from './PlayerContent';
+import {Header} from './PlayerContent/Header';
 import Color from 'color';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {SURAHS} from '@/data/surahData';
 import {useReciterNavigation} from '@/hooks/useReciterNavigation';
 import {SheetManager} from 'react-native-actions-sheet';
 
-// Custom handle component for the bottom sheet
-const CustomHandle = (_props: BottomSheetHandleProps) => {
-  const {theme} = useTheme();
-  const insets = useSafeAreaInsets();
-  return (
-    <View style={[styles.handleContainer, {paddingTop: insets.top + 12}]}>
-      <View
-        style={[
-          styles.handle,
-          {backgroundColor: Color(theme.colors.text).alpha(0.2).toString()},
-        ]}
-      />
-    </View>
-  );
-};
-
 export const PlayerSheet = () => {
   const {theme} = useTheme();
+  const insets = useSafeAreaInsets();
   const bottomSheetRef = useRef<BottomSheet>(null);
   const [remainingTime, setRemainingTime] = useState<number | null>(null);
   const {navigateToReciterProfile} = useReciterNavigation();
@@ -232,6 +218,23 @@ export const PlayerSheet = () => {
     }
   }, [currentTrack, handleGoToReciter]);
 
+  const renderHandleComponent = useCallback(
+    (_props: BottomSheetHandleProps) => (
+      <View style={[styles.handleContainer, {paddingTop: insets.top + 12}]}>
+        <View
+          style={[
+            styles.handle,
+            {
+              backgroundColor: Color(theme.colors.text).alpha(0.2).toString(),
+            },
+          ]}
+        />
+        <Header onOptionsPress={handleShowOptionsSheet} />
+      </View>
+    ),
+    [insets.top, theme.colors.text, handleShowOptionsSheet],
+  );
+
   // Only render modals once settings are loaded to prevent hydration issues
   if (!shouldShow) {
     return null;
@@ -255,7 +258,7 @@ export const PlayerSheet = () => {
         backdropComponent={renderBackdrop}
         index={currentIndex}
         animateOnMount={false}
-        handleComponent={CustomHandle}
+        handleComponent={renderHandleComponent}
         enableContentPanningGesture
         style={styles.sheet}
         backgroundStyle={[
@@ -266,7 +269,6 @@ export const PlayerSheet = () => {
           onSpeedPress={handleShowSpeedSheet}
           onSleepTimerPress={handleShowSleepTimerSheet}
           onMushafLayoutPress={handleShowMushafLayoutSheet}
-          onOptionsPress={handleShowOptionsSheet}
           onAmbientPress={handleShowAmbientSheet}
         />
       </BottomSheet>


### PR DESCRIPTION
## Summary
- Reverted `enableContentPanningGesture={false}` which broke overscroll-to-dismiss and content area panning
- Moved Header into the bottom sheet handle component so it uses the independent handle pan gesture
- Switched TrackInfo's `Pressable` import from `react-native` to `react-native-gesture-handler` so it coordinates with the sheet's RNGH pan gesture instead of blocking it

## Test plan
- [ ] Open player sheet → scroll QuranView down → swipe Header area down → sheet dismisses
- [ ] Open player sheet → scroll QueueList down → swipe Header area down → sheet dismisses
- [ ] Open player sheet → scroll QuranView to top → keep pulling down → sheet dismisses (overscroll-to-dismiss)
- [ ] Swipe down on reciter info row (TrackInfo) → sheet dismisses
- [ ] Tap reciter info → navigates to reciter profile
- [ ] Tap heart button → toggles loved state
- [ ] Content scrolling works normally in both QuranView and QueueList

🤖 Generated with [Claude Code](https://claude.com/claude-code)