### PR TITLE
feat: verse interactions — annotations, sheets, and collection screens

### DIFF
--- a/app/(tabs)/(c.collection)/_layout.tsx
+++ b/app/(tabs)/(c.collection)/_layout.tsx
@@ -15,6 +15,8 @@ export default function CollectionLayout() {
       <Stack.Screen name="collection/playlists" />
       <Stack.Screen name="collection/downloads" />
       <Stack.Screen name="collection/uploads" />
+      <Stack.Screen name="collection/bookmarks" />
+      <Stack.Screen name="collection/notes" />
       <Stack.Screen name="playlist/[id]" />
     </Stack>
   );

--- a/app/(tabs)/(c.collection)/collection/bookmarks.tsx
+++ b/app/(tabs)/(c.collection)/collection/bookmarks.tsx
@@ -1,0 +1,330 @@
+import React, {useState, useCallback, useRef} from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  StatusBar,
+  Animated as RNAnimated,
+} from 'react-native';
+import {useTheme} from '@/hooks/useTheme';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {useRouter} from 'expo-router';
+import {useFocusEffect} from '@react-navigation/native';
+import {moderateScale} from 'react-native-size-matters';
+import {Feather} from '@expo/vector-icons';
+import {ListRenderItem} from 'react-native';
+import {getSurahById} from '@/services/dataService';
+import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {BookmarkItem} from '@/components/collection/BookmarkItem';
+import {CollectionStickyHeader} from '@/components/collection/CollectionStickyHeader';
+import {SheetManager} from 'react-native-actions-sheet';
+import Color from 'color';
+import type {VerseBookmark} from '@/types/verse-annotations';
+
+interface BookmarkData {
+  bookmark: VerseBookmark;
+  surahName: string;
+}
+
+const BookmarksScreen = () => {
+  const {theme} = useTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const [bookmarks, setBookmarks] = useState<BookmarkData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const scrollY = useRef(new RNAnimated.Value(0)).current;
+
+  const loadBookmarks = useCallback(async () => {
+    try {
+      setLoading(true);
+      const allBookmarks = await verseAnnotationService.getAllBookmarks();
+      const enriched = allBookmarks.map(bookmark => {
+        const surah = getSurahById(bookmark.surahNumber);
+        return {
+          bookmark,
+          surahName: surah?.name ?? `Surah ${bookmark.surahNumber}`,
+        };
+      });
+      setBookmarks(enriched);
+    } catch (error) {
+      console.error('Failed to load bookmarks:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadBookmarks();
+    }, [loadBookmarks]),
+  );
+
+  const handleRemoveBookmark = useCallback(async (bookmark: VerseBookmark) => {
+    await verseAnnotationService.removeBookmark(bookmark.verseKey);
+    useVerseAnnotationsStore.getState().removeBookmark(bookmark.verseKey);
+    setBookmarks(prev => prev.filter(b => b.bookmark.id !== bookmark.id));
+  }, []);
+
+  const handleOptionsPress = useCallback(
+    (item: BookmarkData) => {
+      SheetManager.show('collection-options', {
+        payload: {
+          title: item.surahName,
+          subtitle: `Ayah ${item.bookmark.ayahNumber}`,
+          options: [
+            {
+              label: 'Remove Bookmark',
+              icon: 'trash-2',
+              destructive: true,
+              onPress: () => handleRemoveBookmark(item.bookmark),
+            },
+          ],
+        },
+      });
+    },
+    [handleRemoveBookmark],
+  );
+
+  const ListHeaderComponent = useCallback(() => {
+    return (
+      <View style={styles.headerContainer}>
+        <View style={{paddingTop: insets.top}} />
+        <View style={styles.headerContent}>
+          <View
+            style={[
+              styles.headerIcon,
+              {backgroundColor: Color('#F59E0B').alpha(0.15).toString()},
+            ]}>
+            <Feather name="bookmark" size={moderateScale(28)} color="#F59E0B" />
+          </View>
+          <Text style={[styles.headerTitle, {color: theme.colors.text}]}>
+            Bookmarks
+          </Text>
+          <Text
+            style={[
+              styles.headerSubtitle,
+              {color: theme.colors.textSecondary},
+            ]}>
+            {bookmarks.length}{' '}
+            {bookmarks.length === 1 ? 'bookmark' : 'bookmarks'}
+          </Text>
+        </View>
+      </View>
+    );
+  }, [bookmarks.length, insets.top, theme]);
+
+  const renderItem: ListRenderItem<BookmarkData> = ({item}) => (
+    <BookmarkItem
+      surahName={item.surahName}
+      ayahNumber={item.bookmark.ayahNumber}
+      surahNumber={item.bookmark.surahNumber}
+      onPress={() => {}}
+      onOptionsPress={() => handleOptionsPress(item)}
+    />
+  );
+
+  const getItemKey = (item: BookmarkData) => item.bookmark.id;
+
+  if (loading) {
+    return (
+      <View
+        style={[styles.container, {backgroundColor: theme.colors.background}]}>
+        <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
+          <Pressable
+            style={styles.emptyHeaderBack}
+            onPress={() => router.back()}
+            hitSlop={8}>
+            <Feather
+              name="arrow-left"
+              size={moderateScale(22)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+          <Text style={[styles.emptyHeaderTitle, {color: theme.colors.text}]}>
+            Bookmarks
+          </Text>
+          <View style={styles.emptyHeaderBack} />
+        </View>
+        <View style={styles.emptyContent}>
+          <Text
+            style={[styles.loadingText, {color: theme.colors.textSecondary}]}>
+            Loading...
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  if (bookmarks.length === 0) {
+    return (
+      <View
+        style={[styles.container, {backgroundColor: theme.colors.background}]}>
+        <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
+          <Pressable
+            style={styles.emptyHeaderBack}
+            onPress={() => router.back()}
+            hitSlop={8}>
+            <Feather
+              name="arrow-left"
+              size={moderateScale(22)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+          <Text style={[styles.emptyHeaderTitle, {color: theme.colors.text}]}>
+            Bookmarks
+          </Text>
+          <View style={styles.emptyHeaderBack} />
+        </View>
+        <View style={styles.emptyContent}>
+          <View style={styles.emptyIcon}>
+            <Feather
+              name="bookmark"
+              size={moderateScale(48)}
+              color={theme.colors.textSecondary}
+            />
+          </View>
+          <Text style={[styles.emptyTitle, {color: theme.colors.text}]}>
+            No bookmarks yet
+          </Text>
+          <Text
+            style={[styles.emptySubtitle, {color: theme.colors.textSecondary}]}>
+            Bookmark verses to see them here
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.container, {backgroundColor: theme.colors.background}]}>
+      <StatusBar barStyle="default" />
+
+      <RNAnimated.View
+        style={[
+          styles.fixedBackButton,
+          {
+            top: insets.top + moderateScale(10),
+            opacity: scrollY.interpolate({
+              inputRange: [80, 120],
+              outputRange: [1, 0],
+              extrapolate: 'clamp',
+            }),
+          },
+        ]}>
+        <Pressable onPress={() => router.back()} hitSlop={8}>
+          <Feather
+            name="arrow-left"
+            size={moderateScale(24)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+      </RNAnimated.View>
+
+      <RNAnimated.FlatList
+        data={bookmarks}
+        renderItem={renderItem}
+        keyExtractor={getItemKey}
+        ListHeaderComponent={ListHeaderComponent}
+        contentContainerStyle={styles.listContentContainer}
+        onScroll={RNAnimated.event(
+          [{nativeEvent: {contentOffset: {y: scrollY}}}],
+          {useNativeDriver: true},
+        )}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator={false}
+      />
+      <CollectionStickyHeader title="Bookmarks" scrollY={scrollY} />
+    </View>
+  );
+};
+
+export default BookmarksScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  headerContainer: {
+    alignItems: 'center',
+  },
+  headerContent: {
+    alignItems: 'center',
+    paddingVertical: moderateScale(24),
+  },
+  headerIcon: {
+    width: moderateScale(64),
+    height: moderateScale(64),
+    borderRadius: moderateScale(16),
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: moderateScale(12),
+  },
+  headerTitle: {
+    fontSize: moderateScale(22),
+    fontFamily: 'Manrope-Bold',
+    marginBottom: moderateScale(4),
+  },
+  headerSubtitle: {
+    fontSize: moderateScale(14),
+    fontFamily: 'Manrope-Regular',
+  },
+  listContentContainer: {
+    flexGrow: 1,
+    paddingBottom: moderateScale(65),
+  },
+  fixedBackButton: {
+    position: 'absolute',
+    left: moderateScale(15),
+    zIndex: 5,
+    padding: moderateScale(8),
+  },
+  emptyHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingBottom: moderateScale(12),
+    paddingHorizontal: moderateScale(16),
+  },
+  emptyHeaderBack: {
+    width: moderateScale(36),
+    height: moderateScale(36),
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  emptyHeaderTitle: {
+    flex: 1,
+    fontSize: moderateScale(17),
+    fontFamily: 'Manrope-Bold',
+    textAlign: 'center',
+  },
+  emptyContent: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: moderateScale(32),
+    paddingBottom: moderateScale(60),
+  },
+  emptyIcon: {
+    marginBottom: moderateScale(16),
+  },
+  emptyTitle: {
+    fontSize: moderateScale(17),
+    fontFamily: 'Manrope-Bold',
+    textAlign: 'center',
+    marginBottom: moderateScale(8),
+  },
+  emptySubtitle: {
+    fontSize: moderateScale(13),
+    fontFamily: 'Manrope-Regular',
+    textAlign: 'center',
+    marginBottom: moderateScale(20),
+  },
+  loadingText: {
+    fontSize: moderateScale(16),
+    textAlign: 'center',
+  },
+});

--- a/app/(tabs)/(c.collection)/collection/bookmarks.tsx
+++ b/app/(tabs)/(c.collection)/collection/bookmarks.tsx
@@ -88,17 +88,24 @@ const BookmarksScreen = () => {
     [handleRemoveBookmark],
   );
 
+  const heroOuterBg = Color(theme.colors.textSecondary).alpha(0.1).toString();
+  const heroInnerBg = Color(theme.colors.textSecondary).alpha(0.08).toString();
+
   const ListHeaderComponent = useCallback(() => {
     return (
       <View style={styles.headerContainer}>
         <View style={{paddingTop: insets.top}} />
         <View style={styles.headerContent}>
           <View
-            style={[
-              styles.headerIcon,
-              {backgroundColor: Color('#F59E0B').alpha(0.15).toString()},
-            ]}>
-            <Feather name="bookmark" size={moderateScale(28)} color="#F59E0B" />
+            style={[styles.heroIconContainer, {backgroundColor: heroOuterBg}]}>
+            <View
+              style={[styles.heroIconInner, {backgroundColor: heroInnerBg}]}>
+              <Feather
+                name="bookmark"
+                size={moderateScale(30)}
+                color={theme.colors.text}
+              />
+            </View>
           </View>
           <Text style={[styles.headerTitle, {color: theme.colors.text}]}>
             Bookmarks
@@ -114,13 +121,14 @@ const BookmarksScreen = () => {
         </View>
       </View>
     );
-  }, [bookmarks.length, insets.top, theme]);
+  }, [bookmarks.length, insets.top, theme, heroOuterBg, heroInnerBg]);
 
   const renderItem: ListRenderItem<BookmarkData> = ({item}) => (
     <BookmarkItem
       surahName={item.surahName}
       ayahNumber={item.bookmark.ayahNumber}
       surahNumber={item.bookmark.surahNumber}
+      verseKey={item.bookmark.verseKey}
       onPress={() => {}}
       onOptionsPress={() => handleOptionsPress(item)}
     />
@@ -255,13 +263,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: moderateScale(24),
   },
-  headerIcon: {
+  heroIconContainer: {
     width: moderateScale(64),
     height: moderateScale(64),
-    borderRadius: moderateScale(16),
+    borderRadius: moderateScale(32),
     justifyContent: 'center',
     alignItems: 'center',
     marginBottom: moderateScale(12),
+  },
+  heroIconInner: {
+    width: moderateScale(56),
+    height: moderateScale(56),
+    borderRadius: moderateScale(28),
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   headerTitle: {
     fontSize: moderateScale(22),

--- a/app/(tabs)/(c.collection)/collection/notes.tsx
+++ b/app/(tabs)/(c.collection)/collection/notes.tsx
@@ -1,0 +1,355 @@
+import React, {useState, useCallback, useRef} from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  StatusBar,
+  Animated as RNAnimated,
+} from 'react-native';
+import {useTheme} from '@/hooks/useTheme';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {useRouter} from 'expo-router';
+import {useFocusEffect} from '@react-navigation/native';
+import {moderateScale} from 'react-native-size-matters';
+import {Feather} from '@expo/vector-icons';
+import {ListRenderItem} from 'react-native';
+import {getSurahById} from '@/services/dataService';
+import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {NoteItem} from '@/components/collection/NoteItem';
+import {CollectionStickyHeader} from '@/components/collection/CollectionStickyHeader';
+import {SheetManager} from 'react-native-actions-sheet';
+import Color from 'color';
+import type {VerseNote} from '@/types/verse-annotations';
+
+interface NoteData {
+  note: VerseNote;
+  surahName: string;
+}
+
+const NotesScreen = () => {
+  const {theme} = useTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const [notes, setNotes] = useState<NoteData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const scrollY = useRef(new RNAnimated.Value(0)).current;
+
+  const loadNotes = useCallback(async () => {
+    try {
+      setLoading(true);
+      const allNotes = await verseAnnotationService.getAllNotes();
+      const enriched = allNotes.map(note => {
+        const surah = getSurahById(note.surahNumber);
+        return {
+          note,
+          surahName: surah?.name ?? `Surah ${note.surahNumber}`,
+        };
+      });
+      setNotes(enriched);
+    } catch (error) {
+      console.error('Failed to load notes:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadNotes();
+    }, [loadNotes]),
+  );
+
+  const handleDeleteNote = useCallback(async (note: VerseNote) => {
+    await verseAnnotationService.deleteNoteById(note.id);
+    const remaining = await verseAnnotationService.getNotesCountForVerse(
+      note.verseKey,
+    );
+    if (remaining === 0) {
+      useVerseAnnotationsStore.getState().removeNote(note.verseKey);
+    }
+    setNotes(prev => prev.filter(n => n.note.id !== note.id));
+  }, []);
+
+  const handleNotePress = useCallback((item: NoteData) => {
+    SheetManager.show('verse-note', {
+      payload: {
+        verseKey: item.note.verseKey,
+        surahNumber: item.note.surahNumber,
+        ayahNumber: item.note.ayahNumber,
+        noteId: item.note.id,
+      },
+    });
+  }, []);
+
+  const handleOptionsPress = useCallback(
+    (item: NoteData) => {
+      SheetManager.show('collection-options', {
+        payload: {
+          title: item.surahName,
+          subtitle: `Ayah ${item.note.ayahNumber}`,
+          options: [
+            {
+              label: 'Edit Note',
+              icon: 'edit-2',
+              onPress: () => handleNotePress(item),
+            },
+            {
+              label: 'Delete Note',
+              icon: 'trash-2',
+              destructive: true,
+              onPress: () => handleDeleteNote(item.note),
+            },
+          ],
+        },
+      });
+    },
+    [handleDeleteNote, handleNotePress],
+  );
+
+  const ListHeaderComponent = useCallback(() => {
+    return (
+      <View style={styles.headerContainer}>
+        <View style={{paddingTop: insets.top}} />
+        <View style={styles.headerContent}>
+          <View
+            style={[
+              styles.headerIcon,
+              {backgroundColor: Color('#3B82F6').alpha(0.15).toString()},
+            ]}>
+            <Feather
+              name="file-text"
+              size={moderateScale(28)}
+              color="#3B82F6"
+            />
+          </View>
+          <Text style={[styles.headerTitle, {color: theme.colors.text}]}>
+            Notes
+          </Text>
+          <Text
+            style={[
+              styles.headerSubtitle,
+              {color: theme.colors.textSecondary},
+            ]}>
+            {notes.length} {notes.length === 1 ? 'note' : 'notes'}
+          </Text>
+        </View>
+      </View>
+    );
+  }, [notes.length, insets.top, theme]);
+
+  const renderItem: ListRenderItem<NoteData> = ({item}) => (
+    <NoteItem
+      surahName={item.surahName}
+      ayahNumber={item.note.ayahNumber}
+      surahNumber={item.note.surahNumber}
+      notePreview={item.note.content}
+      onPress={() => handleNotePress(item)}
+      onOptionsPress={() => handleOptionsPress(item)}
+    />
+  );
+
+  const getItemKey = (item: NoteData) => item.note.id;
+
+  if (loading) {
+    return (
+      <View
+        style={[styles.container, {backgroundColor: theme.colors.background}]}>
+        <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
+          <Pressable
+            style={styles.emptyHeaderBack}
+            onPress={() => router.back()}
+            hitSlop={8}>
+            <Feather
+              name="arrow-left"
+              size={moderateScale(22)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+          <Text style={[styles.emptyHeaderTitle, {color: theme.colors.text}]}>
+            Notes
+          </Text>
+          <View style={styles.emptyHeaderBack} />
+        </View>
+        <View style={styles.emptyContent}>
+          <Text
+            style={[styles.loadingText, {color: theme.colors.textSecondary}]}>
+            Loading...
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  if (notes.length === 0) {
+    return (
+      <View
+        style={[styles.container, {backgroundColor: theme.colors.background}]}>
+        <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
+          <Pressable
+            style={styles.emptyHeaderBack}
+            onPress={() => router.back()}
+            hitSlop={8}>
+            <Feather
+              name="arrow-left"
+              size={moderateScale(22)}
+              color={theme.colors.text}
+            />
+          </Pressable>
+          <Text style={[styles.emptyHeaderTitle, {color: theme.colors.text}]}>
+            Notes
+          </Text>
+          <View style={styles.emptyHeaderBack} />
+        </View>
+        <View style={styles.emptyContent}>
+          <View style={styles.emptyIcon}>
+            <Feather
+              name="file-text"
+              size={moderateScale(48)}
+              color={theme.colors.textSecondary}
+            />
+          </View>
+          <Text style={[styles.emptyTitle, {color: theme.colors.text}]}>
+            No notes yet
+          </Text>
+          <Text
+            style={[styles.emptySubtitle, {color: theme.colors.textSecondary}]}>
+            Add notes to verses to see them here
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.container, {backgroundColor: theme.colors.background}]}>
+      <StatusBar barStyle="default" />
+
+      <RNAnimated.View
+        style={[
+          styles.fixedBackButton,
+          {
+            top: insets.top + moderateScale(10),
+            opacity: scrollY.interpolate({
+              inputRange: [80, 120],
+              outputRange: [1, 0],
+              extrapolate: 'clamp',
+            }),
+          },
+        ]}>
+        <Pressable onPress={() => router.back()} hitSlop={8}>
+          <Feather
+            name="arrow-left"
+            size={moderateScale(24)}
+            color={theme.colors.text}
+          />
+        </Pressable>
+      </RNAnimated.View>
+
+      <RNAnimated.FlatList
+        data={notes}
+        renderItem={renderItem}
+        keyExtractor={getItemKey}
+        ListHeaderComponent={ListHeaderComponent}
+        contentContainerStyle={styles.listContentContainer}
+        onScroll={RNAnimated.event(
+          [{nativeEvent: {contentOffset: {y: scrollY}}}],
+          {useNativeDriver: true},
+        )}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator={false}
+      />
+      <CollectionStickyHeader title="Notes" scrollY={scrollY} />
+    </View>
+  );
+};
+
+export default NotesScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  headerContainer: {
+    alignItems: 'center',
+  },
+  headerContent: {
+    alignItems: 'center',
+    paddingVertical: moderateScale(24),
+  },
+  headerIcon: {
+    width: moderateScale(64),
+    height: moderateScale(64),
+    borderRadius: moderateScale(16),
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: moderateScale(12),
+  },
+  headerTitle: {
+    fontSize: moderateScale(22),
+    fontFamily: 'Manrope-Bold',
+    marginBottom: moderateScale(4),
+  },
+  headerSubtitle: {
+    fontSize: moderateScale(14),
+    fontFamily: 'Manrope-Regular',
+  },
+  listContentContainer: {
+    flexGrow: 1,
+    paddingBottom: moderateScale(65),
+  },
+  fixedBackButton: {
+    position: 'absolute',
+    left: moderateScale(15),
+    zIndex: 5,
+    padding: moderateScale(8),
+  },
+  emptyHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingBottom: moderateScale(12),
+    paddingHorizontal: moderateScale(16),
+  },
+  emptyHeaderBack: {
+    width: moderateScale(36),
+    height: moderateScale(36),
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  emptyHeaderTitle: {
+    flex: 1,
+    fontSize: moderateScale(17),
+    fontFamily: 'Manrope-Bold',
+    textAlign: 'center',
+  },
+  emptyContent: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: moderateScale(32),
+    paddingBottom: moderateScale(60),
+  },
+  emptyIcon: {
+    marginBottom: moderateScale(16),
+  },
+  emptyTitle: {
+    fontSize: moderateScale(17),
+    fontFamily: 'Manrope-Bold',
+    textAlign: 'center',
+    marginBottom: moderateScale(8),
+  },
+  emptySubtitle: {
+    fontSize: moderateScale(13),
+    fontFamily: 'Manrope-Regular',
+    textAlign: 'center',
+    marginBottom: moderateScale(20),
+  },
+  loadingText: {
+    fontSize: moderateScale(16),
+    textAlign: 'center',
+  },
+});

--- a/app/(tabs)/(c.collection)/collection/notes.tsx
+++ b/app/(tabs)/(c.collection)/collection/notes.tsx
@@ -109,21 +109,24 @@ const NotesScreen = () => {
     [handleDeleteNote, handleNotePress],
   );
 
+  const heroOuterBg = Color(theme.colors.textSecondary).alpha(0.1).toString();
+  const heroInnerBg = Color(theme.colors.textSecondary).alpha(0.08).toString();
+
   const ListHeaderComponent = useCallback(() => {
     return (
       <View style={styles.headerContainer}>
         <View style={{paddingTop: insets.top}} />
         <View style={styles.headerContent}>
           <View
-            style={[
-              styles.headerIcon,
-              {backgroundColor: Color('#3B82F6').alpha(0.15).toString()},
-            ]}>
-            <Feather
-              name="file-text"
-              size={moderateScale(28)}
-              color="#3B82F6"
-            />
+            style={[styles.heroIconContainer, {backgroundColor: heroOuterBg}]}>
+            <View
+              style={[styles.heroIconInner, {backgroundColor: heroInnerBg}]}>
+              <Feather
+                name="file-text"
+                size={moderateScale(30)}
+                color={theme.colors.text}
+              />
+            </View>
           </View>
           <Text style={[styles.headerTitle, {color: theme.colors.text}]}>
             Notes
@@ -138,13 +141,14 @@ const NotesScreen = () => {
         </View>
       </View>
     );
-  }, [notes.length, insets.top, theme]);
+  }, [notes.length, insets.top, theme, heroOuterBg, heroInnerBg]);
 
   const renderItem: ListRenderItem<NoteData> = ({item}) => (
     <NoteItem
       surahName={item.surahName}
       ayahNumber={item.note.ayahNumber}
       surahNumber={item.note.surahNumber}
+      verseKey={item.note.verseKey}
       notePreview={item.note.content}
       onPress={() => handleNotePress(item)}
       onOptionsPress={() => handleOptionsPress(item)}
@@ -280,13 +284,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: moderateScale(24),
   },
-  headerIcon: {
+  heroIconContainer: {
     width: moderateScale(64),
     height: moderateScale(64),
-    borderRadius: moderateScale(16),
+    borderRadius: moderateScale(32),
     justifyContent: 'center',
     alignItems: 'center',
     marginBottom: moderateScale(12),
+  },
+  heroIconInner: {
+    width: moderateScale(56),
+    height: moderateScale(56),
+    borderRadius: moderateScale(28),
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   headerTitle: {
     fontSize: moderateScale(22),

--- a/app/(tabs)/(c.collection)/index.tsx
+++ b/app/(tabs)/(c.collection)/index.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 import {View, ScrollView, Platform, Text, Pressable} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -23,6 +23,8 @@ import {
   ProfileIcon,
 } from '@/components/Icons';
 import {useUploadsStore} from '@/store/uploadsStore';
+import {useFocusEffect} from '@react-navigation/native';
+import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
 
 interface CategoryItem {
   id: string;
@@ -44,6 +46,22 @@ export default function CollectionScreen() {
   const downloads = useDownloads();
   const {playlists} = usePlaylists();
   const {totalCount: uploadsTotalCount} = useUploadsStore();
+
+  const [bookmarkCount, setBookmarkCount] = useState(0);
+  const [noteCount, setNoteCount] = useState(0);
+
+  useFocusEffect(
+    useCallback(() => {
+      verseAnnotationService
+        .getAllBookmarks()
+        .then(b => setBookmarkCount(b.length))
+        .catch(() => {});
+      verseAnnotationService
+        .getAllNotes()
+        .then(n => setNoteCount(n.length))
+        .catch(() => {});
+    }, []),
+  );
 
   const handleAddPress = useCallback(() => {
     SheetManager.show('add-to-collection');
@@ -89,6 +107,28 @@ export default function CollectionScreen() {
       count: lovedTracks.length,
       emptyText: 'No loved surahs yet',
       route: '/collection/loved',
+    },
+    {
+      id: 'bookmarks',
+      label: 'Bookmarks',
+      icon: (
+        <Feather name="bookmark" size={moderateScale(22)} color="#F59E0B" />
+      ),
+      color: '#F59E0B',
+      count: bookmarkCount,
+      emptyText: 'No bookmarks yet',
+      route: '/collection/bookmarks',
+    },
+    {
+      id: 'notes',
+      label: 'Notes',
+      icon: (
+        <Feather name="file-text" size={moderateScale(22)} color="#3B82F6" />
+      ),
+      color: '#3B82F6',
+      count: noteCount,
+      emptyText: 'No notes yet',
+      route: '/collection/notes',
     },
     {
       id: 'uploads',

--- a/components/adhkar/DhikrListItem.tsx
+++ b/components/adhkar/DhikrListItem.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import {View, Text, TouchableOpacity} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -29,8 +29,7 @@ export const DhikrListItem: React.FC<DhikrListItemProps> = React.memo(
     const hasAudio = !!dhikr.audioFile;
 
     return (
-      <TouchableOpacity
-        activeOpacity={1}
+      <Pressable
         style={styles.container}
         onPress={onPress}
         accessibilityRole="button"
@@ -65,7 +64,7 @@ export const DhikrListItem: React.FC<DhikrListItemProps> = React.memo(
             <View style={styles.audioIndicator} />
           )}
         </View>
-      </TouchableOpacity>
+      </Pressable>
     );
   },
 );
@@ -73,42 +72,30 @@ export const DhikrListItem: React.FC<DhikrListItemProps> = React.memo(
 DhikrListItem.displayName = 'DhikrListItem';
 
 const createStyles = (theme: Theme) => {
-  const isDark =
-    theme.colors.background === '#000000' ||
-    Color(theme.colors.background).luminosity() < 0.5;
-
-  const parchmentBg = isDark
-    ? Color(theme.colors.card).lighten(0.1).toString()
-    : Color('#F5F0E6').mix(Color(theme.colors.card), 0.3).toString();
-
-  const inkColor = isDark
-    ? Color(theme.colors.text).alpha(0.9).toString()
-    : Color('#2C1810').mix(Color(theme.colors.text), 0.5).toString();
-
-  const goldAccent = isDark ? '#C9A85C' : '#8B7355';
+  const accentColor = theme.colors.textSecondary;
 
   return ScaledSheet.create({
     container: {
-      backgroundColor: parchmentBg,
+      backgroundColor: theme.colors.card,
       marginHorizontal: moderateScale(16),
       marginVertical: moderateScale(10),
-      borderRadius: moderateScale(16),
+      borderRadius: moderateScale(20),
       overflow: 'hidden',
       borderWidth: 1,
-      borderColor: Color(goldAccent).alpha(0.3).toString(),
+      borderColor: Color(accentColor).alpha(0.15).toString(),
     },
     ornamentBar: {
       flexDirection: 'row',
       alignItems: 'center',
       paddingVertical: moderateScale(8),
-      backgroundColor: Color(goldAccent).alpha(0.08).toString(),
+      backgroundColor: Color(accentColor).alpha(0.05).toString(),
       borderBottomWidth: 1,
-      borderBottomColor: Color(goldAccent).alpha(0.2).toString(),
+      borderBottomColor: Color(accentColor).alpha(0.1).toString(),
     },
     ornamentLeft: {
       flex: 1,
       height: 1,
-      backgroundColor: Color(goldAccent).alpha(0.4).toString(),
+      backgroundColor: Color(accentColor).alpha(0.2).toString(),
       marginLeft: moderateScale(16),
     },
     ornamentCenter: {
@@ -117,12 +104,12 @@ const createStyles = (theme: Theme) => {
     ornamentNumber: {
       fontSize: moderateScale(14),
       fontFamily: theme.fonts.semiBold,
-      color: goldAccent,
+      color: accentColor,
     },
     ornamentRight: {
       flex: 1,
       height: 1,
-      backgroundColor: Color(goldAccent).alpha(0.4).toString(),
+      backgroundColor: Color(accentColor).alpha(0.2).toString(),
       marginRight: moderateScale(16),
     },
     arabicContainer: {
@@ -132,7 +119,7 @@ const createStyles = (theme: Theme) => {
     arabicText: {
       fontSize: moderateScale(18),
       fontFamily: 'ScheherazadeNew-Regular',
-      color: inkColor,
+      color: theme.colors.text,
       textAlign: 'center',
       writingDirection: 'rtl',
       lineHeight: moderateScale(40),
@@ -143,13 +130,13 @@ const createStyles = (theme: Theme) => {
     },
     annotationLine: {
       height: 1,
-      backgroundColor: Color(inkColor).alpha(0.1).toString(),
+      backgroundColor: Color(accentColor).alpha(0.1).toString(),
       marginBottom: moderateScale(12),
     },
     translationText: {
       fontSize: moderateScale(13),
       fontFamily: theme.fonts.regular,
-      color: Color(inkColor).alpha(0.7).toString(),
+      color: accentColor,
       textAlign: 'center',
       lineHeight: moderateScale(20),
       fontStyle: 'italic',
@@ -160,20 +147,20 @@ const createStyles = (theme: Theme) => {
       alignItems: 'center',
       gap: moderateScale(12),
       paddingVertical: moderateScale(10),
-      backgroundColor: Color(goldAccent).alpha(0.05).toString(),
+      backgroundColor: Color(accentColor).alpha(0.05).toString(),
       borderTopWidth: 1,
-      borderTopColor: Color(goldAccent).alpha(0.15).toString(),
+      borderTopColor: Color(accentColor).alpha(0.15).toString(),
     },
     repeatText: {
       fontSize: moderateScale(11),
       fontFamily: theme.fonts.medium,
-      color: Color(goldAccent).darken(0.2).toString(),
+      color: accentColor,
     },
     audioIndicator: {
       width: moderateScale(6),
       height: moderateScale(6),
       borderRadius: moderateScale(3),
-      backgroundColor: goldAccent,
+      backgroundColor: accentColor,
     },
   });
 };

--- a/components/collection/BookmarkItem.tsx
+++ b/components/collection/BookmarkItem.tsx
@@ -1,0 +1,92 @@
+import React, {memo} from 'react';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
+import {moderateScale} from 'react-native-size-matters';
+import {Feather} from '@expo/vector-icons';
+import {useTheme} from '@/hooks/useTheme';
+import Color from 'color';
+
+interface BookmarkItemProps {
+  surahName: string;
+  ayahNumber: number;
+  surahNumber: number;
+  onPress: () => void;
+  onOptionsPress: () => void;
+}
+
+export const BookmarkItem = memo<BookmarkItemProps>(
+  ({surahName, ayahNumber, surahNumber, onPress, onOptionsPress}) => {
+    const {theme} = useTheme();
+
+    return (
+      <Pressable style={styles.container} onPress={onPress}>
+        <View
+          style={[
+            styles.iconContainer,
+            {
+              backgroundColor: Color('#F59E0B').alpha(0.15).toString(),
+            },
+          ]}>
+          <Feather name="bookmark" size={moderateScale(20)} color="#F59E0B" />
+        </View>
+        <View style={styles.info}>
+          <Text
+            style={[styles.surahName, {color: theme.colors.text}]}
+            numberOfLines={1}>
+            {surahName}
+          </Text>
+          <Text style={[styles.ayahLabel, {color: theme.colors.textSecondary}]}>
+            Ayah {ayahNumber}
+          </Text>
+        </View>
+        <Pressable
+          onPress={onOptionsPress}
+          hitSlop={8}
+          style={({pressed}) => [
+            styles.optionsButton,
+            {opacity: pressed ? 0.5 : 1},
+          ]}>
+          <Feather
+            name="more-horizontal"
+            size={moderateScale(18)}
+            color={theme.colors.textSecondary}
+          />
+        </Pressable>
+      </Pressable>
+    );
+  },
+);
+
+BookmarkItem.displayName = 'BookmarkItem';
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: moderateScale(10),
+    paddingHorizontal: moderateScale(16),
+  },
+  iconContainer: {
+    width: moderateScale(46),
+    height: moderateScale(46),
+    borderRadius: moderateScale(12),
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: moderateScale(14),
+  },
+  info: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  surahName: {
+    fontSize: moderateScale(15),
+    fontFamily: 'Manrope-SemiBold',
+    marginBottom: moderateScale(2),
+  },
+  ayahLabel: {
+    fontSize: moderateScale(12),
+    fontFamily: 'Manrope-Regular',
+  },
+  optionsButton: {
+    padding: moderateScale(4),
+  },
+});

--- a/components/collection/BookmarkItem.tsx
+++ b/components/collection/BookmarkItem.tsx
@@ -1,56 +1,97 @@
-import React, {memo} from 'react';
-import {View, Text, Pressable, StyleSheet} from 'react-native';
-import {moderateScale} from 'react-native-size-matters';
+import React, {memo, useMemo} from 'react';
+import {View, Text, Pressable} from 'react-native';
+import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {Feather} from '@expo/vector-icons';
 import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
+import {surahGlyphMap} from '@/utils/surahGlyphMap';
 import Color from 'color';
+
+// Build verse_key -> text lookup once at module scope
+interface QuranEntry {
+  verse_key: string;
+  text: string;
+}
+const quranRaw = require('@/data/quran.json') as Record<string, QuranEntry>;
+const qpcTextByKey: Record<string, string> = {};
+for (const key of Object.keys(quranRaw)) {
+  const entry = quranRaw[key];
+  if (entry?.verse_key) qpcTextByKey[entry.verse_key] = entry.text;
+}
+
+// Lazy-load Indopak data
+interface IndopakEntry {
+  text: string;
+}
+let indopakCache: Record<string, IndopakEntry> | null = null;
+function getIndopakData(): Record<string, IndopakEntry> | null {
+  if (!indopakCache) {
+    try {
+      indopakCache = require('@/data/IndopakNastaleeq.json');
+    } catch {
+      // not available
+    }
+  }
+  return indopakCache;
+}
 
 interface BookmarkItemProps {
   surahName: string;
   ayahNumber: number;
   surahNumber: number;
+  verseKey: string;
   onPress: () => void;
   onOptionsPress: () => void;
 }
 
 export const BookmarkItem = memo<BookmarkItemProps>(
-  ({surahName, ayahNumber, surahNumber, onPress, onOptionsPress}) => {
+  ({surahName, ayahNumber, surahNumber, verseKey, onPress, onOptionsPress}) => {
     const {theme} = useTheme();
+    const {arabicFontFamily} = useMushafSettingsStore();
+    const styles = useMemo(() => createStyles(theme), [theme]);
+
+    const surahGlyph = surahGlyphMap[surahNumber] ?? '';
+    const isIndopak = arabicFontFamily === 'Indopak';
+    const arabicText = isIndopak
+      ? getIndopakData()?.[verseKey]?.text ?? ''
+      : qpcTextByKey[verseKey] ?? '';
 
     return (
-      <Pressable style={styles.container} onPress={onPress}>
-        <View
-          style={[
-            styles.iconContainer,
-            {
-              backgroundColor: Color('#F59E0B').alpha(0.15).toString(),
-            },
-          ]}>
-          <Feather name="bookmark" size={moderateScale(20)} color="#F59E0B" />
+      <Pressable
+        style={styles.container}
+        onPress={onPress}
+        onLongPress={onOptionsPress}>
+        {/* Top bar: pill + surah glyph + options */}
+        <View style={styles.topBar}>
+          <View style={styles.versePill}>
+            <Text style={styles.versePillText}>
+              {surahNumber}:{ayahNumber}
+            </Text>
+          </View>
+          <View style={styles.lineLeft} />
+          {surahGlyph ? (
+            <Text style={styles.surahGlyph}>{surahGlyph}</Text>
+          ) : null}
+          <View style={styles.lineRight} />
+          <Pressable
+            onPress={onOptionsPress}
+            hitSlop={8}
+            style={styles.optionsButton}>
+            <Feather
+              name="more-horizontal"
+              size={moderateScale(18)}
+              color={theme.colors.textSecondary}
+            />
+          </Pressable>
         </View>
-        <View style={styles.info}>
-          <Text
-            style={[styles.surahName, {color: theme.colors.text}]}
-            numberOfLines={1}>
-            {surahName}
-          </Text>
-          <Text style={[styles.ayahLabel, {color: theme.colors.textSecondary}]}>
-            Ayah {ayahNumber}
+
+        {/* Arabic text */}
+        <View style={styles.arabicContainer}>
+          <Text style={[styles.arabicText, {fontFamily: arabicFontFamily}]}>
+            {arabicText}
           </Text>
         </View>
-        <Pressable
-          onPress={onOptionsPress}
-          hitSlop={8}
-          style={({pressed}) => [
-            styles.optionsButton,
-            {opacity: pressed ? 0.5 : 1},
-          ]}>
-          <Feather
-            name="more-horizontal"
-            size={moderateScale(18)}
-            color={theme.colors.textSecondary}
-          />
-        </Pressable>
       </Pressable>
     );
   },
@@ -58,35 +99,70 @@ export const BookmarkItem = memo<BookmarkItemProps>(
 
 BookmarkItem.displayName = 'BookmarkItem';
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: moderateScale(10),
-    paddingHorizontal: moderateScale(16),
-  },
-  iconContainer: {
-    width: moderateScale(46),
-    height: moderateScale(46),
-    borderRadius: moderateScale(12),
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: moderateScale(14),
-  },
-  info: {
-    flex: 1,
-    justifyContent: 'center',
-  },
-  surahName: {
-    fontSize: moderateScale(15),
-    fontFamily: 'Manrope-SemiBold',
-    marginBottom: moderateScale(2),
-  },
-  ayahLabel: {
-    fontSize: moderateScale(12),
-    fontFamily: 'Manrope-Regular',
-  },
-  optionsButton: {
-    padding: moderateScale(4),
-  },
-});
+const createStyles = (theme: Theme) => {
+  const accentColor = theme.colors.textSecondary;
+
+  return ScaledSheet.create({
+    container: {
+      backgroundColor: theme.colors.card,
+      marginHorizontal: moderateScale(16),
+      marginVertical: moderateScale(6),
+      borderRadius: moderateScale(20),
+      overflow: 'hidden',
+      borderWidth: 1,
+      borderColor: Color(accentColor).alpha(0.15).toString(),
+    },
+    topBar: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: moderateScale(10),
+      paddingLeft: moderateScale(14),
+      backgroundColor: Color(accentColor).alpha(0.05).toString(),
+      borderBottomWidth: 1,
+      borderBottomColor: Color(accentColor).alpha(0.1).toString(),
+    },
+    versePill: {
+      backgroundColor: Color(accentColor).alpha(0.1).toString(),
+      paddingHorizontal: moderateScale(6),
+      paddingVertical: moderateScale(3),
+      borderRadius: moderateScale(6),
+    },
+    versePillText: {
+      fontSize: moderateScale(12),
+      fontFamily: theme.fonts.medium,
+      color: accentColor,
+    },
+    lineLeft: {
+      flex: 1,
+      height: 1,
+      backgroundColor: Color(accentColor).alpha(0.2).toString(),
+      marginHorizontal: moderateScale(10),
+    },
+    surahGlyph: {
+      fontFamily: 'SurahNames',
+      fontSize: moderateScale(22),
+      color: accentColor,
+    },
+    lineRight: {
+      flex: 1,
+      height: 1,
+      backgroundColor: Color(accentColor).alpha(0.2).toString(),
+      marginHorizontal: moderateScale(10),
+    },
+    optionsButton: {
+      paddingHorizontal: moderateScale(12),
+      paddingVertical: moderateScale(2),
+    },
+    arabicContainer: {
+      padding: moderateScale(16),
+      paddingBottom: moderateScale(18),
+    },
+    arabicText: {
+      fontSize: moderateScale(20),
+      color: theme.colors.text,
+      textAlign: 'center',
+      writingDirection: 'rtl',
+      lineHeight: moderateScale(38),
+    },
+  });
+};

--- a/components/collection/NoteItem.tsx
+++ b/components/collection/NoteItem.tsx
@@ -1,14 +1,46 @@
-import React, {memo} from 'react';
-import {View, Text, Pressable, StyleSheet} from 'react-native';
-import {moderateScale} from 'react-native-size-matters';
+import React, {memo, useMemo} from 'react';
+import {View, Text, Pressable} from 'react-native';
+import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {Feather} from '@expo/vector-icons';
 import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
+import {surahGlyphMap} from '@/utils/surahGlyphMap';
 import Color from 'color';
+
+// Build verse_key -> text lookup once at module scope
+interface QuranEntry {
+  verse_key: string;
+  text: string;
+}
+const quranRaw = require('@/data/quran.json') as Record<string, QuranEntry>;
+const qpcTextByKey: Record<string, string> = {};
+for (const key of Object.keys(quranRaw)) {
+  const entry = quranRaw[key];
+  if (entry?.verse_key) qpcTextByKey[entry.verse_key] = entry.text;
+}
+
+// Lazy-load Indopak data
+interface IndopakEntry {
+  text: string;
+}
+let indopakCache: Record<string, IndopakEntry> | null = null;
+function getIndopakData(): Record<string, IndopakEntry> | null {
+  if (!indopakCache) {
+    try {
+      indopakCache = require('@/data/IndopakNastaleeq.json');
+    } catch {
+      // not available
+    }
+  }
+  return indopakCache;
+}
 
 interface NoteItemProps {
   surahName: string;
   ayahNumber: number;
   surahNumber: number;
+  verseKey: string;
   notePreview: string;
   onPress: () => void;
   onOptionsPress: () => void;
@@ -19,51 +51,64 @@ export const NoteItem = memo<NoteItemProps>(
     surahName,
     ayahNumber,
     surahNumber,
+    verseKey,
     notePreview,
     onPress,
     onOptionsPress,
   }) => {
     const {theme} = useTheme();
+    const {arabicFontFamily} = useMushafSettingsStore();
+    const styles = useMemo(() => createStyles(theme), [theme]);
+
+    const surahGlyph = surahGlyphMap[surahNumber] ?? '';
+    const isIndopak = arabicFontFamily === 'Indopak';
+    const arabicText = isIndopak
+      ? getIndopakData()?.[verseKey]?.text ?? ''
+      : qpcTextByKey[verseKey] ?? '';
 
     return (
-      <Pressable style={styles.container} onPress={onPress}>
-        <View
-          style={[
-            styles.iconContainer,
-            {
-              backgroundColor: Color('#3B82F6').alpha(0.15).toString(),
-            },
-          ]}>
-          <Feather name="file-text" size={moderateScale(20)} color="#3B82F6" />
-        </View>
-        <View style={styles.info}>
-          <Text
-            style={[styles.topLine, {color: theme.colors.text}]}
-            numberOfLines={1}>
-            {surahName}{' '}
-            <Text style={[styles.ayahRef, {color: theme.colors.textSecondary}]}>
-              Ayah {ayahNumber}
+      <Pressable
+        style={styles.container}
+        onPress={onPress}
+        onLongPress={onOptionsPress}>
+        {/* Top bar: pill + surah glyph + options */}
+        <View style={styles.topBar}>
+          <View style={styles.versePill}>
+            <Text style={styles.versePillText}>
+              {surahNumber}:{ayahNumber}
             </Text>
+          </View>
+          <View style={styles.lineLeft} />
+          {surahGlyph ? (
+            <Text style={styles.surahGlyph}>{surahGlyph}</Text>
+          ) : null}
+          <View style={styles.lineRight} />
+          <Pressable
+            onPress={onOptionsPress}
+            hitSlop={8}
+            style={styles.optionsButton}>
+            <Feather
+              name="more-horizontal"
+              size={moderateScale(18)}
+              color={theme.colors.textSecondary}
+            />
+          </Pressable>
+        </View>
+
+        {/* Arabic text */}
+        <View style={styles.arabicContainer}>
+          <Text style={[styles.arabicText, {fontFamily: arabicFontFamily}]}>
+            {arabicText}
           </Text>
-          <Text
-            style={[styles.notePreview, {color: theme.colors.textSecondary}]}
-            numberOfLines={2}>
+        </View>
+
+        {/* Note preview */}
+        <View style={styles.annotationContainer}>
+          <View style={styles.annotationLine} />
+          <Text style={styles.notePreviewText} numberOfLines={2}>
             {notePreview}
           </Text>
         </View>
-        <Pressable
-          onPress={onOptionsPress}
-          hitSlop={8}
-          style={({pressed}) => [
-            styles.optionsButton,
-            {opacity: pressed ? 0.5 : 1},
-          ]}>
-          <Feather
-            name="more-horizontal"
-            size={moderateScale(18)}
-            color={theme.colors.textSecondary}
-          />
-        </Pressable>
       </Pressable>
     );
   },
@@ -71,40 +116,87 @@ export const NoteItem = memo<NoteItemProps>(
 
 NoteItem.displayName = 'NoteItem';
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: moderateScale(10),
-    paddingHorizontal: moderateScale(16),
-  },
-  iconContainer: {
-    width: moderateScale(46),
-    height: moderateScale(46),
-    borderRadius: moderateScale(12),
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: moderateScale(14),
-  },
-  info: {
-    flex: 1,
-    justifyContent: 'center',
-  },
-  topLine: {
-    fontSize: moderateScale(15),
-    fontFamily: 'Manrope-SemiBold',
-    marginBottom: moderateScale(2),
-  },
-  ayahRef: {
-    fontSize: moderateScale(13),
-    fontFamily: 'Manrope-Regular',
-  },
-  notePreview: {
-    fontSize: moderateScale(12),
-    fontFamily: 'Manrope-Regular',
-    lineHeight: moderateScale(16),
-  },
-  optionsButton: {
-    padding: moderateScale(4),
-  },
-});
+const createStyles = (theme: Theme) => {
+  const accentColor = theme.colors.textSecondary;
+
+  return ScaledSheet.create({
+    container: {
+      backgroundColor: theme.colors.card,
+      marginHorizontal: moderateScale(16),
+      marginVertical: moderateScale(6),
+      borderRadius: moderateScale(20),
+      overflow: 'hidden',
+      borderWidth: 1,
+      borderColor: Color(accentColor).alpha(0.15).toString(),
+    },
+    topBar: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: moderateScale(10),
+      paddingLeft: moderateScale(14),
+      backgroundColor: Color(accentColor).alpha(0.05).toString(),
+      borderBottomWidth: 1,
+      borderBottomColor: Color(accentColor).alpha(0.1).toString(),
+    },
+    versePill: {
+      backgroundColor: Color(accentColor).alpha(0.1).toString(),
+      paddingHorizontal: moderateScale(6),
+      paddingVertical: moderateScale(3),
+      borderRadius: moderateScale(6),
+    },
+    versePillText: {
+      fontSize: moderateScale(12),
+      fontFamily: theme.fonts.medium,
+      color: accentColor,
+    },
+    lineLeft: {
+      flex: 1,
+      height: 1,
+      backgroundColor: Color(accentColor).alpha(0.2).toString(),
+      marginHorizontal: moderateScale(10),
+    },
+    surahGlyph: {
+      fontFamily: 'SurahNames',
+      fontSize: moderateScale(22),
+      color: accentColor,
+    },
+    lineRight: {
+      flex: 1,
+      height: 1,
+      backgroundColor: Color(accentColor).alpha(0.2).toString(),
+      marginHorizontal: moderateScale(10),
+    },
+    optionsButton: {
+      paddingHorizontal: moderateScale(12),
+      paddingVertical: moderateScale(2),
+    },
+    arabicContainer: {
+      padding: moderateScale(16),
+      paddingBottom: moderateScale(14),
+    },
+    arabicText: {
+      fontSize: moderateScale(20),
+      color: theme.colors.text,
+      textAlign: 'center',
+      writingDirection: 'rtl',
+      lineHeight: moderateScale(38),
+    },
+    annotationContainer: {
+      paddingHorizontal: moderateScale(16),
+      paddingBottom: moderateScale(16),
+    },
+    annotationLine: {
+      height: 1,
+      backgroundColor: Color(accentColor).alpha(0.1).toString(),
+      marginBottom: moderateScale(10),
+    },
+    notePreviewText: {
+      fontSize: moderateScale(13),
+      fontFamily: theme.fonts.regular,
+      color: accentColor,
+      textAlign: 'center',
+      lineHeight: moderateScale(20),
+      fontStyle: 'italic',
+    },
+  });
+};

--- a/components/collection/NoteItem.tsx
+++ b/components/collection/NoteItem.tsx
@@ -1,0 +1,110 @@
+import React, {memo} from 'react';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
+import {moderateScale} from 'react-native-size-matters';
+import {Feather} from '@expo/vector-icons';
+import {useTheme} from '@/hooks/useTheme';
+import Color from 'color';
+
+interface NoteItemProps {
+  surahName: string;
+  ayahNumber: number;
+  surahNumber: number;
+  notePreview: string;
+  onPress: () => void;
+  onOptionsPress: () => void;
+}
+
+export const NoteItem = memo<NoteItemProps>(
+  ({
+    surahName,
+    ayahNumber,
+    surahNumber,
+    notePreview,
+    onPress,
+    onOptionsPress,
+  }) => {
+    const {theme} = useTheme();
+
+    return (
+      <Pressable style={styles.container} onPress={onPress}>
+        <View
+          style={[
+            styles.iconContainer,
+            {
+              backgroundColor: Color('#3B82F6').alpha(0.15).toString(),
+            },
+          ]}>
+          <Feather name="file-text" size={moderateScale(20)} color="#3B82F6" />
+        </View>
+        <View style={styles.info}>
+          <Text
+            style={[styles.topLine, {color: theme.colors.text}]}
+            numberOfLines={1}>
+            {surahName}{' '}
+            <Text style={[styles.ayahRef, {color: theme.colors.textSecondary}]}>
+              Ayah {ayahNumber}
+            </Text>
+          </Text>
+          <Text
+            style={[styles.notePreview, {color: theme.colors.textSecondary}]}
+            numberOfLines={2}>
+            {notePreview}
+          </Text>
+        </View>
+        <Pressable
+          onPress={onOptionsPress}
+          hitSlop={8}
+          style={({pressed}) => [
+            styles.optionsButton,
+            {opacity: pressed ? 0.5 : 1},
+          ]}>
+          <Feather
+            name="more-horizontal"
+            size={moderateScale(18)}
+            color={theme.colors.textSecondary}
+          />
+        </Pressable>
+      </Pressable>
+    );
+  },
+);
+
+NoteItem.displayName = 'NoteItem';
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: moderateScale(10),
+    paddingHorizontal: moderateScale(16),
+  },
+  iconContainer: {
+    width: moderateScale(46),
+    height: moderateScale(46),
+    borderRadius: moderateScale(12),
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: moderateScale(14),
+  },
+  info: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  topLine: {
+    fontSize: moderateScale(15),
+    fontFamily: 'Manrope-SemiBold',
+    marginBottom: moderateScale(2),
+  },
+  ayahRef: {
+    fontSize: moderateScale(13),
+    fontFamily: 'Manrope-Regular',
+  },
+  notePreview: {
+    fontSize: moderateScale(12),
+    fontFamily: 'Manrope-Regular',
+    lineHeight: moderateScale(16),
+  },
+  optionsButton: {
+    padding: moderateScale(4),
+  },
+});

--- a/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
+++ b/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
@@ -273,6 +273,10 @@ export const VerseItem = memo<VerseItemProps>(
             backgroundColor: Color(textColor).alpha(0.06).toString(),
             borderRadius: moderateScale(8),
           },
+          highlightBgColor && {
+            backgroundColor: highlightBgColor,
+            borderRadius: moderateScale(8),
+          },
         ]}
         onPress={onPress}
         onLongPress={onLongPress}>
@@ -302,10 +306,7 @@ export const VerseItem = memo<VerseItemProps>(
             <Pressable
               onPress={onOptionsPress}
               hitSlop={8}
-              style={({pressed}) => [
-                styles.optionsButton,
-                {opacity: pressed ? 0.5 : 1},
-              ]}>
+              style={styles.optionsButton}>
               <Feather
                 name="more-horizontal"
                 size={moderateScale(18)}
@@ -315,12 +316,7 @@ export const VerseItem = memo<VerseItemProps>(
           </View>
         </View>
         {/* ---> Simplified Arabic Text Rendering <-- */}
-        <View
-          style={
-            highlightBgColor
-              ? [styles.highlightContainer, {backgroundColor: highlightBgColor}]
-              : undefined
-          }>
+        <View>
           {isIndopakSelected ? (
             // Indopak Rendering
             <Text
@@ -458,11 +454,6 @@ const styles = StyleSheet.create({
   },
   annotationIcon: {
     opacity: 0.7,
-  },
-  highlightContainer: {
-    borderRadius: moderateScale(4),
-    paddingHorizontal: moderateScale(4),
-    paddingVertical: moderateScale(2),
   },
   verseInfo: {
     fontSize: moderateScale(12),

--- a/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
+++ b/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
@@ -4,7 +4,7 @@ import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {Verse} from '@/types/quran';
 import Color from 'color';
 import FormattedTextRenderer from '@/components/utils/FormattedText';
-import {Ionicons} from '@expo/vector-icons';
+import {Feather, Ionicons} from '@expo/vector-icons';
 import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import {useTajweedStore} from '@/store/tajweedStore';
 
@@ -97,6 +97,11 @@ interface VerseItemProps {
   transliterationFontSize: number;
   translationFontSize: number;
   arabicFontSize: number;
+  isSelected?: boolean;
+  highlightColor?: string | null;
+  hasBookmark?: boolean;
+  hasNote?: boolean;
+  onLongPress?: () => void;
 }
 
 /**
@@ -119,6 +124,11 @@ export const VerseItem = memo<VerseItemProps>(
     transliterationFontSize: propTransliterationFontSize,
     translationFontSize: propTranslationFontSize,
     arabicFontSize: propArabicFontSize,
+    isSelected,
+    highlightColor,
+    hasBookmark,
+    hasNote,
+    onLongPress,
   }) => {
     // Get settings from the store
     const {
@@ -248,61 +258,95 @@ export const VerseItem = memo<VerseItemProps>(
       : null;
     // <--- End Get Indopak text
 
+    const highlightBgColor = highlightColor
+      ? Color(highlightColor).alpha(0.3).toString()
+      : undefined;
+
     return (
       <Pressable
         style={({pressed}) => [
           styles.container,
           {borderBottomColor: borderColor, opacity: pressed ? 0.7 : 1},
+          isSelected && styles.selectedContainer,
+          isSelected && {
+            borderLeftColor: Color(textColor).alpha(0.6).toString(),
+          },
         ]}
-        onPress={onPress}>
+        onPress={onPress}
+        onLongPress={onLongPress}>
         <View style={styles.verseInfoContainer}>
-          <View style={[styles.verseInfoPill, {backgroundColor: bgColor}]}>
-            <Text style={[styles.verseInfo, {color: textColor}]}>
-              {verse.surah_number}:{verse.ayah_number}
-            </Text>
+          <View style={styles.verseInfoRow}>
+            <View style={[styles.verseInfoPill, {backgroundColor: bgColor}]}>
+              <Text style={[styles.verseInfo, {color: textColor}]}>
+                {verse.surah_number}:{verse.ayah_number}
+              </Text>
+            </View>
+            {hasBookmark && (
+              <Feather
+                name="bookmark"
+                size={moderateScale(12)}
+                color={textColor}
+                style={styles.annotationIcon}
+              />
+            )}
+            {hasNote && (
+              <Feather
+                name="edit-3"
+                size={moderateScale(12)}
+                color={textColor}
+                style={styles.annotationIcon}
+              />
+            )}
           </View>
         </View>
         {/* ---> Simplified Arabic Text Rendering <-- */}
-        {isIndopakSelected ? (
-          // Indopak Rendering
-          <Text
-            style={[
-              styles.arabicText,
-              {
-                color: textColor,
-                fontSize: moderateScale(arabicFontSize),
-                fontFamily: arabicFontFamily, // 'Indopak'
-              },
-            ]}>
-            {indopakText || 'Loading Indopak...'}
-          </Text>
-        ) : isQPCSelected && tajweedNodes ? (
-          // QPC Rendering: Always use generated tajweedNodes
-          <Text
-            style={[
-              styles.arabicText,
-              {
-                fontSize: moderateScale(arabicFontSize),
-                fontFamily: arabicFontFamily, // 'QPC'
-              },
-            ]}>
-            {tajweedNodes}
-          </Text>
-        ) : (
-          // Fallback (e.g., QPC selected but data is loading/missing)
-          <Text
-            style={[
-              styles.arabicText,
-              {
-                color: textColor,
-                fontSize: moderateScale(arabicFontSize),
-                fontFamily: arabicFontFamily, // Should be QPC here ideally
-              },
-            ]}>
-            {/* Display plain text or loading indicator */}
-            {verse.text || 'Loading...'}
-          </Text>
-        )}
+        <View
+          style={
+            highlightBgColor
+              ? [styles.highlightContainer, {backgroundColor: highlightBgColor}]
+              : undefined
+          }>
+          {isIndopakSelected ? (
+            // Indopak Rendering
+            <Text
+              style={[
+                styles.arabicText,
+                {
+                  color: textColor,
+                  fontSize: moderateScale(arabicFontSize),
+                  fontFamily: arabicFontFamily, // 'Indopak'
+                },
+              ]}>
+              {indopakText || 'Loading Indopak...'}
+            </Text>
+          ) : isQPCSelected && tajweedNodes ? (
+            // QPC Rendering: Always use generated tajweedNodes
+            <Text
+              style={[
+                styles.arabicText,
+                {
+                  fontSize: moderateScale(arabicFontSize),
+                  fontFamily: arabicFontFamily, // 'QPC'
+                },
+              ]}>
+              {tajweedNodes}
+            </Text>
+          ) : (
+            // Fallback (e.g., QPC selected but data is loading/missing)
+            <Text
+              style={[
+                styles.arabicText,
+                {
+                  color: textColor,
+                  fontSize: moderateScale(arabicFontSize),
+                  fontFamily: arabicFontFamily, // Should be QPC here ideally
+                },
+              ]}>
+              {/* Display plain text or loading indicator */}
+              {verse.text || 'Loading...'}
+            </Text>
+          )}
+        </View>
         {/* ---> End Conditional Rendering <--- */}
         {showTransliteration && verse.transliteration && (
           <FormattedTextRenderer
@@ -380,14 +424,31 @@ const styles = StyleSheet.create({
     paddingVertical: verticalScale(12),
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
+  selectedContainer: {
+    borderLeftWidth: 3,
+    paddingLeft: moderateScale(8),
+  },
   verseInfoContainer: {
     alignSelf: 'flex-start',
     marginBottom: verticalScale(6),
+  },
+  verseInfoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: moderateScale(4),
   },
   verseInfoPill: {
     paddingHorizontal: moderateScale(4),
     paddingVertical: moderateScale(3),
     borderRadius: moderateScale(6),
+  },
+  annotationIcon: {
+    opacity: 0.7,
+  },
+  highlightContainer: {
+    borderRadius: moderateScale(4),
+    paddingHorizontal: moderateScale(4),
+    paddingVertical: moderateScale(2),
   },
   verseInfo: {
     fontSize: moderateScale(12),

--- a/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
+++ b/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
@@ -102,6 +102,7 @@ interface VerseItemProps {
   hasBookmark?: boolean;
   hasNote?: boolean;
   onLongPress?: () => void;
+  onOptionsPress?: () => void;
 }
 
 /**
@@ -129,6 +130,7 @@ export const VerseItem = memo<VerseItemProps>(
     hasBookmark,
     hasNote,
     onLongPress,
+    onOptionsPress,
   }) => {
     // Get settings from the store
     const {
@@ -264,12 +266,12 @@ export const VerseItem = memo<VerseItemProps>(
 
     return (
       <Pressable
-        style={({pressed}) => [
+        style={() => [
           styles.container,
-          {borderBottomColor: borderColor, opacity: pressed ? 0.7 : 1},
-          isSelected && styles.selectedContainer,
+          {borderBottomColor: borderColor},
           isSelected && {
-            borderLeftColor: Color(textColor).alpha(0.6).toString(),
+            backgroundColor: Color(textColor).alpha(0.06).toString(),
+            borderRadius: moderateScale(8),
           },
         ]}
         onPress={onPress}
@@ -291,12 +293,25 @@ export const VerseItem = memo<VerseItemProps>(
             )}
             {hasNote && (
               <Feather
-                name="edit-3"
+                name="file-text"
                 size={moderateScale(12)}
                 color={textColor}
                 style={styles.annotationIcon}
               />
             )}
+            <Pressable
+              onPress={onOptionsPress}
+              hitSlop={8}
+              style={({pressed}) => [
+                styles.optionsButton,
+                {opacity: pressed ? 0.5 : 1},
+              ]}>
+              <Feather
+                name="more-horizontal"
+                size={moderateScale(18)}
+                color={Color(textColor).alpha(0.5).toString()}
+              />
+            </Pressable>
           </View>
         </View>
         {/* ---> Simplified Arabic Text Rendering <-- */}
@@ -424,12 +439,11 @@ const styles = StyleSheet.create({
     paddingVertical: verticalScale(12),
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  selectedContainer: {
-    borderLeftWidth: 3,
-    paddingLeft: moderateScale(8),
+  optionsButton: {
+    marginLeft: 'auto',
+    padding: moderateScale(4),
   },
   verseInfoContainer: {
-    alignSelf: 'flex-start',
     marginBottom: verticalScale(6),
   },
   verseInfoRow: {

--- a/components/player/v2/PlayerContent/QuranView/index.tsx
+++ b/components/player/v2/PlayerContent/QuranView/index.tsx
@@ -166,6 +166,7 @@ export const QuranView: React.FC<QuranViewProps> = ({
           ayahNumber: item.ayah_number,
           arabicText: item.text,
           translation: item.translation || '',
+          transliteration: item.transliteration || '',
         },
       });
     },

--- a/components/player/v2/PlayerContent/QuranView/index.tsx
+++ b/components/player/v2/PlayerContent/QuranView/index.tsx
@@ -154,6 +154,24 @@ export const QuranView: React.FC<QuranViewProps> = ({
     );
   }, [surah?.bismillah_pre, theme.colors.text]);
 
+  // Open verse actions sheet for a given verse
+  const openVerseActions = useCallback(
+    (item: EnhancedVerse) => {
+      const vk = item.verse_key;
+      selectVerse(vk, item.surah_number, item.ayah_number);
+      SheetManager.show('verse-actions', {
+        payload: {
+          verseKey: vk,
+          surahNumber: item.surah_number,
+          ayahNumber: item.ayah_number,
+          arabicText: item.text,
+          translation: item.translation || '',
+        },
+      });
+    },
+    [selectVerse],
+  );
+
   // Render the verse items (optimized with LegendList)
   const renderItem = useCallback(
     ({item}: LegendListRenderItemProps<EnhancedVerse>) => {
@@ -176,17 +194,9 @@ export const QuranView: React.FC<QuranViewProps> = ({
           hasNote={notedVerseKeys.has(vk)}
           onLongPress={() => {
             mediumHaptics();
-            selectVerse(vk, item.surah_number, item.ayah_number);
-            SheetManager.show('verse-actions', {
-              payload: {
-                verseKey: vk,
-                surahNumber: item.surah_number,
-                ayahNumber: item.ayah_number,
-                arabicText: item.text,
-                translation: item.translation || '',
-              },
-            });
+            openVerseActions(item);
           }}
+          onOptionsPress={() => openVerseActions(item)}
         />
       );
     },
@@ -203,7 +213,7 @@ export const QuranView: React.FC<QuranViewProps> = ({
       highlights,
       bookmarkedVerseKeys,
       notedVerseKeys,
-      selectVerse,
+      openVerseActions,
     ],
   );
 

--- a/components/player/v2/PlayerContent/QuranView/index.tsx
+++ b/components/player/v2/PlayerContent/QuranView/index.tsx
@@ -10,6 +10,11 @@ import {
   LegendListRenderItemProps,
 } from '@legendapp/list';
 import {useBottomSheetScrollableCreator} from '@gorhom/bottom-sheet';
+import {useVerseSelectionStore} from '@/store/verseSelectionStore';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {HIGHLIGHT_COLORS} from '@/types/verse-annotations';
+import {SheetManager} from 'react-native-actions-sheet';
+import {mediumHaptics} from '@/utils/haptics';
 
 // Import data with type safety - move outside component to load only once
 const quranData = require('@/data/quran.json') as QuranData;
@@ -79,6 +84,25 @@ export const QuranView: React.FC<QuranViewProps> = ({
   const renderScrollComponent = useBottomSheetScrollableCreator();
   const surah = surahData.find(s => s.id === currentSurah);
 
+  // Verse selection
+  const selectedVerseKey = useVerseSelectionStore(s => s.selectedVerseKey);
+  const selectVerse = useVerseSelectionStore(s => s.selectVerse);
+
+  // Verse annotations
+  const bookmarkedVerseKeys = useVerseAnnotationsStore(
+    s => s.bookmarkedVerseKeys,
+  );
+  const notedVerseKeys = useVerseAnnotationsStore(s => s.notedVerseKeys);
+  const highlights = useVerseAnnotationsStore(s => s.highlights);
+  const loadAnnotationsForSurah = useVerseAnnotationsStore(
+    s => s.loadAnnotationsForSurah,
+  );
+
+  // Load annotations when surah changes
+  useEffect(() => {
+    loadAnnotationsForSurah(currentSurah);
+  }, [currentSurah, loadAnnotationsForSurah]);
+
   // Memoize the getVersesForSurah function — no tajweed dependency
   const getVersesForSurahMemo = useCallback(() => {
     const surahVerses = versesBySurah[currentSurah];
@@ -133,10 +157,12 @@ export const QuranView: React.FC<QuranViewProps> = ({
   // Render the verse items (optimized with LegendList)
   const renderItem = useCallback(
     ({item}: LegendListRenderItemProps<EnhancedVerse>) => {
+      const vk = item.verse_key;
+      const hlColor = highlights[vk];
       return (
         <VerseItem
           verse={item}
-          onPress={() => onVersePress(item.verse_key)}
+          onPress={() => onVersePress(vk)}
           textColor={theme.colors.text}
           borderColor={theme.colors.border}
           showTranslation={showTranslation}
@@ -144,6 +170,23 @@ export const QuranView: React.FC<QuranViewProps> = ({
           transliterationFontSize={transliterationFontSize}
           translationFontSize={translationFontSize}
           arabicFontSize={arabicFontSize}
+          isSelected={selectedVerseKey === vk}
+          highlightColor={hlColor ? HIGHLIGHT_COLORS[hlColor] : null}
+          hasBookmark={bookmarkedVerseKeys.has(vk)}
+          hasNote={notedVerseKeys.has(vk)}
+          onLongPress={() => {
+            mediumHaptics();
+            selectVerse(vk, item.surah_number, item.ayah_number);
+            SheetManager.show('verse-actions', {
+              payload: {
+                verseKey: vk,
+                surahNumber: item.surah_number,
+                ayahNumber: item.ayah_number,
+                arabicText: item.text,
+                translation: item.translation || '',
+              },
+            });
+          }}
         />
       );
     },
@@ -156,6 +199,11 @@ export const QuranView: React.FC<QuranViewProps> = ({
       transliterationFontSize,
       translationFontSize,
       arabicFontSize,
+      selectedVerseKey,
+      highlights,
+      bookmarkedVerseKeys,
+      notedVerseKeys,
+      selectVerse,
     ],
   );
 

--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -1,6 +1,5 @@
-import React, {useState, useCallback} from 'react';
+import React, {useState, useCallback, useEffect} from 'react';
 import {View, StyleSheet} from 'react-native';
-import {Header} from './Header';
 import {QueueList} from './QueueList';
 import {QuranView} from './QuranView';
 import {TrackInfo} from './TrackInfo';
@@ -10,6 +9,7 @@ import {UploadPlaceholder} from './UploadPlaceholder';
 import {moderateScale} from 'react-native-size-matters';
 import {usePlayerActions} from '@/hooks/usePlayerActions';
 import {usePlayerStore} from '@/services/player/store/playerStore';
+import {useVerseSelectionStore} from '@/store/verseSelectionStore';
 import {useTheme} from '@/hooks/useTheme';
 import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -18,7 +18,6 @@ interface PlayerContentProps {
   onSpeedPress: () => void;
   onSleepTimerPress: () => void;
   onMushafLayoutPress: () => void;
-  onOptionsPress: () => void;
   onAmbientPress: () => void;
 }
 
@@ -26,7 +25,6 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
   onSpeedPress,
   onSleepTimerPress,
   onMushafLayoutPress,
-  onOptionsPress,
   onAmbientPress,
 }) => {
   useTheme();
@@ -85,43 +83,38 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
     : undefined;
   const isUntaggedUpload = currentTrack?.isUserUpload && !currentTrack?.surahId;
 
+  // Clear verse selection when surah changes
+  useEffect(() => {
+    useVerseSelectionStore.getState().clearSelection();
+  }, [currentSurah]);
+
   return (
     <View style={styles.container}>
-      <Header onOptionsPress={onOptionsPress} />
       <View style={styles.viewsContainer}>
-        {/* QuranView or UploadPlaceholder */}
-        <View
-          pointerEvents={showQueue ? 'none' : 'auto'}
-          style={[
-            styles.viewWrapper,
-            showQueue ? styles.hidden : styles.visible,
-          ]}>
-          {isUntaggedUpload ? (
-            <UploadPlaceholder currentTrack={currentTrack} />
-          ) : (
-            <QuranView
-              currentSurah={currentSurah ?? 1}
-              onVersePress={handleVersePress}
-              showTranslation={showTranslation}
-              showTransliteration={showTransliteration}
-              transliterationFontSize={transliterationFontSize}
-              translationFontSize={translationFontSize}
-              arabicFontSize={arabicFontSize}
+        {showQueue ? (
+          <View style={styles.viewWrapper}>
+            <QueueList
+              onQueueItemPress={handleQueueItemPress}
+              onRemoveQueueItem={handleRemoveQueueItem}
             />
-          )}
-        </View>
-        {/* QueueList */}
-        <View
-          pointerEvents={showQueue ? 'auto' : 'none'}
-          style={[
-            styles.viewWrapper,
-            showQueue ? styles.visible : styles.hidden,
-          ]}>
-          <QueueList
-            onQueueItemPress={handleQueueItemPress}
-            onRemoveQueueItem={handleRemoveQueueItem}
-          />
-        </View>
+          </View>
+        ) : (
+          <View style={styles.viewWrapper}>
+            {isUntaggedUpload ? (
+              <UploadPlaceholder currentTrack={currentTrack} />
+            ) : (
+              <QuranView
+                currentSurah={currentSurah ?? 1}
+                onVersePress={handleVersePress}
+                showTranslation={showTranslation}
+                showTransliteration={showTransliteration}
+                transliterationFontSize={transliterationFontSize}
+                translationFontSize={translationFontSize}
+                arabicFontSize={arabicFontSize}
+              />
+            )}
+          </View>
+        )}
       </View>
       <View
         style={[
@@ -166,14 +159,6 @@ const styles = StyleSheet.create({
     width: '100%',
     paddingHorizontal: moderateScale(20),
     paddingTop: moderateScale(10),
-  },
-  visible: {
-    opacity: 1,
-    zIndex: 1,
-  },
-  hidden: {
-    opacity: 0,
-    zIndex: 0,
   },
 });
 

--- a/components/sheets/VerseActionsSheet.tsx
+++ b/components/sheets/VerseActionsSheet.tsx
@@ -27,6 +27,7 @@ export const VerseActionsSheet = (props: SheetProps<'verse-actions'>) => {
   const ayahNumber = payload?.ayahNumber ?? 0;
   const arabicText = payload?.arabicText ?? '';
   const translation = payload?.translation ?? '';
+  const transliteration = payload?.transliteration ?? '';
 
   const surah = surahData.find(
     (s: {id: number; name: string}) => s.id === surahNumber,
@@ -36,7 +37,6 @@ export const VerseActionsSheet = (props: SheetProps<'verse-actions'>) => {
   const isBookmarked = useVerseAnnotationsStore(state =>
     state.isBookmarked(verseKey),
   );
-  const hasNote = useVerseAnnotationsStore(state => state.hasNote(verseKey));
   const isHighlighted = useVerseAnnotationsStore(
     state => !!state.highlights[verseKey],
   );
@@ -78,9 +78,23 @@ export const VerseActionsSheet = (props: SheetProps<'verse-actions'>) => {
 
   const handleCopy = useCallback(() => {
     SheetManager.show('verse-copy', {
-      payload: {verseKey, surahNumber, ayahNumber, arabicText, translation},
+      payload: {
+        verseKey,
+        surahNumber,
+        ayahNumber,
+        arabicText,
+        translation,
+        transliteration,
+      },
     });
-  }, [verseKey, surahNumber, ayahNumber, arabicText, translation]);
+  }, [
+    verseKey,
+    surahNumber,
+    ayahNumber,
+    arabicText,
+    translation,
+    transliteration,
+  ]);
 
   const handleShare = useCallback(async () => {
     lightHaptics();
@@ -174,9 +188,7 @@ export const VerseActionsSheet = (props: SheetProps<'verse-actions'>) => {
               size={moderateScale(20)}
               color={theme.colors.text}
             />
-            <Text style={styles.optionText}>
-              {hasNote ? 'Edit Note' : 'Add Note'}
-            </Text>
+            <Text style={styles.optionText}>Add Note</Text>
           </Pressable>
 
           <Pressable

--- a/components/sheets/VerseActionsSheet.tsx
+++ b/components/sheets/VerseActionsSheet.tsx
@@ -1,0 +1,280 @@
+import React, {useCallback, useState} from 'react';
+import {View, Text, TouchableOpacity, Share} from 'react-native';
+import {ScaledSheet, moderateScale} from 'react-native-size-matters';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import ActionSheet, {
+  SheetProps,
+  SheetManager,
+} from 'react-native-actions-sheet';
+import {Feather, Ionicons} from '@expo/vector-icons';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {useVerseSelectionStore} from '@/store/verseSelectionStore';
+import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
+import {lightHaptics} from '@/utils/haptics';
+import Color from 'color';
+
+const surahData = require('@/data/surahData.json');
+
+export const VerseActionsSheet = (props: SheetProps<'verse-actions'>) => {
+  const {theme} = useTheme();
+  const styles = createStyles(theme);
+  const [pressedOption, setPressedOption] = useState<string | null>(null);
+
+  const payload = props.payload;
+  const verseKey = payload?.verseKey ?? '';
+  const surahNumber = payload?.surahNumber ?? 0;
+  const ayahNumber = payload?.ayahNumber ?? 0;
+  const arabicText = payload?.arabicText ?? '';
+  const translation = payload?.translation ?? '';
+
+  const surah = surahData.find(
+    (s: {id: number; name: string}) => s.id === surahNumber,
+  );
+  const surahName = surah?.name ?? '';
+
+  const isBookmarked = useVerseAnnotationsStore(state =>
+    state.isBookmarked(verseKey),
+  );
+  const hasNote = useVerseAnnotationsStore(state => state.hasNote(verseKey));
+
+  const handleClose = useCallback(() => {
+    SheetManager.hide('verse-actions');
+  }, []);
+
+  const handleToggleBookmark = useCallback(async () => {
+    lightHaptics();
+    const wasAdded = await verseAnnotationService.toggleBookmark(
+      verseKey,
+      surahNumber,
+      ayahNumber,
+    );
+    const store = useVerseAnnotationsStore.getState();
+    if (wasAdded) {
+      store.addBookmark(verseKey);
+    } else {
+      store.removeBookmark(verseKey);
+    }
+    handleClose();
+  }, [verseKey, surahNumber, ayahNumber, handleClose]);
+
+  const handleHighlight = useCallback(() => {
+    SheetManager.show('verse-highlight', {
+      payload: {verseKey, surahNumber, ayahNumber},
+    });
+  }, [verseKey, surahNumber, ayahNumber]);
+
+  const handleNote = useCallback(() => {
+    SheetManager.show('verse-note', {
+      payload: {verseKey, surahNumber, ayahNumber},
+    });
+  }, [verseKey, surahNumber, ayahNumber]);
+
+  const handleCopy = useCallback(() => {
+    SheetManager.show('verse-copy', {
+      payload: {verseKey, surahNumber, ayahNumber, arabicText, translation},
+    });
+  }, [verseKey, surahNumber, ayahNumber, arabicText, translation]);
+
+  const handleShare = useCallback(async () => {
+    lightHaptics();
+    const message = `${arabicText}\n\n${translation}\n\n-- Quran ${surahNumber}:${ayahNumber}`;
+    await Share.share({message});
+    handleClose();
+  }, [arabicText, translation, surahNumber, ayahNumber, handleClose]);
+
+  const handleTranslation = useCallback(() => {
+    SheetManager.show('verse-translation', {
+      payload: {verseKey, surahNumber, ayahNumber, arabicText},
+    });
+  }, [verseKey, surahNumber, ayahNumber, arabicText]);
+
+  const handleOnClose = useCallback(() => {
+    useVerseSelectionStore.getState().clearSelection();
+  }, []);
+
+  if (!payload) return null;
+
+  return (
+    <ActionSheet
+      id={props.sheetId}
+      containerStyle={styles.sheetContainer}
+      indicatorStyle={styles.indicator}
+      gestureEnabled={true}
+      onClose={handleOnClose}>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.surahName}>{surahName}</Text>
+          <Text style={styles.verseRef}>
+            {surahNumber}:{ayahNumber}
+          </Text>
+        </View>
+
+        <View style={styles.optionsGrid}>
+          <TouchableOpacity
+            style={[
+              styles.option,
+              pressedOption === 'bookmark' && styles.optionPressed,
+            ]}
+            onPress={handleToggleBookmark}
+            onPressIn={() => setPressedOption('bookmark')}
+            onPressOut={() => setPressedOption(null)}
+            activeOpacity={1}>
+            <Feather
+              name="bookmark"
+              size={moderateScale(20)}
+              color={theme.colors.text}
+            />
+            <Text style={styles.optionText}>
+              {isBookmarked ? 'Remove Bookmark' : 'Bookmark'}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.option,
+              pressedOption === 'highlight' && styles.optionPressed,
+            ]}
+            onPress={handleHighlight}
+            onPressIn={() => setPressedOption('highlight')}
+            onPressOut={() => setPressedOption(null)}
+            activeOpacity={1}>
+            <Ionicons
+              name="color-palette-outline"
+              size={moderateScale(20)}
+              color={theme.colors.text}
+            />
+            <Text style={styles.optionText}>Highlight</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.option,
+              pressedOption === 'note' && styles.optionPressed,
+            ]}
+            onPress={handleNote}
+            onPressIn={() => setPressedOption('note')}
+            onPressOut={() => setPressedOption(null)}
+            activeOpacity={1}>
+            <Feather
+              name="edit-3"
+              size={moderateScale(20)}
+              color={theme.colors.text}
+            />
+            <Text style={styles.optionText}>
+              {hasNote ? 'Edit Note' : 'Add Note'}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.option,
+              pressedOption === 'copy' && styles.optionPressed,
+            ]}
+            onPress={handleCopy}
+            onPressIn={() => setPressedOption('copy')}
+            onPressOut={() => setPressedOption(null)}
+            activeOpacity={1}>
+            <Feather
+              name="copy"
+              size={moderateScale(20)}
+              color={theme.colors.text}
+            />
+            <Text style={styles.optionText}>Copy</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.option,
+              pressedOption === 'share' && styles.optionPressed,
+            ]}
+            onPress={handleShare}
+            onPressIn={() => setPressedOption('share')}
+            onPressOut={() => setPressedOption(null)}
+            activeOpacity={1}>
+            <Feather
+              name="share"
+              size={moderateScale(20)}
+              color={theme.colors.text}
+            />
+            <Text style={styles.optionText}>Share</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.option,
+              pressedOption === 'translation' && styles.optionPressed,
+            ]}
+            onPress={handleTranslation}
+            onPressIn={() => setPressedOption('translation')}
+            onPressOut={() => setPressedOption(null)}
+            activeOpacity={1}>
+            <Feather
+              name="book-open"
+              size={moderateScale(20)}
+              color={theme.colors.text}
+            />
+            <Text style={styles.optionText}>Translation</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </ActionSheet>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  ScaledSheet.create({
+    sheetContainer: {
+      backgroundColor: theme.colors.background,
+      borderTopLeftRadius: moderateScale(20),
+      borderTopRightRadius: moderateScale(20),
+      paddingTop: moderateScale(8),
+    },
+    indicator: {
+      backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
+      width: moderateScale(40),
+    },
+    container: {
+      paddingHorizontal: moderateScale(20),
+      paddingBottom: moderateScale(40),
+    },
+    header: {
+      alignItems: 'center',
+      marginTop: moderateScale(8),
+      marginBottom: moderateScale(20),
+      gap: moderateScale(4),
+    },
+    surahName: {
+      fontSize: moderateScale(20),
+      fontFamily: 'Manrope-Bold',
+      color: theme.colors.text,
+      textAlign: 'center',
+    },
+    verseRef: {
+      fontSize: moderateScale(14),
+      fontFamily: 'Manrope-Medium',
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
+    },
+    optionsGrid: {
+      gap: moderateScale(8),
+    },
+    option: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: moderateScale(16),
+      paddingHorizontal: moderateScale(16),
+      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
+      borderRadius: moderateScale(12),
+    },
+    optionPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+    },
+    optionText: {
+      flex: 1,
+      fontSize: moderateScale(15),
+      fontFamily: 'Manrope-SemiBold',
+      color: theme.colors.text,
+      marginLeft: moderateScale(12),
+    },
+  });

--- a/components/sheets/VerseActionsSheet.tsx
+++ b/components/sheets/VerseActionsSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {View, Text, TouchableOpacity, Share} from 'react-native';
+import {View, Text, Pressable, Share} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -37,10 +37,9 @@ export const VerseActionsSheet = (props: SheetProps<'verse-actions'>) => {
     state.isBookmarked(verseKey),
   );
   const hasNote = useVerseAnnotationsStore(state => state.hasNote(verseKey));
-
-  const handleClose = useCallback(() => {
-    SheetManager.hide('verse-actions');
-  }, []);
+  const isHighlighted = useVerseAnnotationsStore(
+    state => !!state.highlights[verseKey],
+  );
 
   const handleToggleBookmark = useCallback(async () => {
     lightHaptics();
@@ -55,14 +54,21 @@ export const VerseActionsSheet = (props: SheetProps<'verse-actions'>) => {
     } else {
       store.removeBookmark(verseKey);
     }
-    handleClose();
-  }, [verseKey, surahNumber, ayahNumber, handleClose]);
-
-  const handleHighlight = useCallback(() => {
-    SheetManager.show('verse-highlight', {
-      payload: {verseKey, surahNumber, ayahNumber},
-    });
+    SheetManager.hideAll();
   }, [verseKey, surahNumber, ayahNumber]);
+
+  const handleHighlight = useCallback(async () => {
+    if (isHighlighted) {
+      lightHaptics();
+      await verseAnnotationService.removeHighlight(verseKey);
+      useVerseAnnotationsStore.getState().removeHighlight(verseKey);
+      SheetManager.hideAll();
+    } else {
+      SheetManager.show('verse-highlight', {
+        payload: {verseKey, surahNumber, ayahNumber},
+      });
+    }
+  }, [verseKey, surahNumber, ayahNumber, isHighlighted]);
 
   const handleNote = useCallback(() => {
     SheetManager.show('verse-note', {
@@ -80,8 +86,8 @@ export const VerseActionsSheet = (props: SheetProps<'verse-actions'>) => {
     lightHaptics();
     const message = `${arabicText}\n\n${translation}\n\n-- Quran ${surahNumber}:${ayahNumber}`;
     await Share.share({message});
-    handleClose();
-  }, [arabicText, translation, surahNumber, ayahNumber, handleClose]);
+    SheetManager.hideAll();
+  }, [arabicText, translation, surahNumber, ayahNumber]);
 
   const handleTranslation = useCallback(() => {
     SheetManager.show('verse-translation', {
@@ -111,111 +117,115 @@ export const VerseActionsSheet = (props: SheetProps<'verse-actions'>) => {
         </View>
 
         <View style={styles.optionsGrid}>
-          <TouchableOpacity
+          <Pressable
             style={[
               styles.option,
               pressedOption === 'bookmark' && styles.optionPressed,
             ]}
             onPress={handleToggleBookmark}
             onPressIn={() => setPressedOption('bookmark')}
-            onPressOut={() => setPressedOption(null)}
-            activeOpacity={1}>
+            onPressOut={() => setPressedOption(null)}>
             <Feather
-              name="bookmark"
+              name={isBookmarked ? 'trash-2' : 'bookmark'}
               size={moderateScale(20)}
               color={theme.colors.text}
             />
             <Text style={styles.optionText}>
               {isBookmarked ? 'Remove Bookmark' : 'Bookmark'}
             </Text>
-          </TouchableOpacity>
+          </Pressable>
 
-          <TouchableOpacity
+          <Pressable
             style={[
               styles.option,
               pressedOption === 'highlight' && styles.optionPressed,
             ]}
             onPress={handleHighlight}
             onPressIn={() => setPressedOption('highlight')}
-            onPressOut={() => setPressedOption(null)}
-            activeOpacity={1}>
-            <Ionicons
-              name="color-palette-outline"
-              size={moderateScale(20)}
-              color={theme.colors.text}
-            />
-            <Text style={styles.optionText}>Highlight</Text>
-          </TouchableOpacity>
+            onPressOut={() => setPressedOption(null)}>
+            {isHighlighted ? (
+              <Feather
+                name="trash-2"
+                size={moderateScale(20)}
+                color={theme.colors.text}
+              />
+            ) : (
+              <Ionicons
+                name="brush-outline"
+                size={moderateScale(20)}
+                color={theme.colors.text}
+              />
+            )}
+            <Text style={styles.optionText}>
+              {isHighlighted ? 'Remove Highlight' : 'Highlight'}
+            </Text>
+          </Pressable>
 
-          <TouchableOpacity
+          <Pressable
             style={[
               styles.option,
               pressedOption === 'note' && styles.optionPressed,
             ]}
             onPress={handleNote}
             onPressIn={() => setPressedOption('note')}
-            onPressOut={() => setPressedOption(null)}
-            activeOpacity={1}>
+            onPressOut={() => setPressedOption(null)}>
             <Feather
-              name="edit-3"
+              name="file-text"
               size={moderateScale(20)}
               color={theme.colors.text}
             />
             <Text style={styles.optionText}>
               {hasNote ? 'Edit Note' : 'Add Note'}
             </Text>
-          </TouchableOpacity>
+          </Pressable>
 
-          <TouchableOpacity
+          <Pressable
             style={[
               styles.option,
               pressedOption === 'copy' && styles.optionPressed,
             ]}
             onPress={handleCopy}
             onPressIn={() => setPressedOption('copy')}
-            onPressOut={() => setPressedOption(null)}
-            activeOpacity={1}>
+            onPressOut={() => setPressedOption(null)}>
             <Feather
               name="copy"
               size={moderateScale(20)}
               color={theme.colors.text}
             />
             <Text style={styles.optionText}>Copy</Text>
-          </TouchableOpacity>
+          </Pressable>
 
-          <TouchableOpacity
+          <Pressable
             style={[
               styles.option,
               pressedOption === 'share' && styles.optionPressed,
             ]}
             onPress={handleShare}
             onPressIn={() => setPressedOption('share')}
-            onPressOut={() => setPressedOption(null)}
-            activeOpacity={1}>
+            onPressOut={() => setPressedOption(null)}>
             <Feather
               name="share"
               size={moderateScale(20)}
               color={theme.colors.text}
             />
             <Text style={styles.optionText}>Share</Text>
-          </TouchableOpacity>
+          </Pressable>
 
-          <TouchableOpacity
+          <Pressable
             style={[
               styles.option,
               pressedOption === 'translation' && styles.optionPressed,
             ]}
             onPress={handleTranslation}
             onPressIn={() => setPressedOption('translation')}
-            onPressOut={() => setPressedOption(null)}
-            activeOpacity={1}>
+            onPressOut={() => setPressedOption(null)}>
             <Feather
               name="book-open"
               size={moderateScale(20)}
               color={theme.colors.text}
             />
             <Text style={styles.optionText}>Translation</Text>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </View>
     </ActionSheet>

--- a/components/sheets/VerseCopySheet.tsx
+++ b/components/sheets/VerseCopySheet.tsx
@@ -14,6 +14,35 @@ import ActionSheet, {
 import Color from 'color';
 import {Feather} from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
+import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
+
+// Build verse_key -> text lookup once at module scope
+interface QuranEntry {
+  verse_key: string;
+  text: string;
+}
+const quranRaw = require('@/data/quran.json') as Record<string, QuranEntry>;
+const qpcTextByKey: Record<string, string> = {};
+for (const key of Object.keys(quranRaw)) {
+  const entry = quranRaw[key];
+  if (entry?.verse_key) qpcTextByKey[entry.verse_key] = entry.text;
+}
+
+// Lazy-load Indopak data
+interface IndopakEntry {
+  text: string;
+}
+let indopakCache: Record<string, IndopakEntry> | null = null;
+function getIndopakData(): Record<string, IndopakEntry> | null {
+  if (!indopakCache) {
+    try {
+      indopakCache = require('@/data/IndopakNastaleeq.json');
+    } catch {
+      // not available
+    }
+  }
+  return indopakCache;
+}
 
 interface CheckboxRowProps {
   label: string;
@@ -66,13 +95,24 @@ export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
   const {theme} = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
-  const verseKey = props.payload?.verseKey;
+  const verseKey = props.payload?.verseKey ?? '';
   const surahNumber = props.payload?.surahNumber;
   const ayahNumber = props.payload?.ayahNumber;
   const arabicText = props.payload?.arabicText;
   const translation = props.payload?.translation;
 
+  const {arabicFontFamily} = useMushafSettingsStore();
+
+  // Get mushaf-type-aware Arabic text for display
+  const isIndopak = arabicFontFamily === 'Indopak';
+  const displayArabicText = isIndopak
+    ? getIndopakData()?.[verseKey]?.text ?? arabicText ?? ''
+    : qpcTextByKey[verseKey] ?? arabicText ?? '';
+
+  const transliterationRaw = props.payload?.transliteration;
+
   const [copyArabic, setCopyArabic] = useState(true);
+  const [copyTransliteration, setCopyTransliteration] = useState(false);
   const [copyTranslation, setCopyTranslation] = useState(false);
   const [copyReference, setCopyReference] = useState(true);
 
@@ -81,6 +121,10 @@ export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
 
     if (copyArabic && arabicText) {
       parts.push(arabicText);
+    }
+
+    if (copyTransliteration && transliterationRaw) {
+      parts.push(transliterationRaw.replace(/<[^>]*>/g, ''));
     }
 
     if (copyTranslation && translation) {
@@ -98,15 +142,18 @@ export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
     SheetManager.hideAll();
   }, [
     copyArabic,
+    copyTransliteration,
     copyTranslation,
     copyReference,
     arabicText,
+    transliterationRaw,
     translation,
     surahNumber,
     ayahNumber,
   ]);
 
-  const canCopy = copyArabic || copyTranslation || copyReference;
+  const canCopy =
+    copyArabic || copyTransliteration || copyTranslation || copyReference;
 
   return (
     <ActionSheet
@@ -118,12 +165,28 @@ export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
         <Text style={styles.title}>Copy Options</Text>
         <Text style={styles.subtitle}>Select what to copy</Text>
 
+        {displayArabicText ? (
+          <View style={styles.ayahContainer}>
+            <Text style={[styles.ayahText, {fontFamily: arabicFontFamily}]}>
+              {displayArabicText}
+            </Text>
+          </View>
+        ) : null}
+
         <View style={styles.optionsContainer}>
           <CheckboxRow
             label="Arabic"
             checked={copyArabic}
             onToggle={() => setCopyArabic(!copyArabic)}
             disabled={!arabicText}
+            theme={theme}
+            styles={styles}
+          />
+          <CheckboxRow
+            label="Transliteration"
+            checked={copyTransliteration}
+            onToggle={() => setCopyTransliteration(!copyTransliteration)}
+            disabled={!transliterationRaw}
             theme={theme}
             styles={styles}
           />
@@ -169,7 +232,7 @@ export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
 const createStyles = (theme: Theme) =>
   ScaledSheet.create({
     sheetContainer: {
-      backgroundColor: theme.colors.backgroundSecondary,
+      backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
@@ -195,6 +258,19 @@ const createStyles = (theme: Theme) =>
       textAlign: 'center',
       marginTop: verticalScale(4),
       marginBottom: verticalScale(16),
+    },
+    ayahContainer: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderRadius: moderateScale(12),
+      padding: moderateScale(16),
+      marginBottom: verticalScale(16),
+    },
+    ayahText: {
+      fontSize: moderateScale(24),
+      color: theme.colors.text,
+      textAlign: 'right',
+      writingDirection: 'rtl',
+      lineHeight: moderateScale(48),
     },
     optionsContainer: {
       backgroundColor: theme.colors.card,

--- a/components/sheets/VerseCopySheet.tsx
+++ b/components/sheets/VerseCopySheet.tsx
@@ -1,0 +1,265 @@
+import React, {useState, useMemo, useCallback} from 'react';
+import {View, Text, TouchableOpacity} from 'react-native';
+import {
+  ScaledSheet,
+  moderateScale,
+  verticalScale,
+} from 'react-native-size-matters';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import ActionSheet, {
+  SheetProps,
+  SheetManager,
+} from 'react-native-actions-sheet';
+import Color from 'color';
+import {Feather} from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
+import {useVerseSelectionStore} from '@/store/verseSelectionStore';
+
+interface CheckboxRowProps {
+  label: string;
+  checked: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+  theme: Theme;
+  styles: ReturnType<typeof createStyles>;
+}
+
+const CheckboxRow: React.FC<CheckboxRowProps> = ({
+  label,
+  checked,
+  onToggle,
+  disabled = false,
+  theme,
+  styles,
+}) => {
+  return (
+    <TouchableOpacity
+      style={[styles.checkboxRow, disabled && styles.checkboxRowDisabled]}
+      onPress={onToggle}
+      activeOpacity={1}
+      disabled={disabled}>
+      <View
+        style={[
+          styles.checkbox,
+          checked && styles.checkboxChecked,
+          disabled && styles.checkboxDisabled,
+        ]}>
+        {checked ? (
+          <Feather
+            name="check"
+            size={moderateScale(14)}
+            color={theme.colors.background}
+          />
+        ) : null}
+      </View>
+      <Text
+        style={[
+          styles.checkboxLabel,
+          disabled && styles.checkboxLabelDisabled,
+        ]}>
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+};
+
+export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
+  const {theme} = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const verseKey = props.payload?.verseKey;
+  const surahNumber = props.payload?.surahNumber;
+  const ayahNumber = props.payload?.ayahNumber;
+  const arabicText = props.payload?.arabicText;
+  const translation = props.payload?.translation;
+
+  const [copyArabic, setCopyArabic] = useState(true);
+  const [copyTranslation, setCopyTranslation] = useState(false);
+  const [copyReference, setCopyReference] = useState(true);
+
+  const handleCopy = useCallback(async () => {
+    const parts: string[] = [];
+
+    if (copyArabic && arabicText) {
+      parts.push(arabicText);
+    }
+
+    if (copyTranslation && translation) {
+      parts.push(translation);
+    }
+
+    if (copyReference && surahNumber != null && ayahNumber != null) {
+      parts.push(`Quran ${surahNumber}:${ayahNumber}`);
+    }
+
+    if (parts.length > 0) {
+      await Clipboard.setStringAsync(parts.join('\n\n'));
+    }
+
+    SheetManager.hide('verse-copy');
+    useVerseSelectionStore.getState().clearSelection();
+  }, [
+    copyArabic,
+    copyTranslation,
+    copyReference,
+    arabicText,
+    translation,
+    surahNumber,
+    ayahNumber,
+  ]);
+
+  const canCopy = copyArabic || copyTranslation || copyReference;
+
+  return (
+    <ActionSheet
+      id={props.sheetId}
+      containerStyle={styles.sheetContainer}
+      indicatorStyle={styles.indicator}
+      gestureEnabled={true}>
+      <View style={styles.container}>
+        <Text style={styles.title}>Copy Options</Text>
+        <Text style={styles.subtitle}>Select what to copy</Text>
+
+        <View style={styles.optionsContainer}>
+          <CheckboxRow
+            label="Arabic"
+            checked={copyArabic}
+            onToggle={() => setCopyArabic(!copyArabic)}
+            disabled={!arabicText}
+            theme={theme}
+            styles={styles}
+          />
+          <CheckboxRow
+            label="Translation"
+            checked={copyTranslation}
+            onToggle={() => setCopyTranslation(!copyTranslation)}
+            disabled={!translation}
+            theme={theme}
+            styles={styles}
+          />
+          <CheckboxRow
+            label="Verse Reference"
+            checked={copyReference}
+            onToggle={() => setCopyReference(!copyReference)}
+            theme={theme}
+            styles={styles}
+          />
+        </View>
+
+        <TouchableOpacity
+          style={[styles.copyButton, !canCopy && styles.copyButtonDisabled]}
+          onPress={handleCopy}
+          activeOpacity={1}
+          disabled={!canCopy}>
+          <Feather
+            name="copy"
+            size={moderateScale(18)}
+            color={
+              canCopy ? theme.colors.background : theme.colors.textSecondary
+            }
+          />
+          <Text
+            style={[
+              styles.copyButtonText,
+              !canCopy && styles.copyButtonTextDisabled,
+            ]}>
+            Copy to Clipboard
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </ActionSheet>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  ScaledSheet.create({
+    sheetContainer: {
+      backgroundColor: theme.colors.backgroundSecondary,
+      borderTopLeftRadius: moderateScale(20),
+      borderTopRightRadius: moderateScale(20),
+      paddingTop: moderateScale(8),
+    },
+    indicator: {
+      backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
+      width: moderateScale(40),
+    },
+    container: {
+      padding: moderateScale(16),
+      paddingBottom: moderateScale(40),
+    },
+    title: {
+      fontSize: moderateScale(20),
+      fontFamily: theme.fonts.bold,
+      color: theme.colors.text,
+      textAlign: 'center',
+    },
+    subtitle: {
+      fontSize: moderateScale(14),
+      fontFamily: theme.fonts.regular,
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
+      marginTop: verticalScale(4),
+      marginBottom: verticalScale(16),
+    },
+    optionsContainer: {
+      backgroundColor: theme.colors.card,
+      borderRadius: moderateScale(12),
+      paddingHorizontal: moderateScale(14),
+      paddingVertical: verticalScale(8),
+      marginBottom: verticalScale(16),
+    },
+    checkboxRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: verticalScale(12),
+    },
+    checkboxRowDisabled: {
+      opacity: 0.4,
+    },
+    checkbox: {
+      width: moderateScale(24),
+      height: moderateScale(24),
+      borderRadius: moderateScale(6),
+      borderWidth: 2,
+      borderColor: theme.colors.border,
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginRight: moderateScale(12),
+    },
+    checkboxChecked: {
+      backgroundColor: theme.colors.text,
+      borderColor: theme.colors.text,
+    },
+    checkboxDisabled: {
+      borderColor: Color(theme.colors.border).alpha(0.5).toString(),
+    },
+    checkboxLabel: {
+      fontSize: moderateScale(15),
+      fontFamily: theme.fonts.medium,
+      color: theme.colors.text,
+    },
+    checkboxLabelDisabled: {
+      color: theme.colors.textSecondary,
+    },
+    copyButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.text,
+      borderRadius: moderateScale(12),
+      paddingVertical: verticalScale(14),
+      gap: moderateScale(8),
+    },
+    copyButtonDisabled: {
+      backgroundColor: Color(theme.colors.textSecondary).alpha(0.2).toString(),
+    },
+    copyButtonText: {
+      fontSize: moderateScale(16),
+      fontFamily: theme.fonts.semiBold,
+      color: theme.colors.background,
+    },
+    copyButtonTextDisabled: {
+      color: theme.colors.textSecondary,
+    },
+  });

--- a/components/sheets/VerseCopySheet.tsx
+++ b/components/sheets/VerseCopySheet.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useMemo, useCallback} from 'react';
-import {View, Text, TouchableOpacity} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {
   ScaledSheet,
   moderateScale,
@@ -14,7 +14,6 @@ import ActionSheet, {
 import Color from 'color';
 import {Feather} from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
-import {useVerseSelectionStore} from '@/store/verseSelectionStore';
 
 interface CheckboxRowProps {
   label: string;
@@ -34,10 +33,9 @@ const CheckboxRow: React.FC<CheckboxRowProps> = ({
   styles,
 }) => {
   return (
-    <TouchableOpacity
+    <Pressable
       style={[styles.checkboxRow, disabled && styles.checkboxRowDisabled]}
       onPress={onToggle}
-      activeOpacity={1}
       disabled={disabled}>
       <View
         style={[
@@ -60,7 +58,7 @@ const CheckboxRow: React.FC<CheckboxRowProps> = ({
         ]}>
         {label}
       </Text>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 
@@ -97,8 +95,7 @@ export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
       await Clipboard.setStringAsync(parts.join('\n\n'));
     }
 
-    SheetManager.hide('verse-copy');
-    useVerseSelectionStore.getState().clearSelection();
+    SheetManager.hideAll();
   }, [
     copyArabic,
     copyTranslation,
@@ -147,17 +144,14 @@ export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
           />
         </View>
 
-        <TouchableOpacity
+        <Pressable
           style={[styles.copyButton, !canCopy && styles.copyButtonDisabled]}
           onPress={handleCopy}
-          activeOpacity={1}
           disabled={!canCopy}>
           <Feather
             name="copy"
             size={moderateScale(18)}
-            color={
-              canCopy ? theme.colors.background : theme.colors.textSecondary
-            }
+            color={canCopy ? theme.colors.text : theme.colors.textSecondary}
           />
           <Text
             style={[
@@ -166,7 +160,7 @@ export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
             ]}>
             Copy to Clipboard
           </Text>
-        </TouchableOpacity>
+        </Pressable>
       </View>
     </ActionSheet>
   );
@@ -246,9 +240,9 @@ const createStyles = (theme: Theme) =>
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'center',
-      backgroundColor: theme.colors.text,
+      backgroundColor: Color(theme.colors.text).alpha(0.1).toString(),
       borderRadius: moderateScale(12),
-      paddingVertical: verticalScale(14),
+      paddingVertical: verticalScale(12),
       gap: moderateScale(8),
     },
     copyButtonDisabled: {
@@ -257,7 +251,7 @@ const createStyles = (theme: Theme) =>
     copyButtonText: {
       fontSize: moderateScale(16),
       fontFamily: theme.fonts.semiBold,
-      color: theme.colors.background,
+      color: theme.colors.text,
     },
     copyButtonTextDisabled: {
       color: theme.colors.textSecondary,

--- a/components/sheets/VerseHighlightSheet.tsx
+++ b/components/sheets/VerseHighlightSheet.tsx
@@ -1,0 +1,156 @@
+import React, {useMemo, useCallback} from 'react';
+import {View, Text, TouchableOpacity} from 'react-native';
+import {
+  ScaledSheet,
+  moderateScale,
+  verticalScale,
+} from 'react-native-size-matters';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import ActionSheet, {
+  SheetProps,
+  SheetManager,
+} from 'react-native-actions-sheet';
+import Color from 'color';
+import {Feather} from '@expo/vector-icons';
+import {HIGHLIGHT_COLORS, HighlightColor} from '@/types/verse-annotations';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
+import {useVerseSelectionStore} from '@/store/verseSelectionStore';
+
+const COLORS = Object.entries(HIGHLIGHT_COLORS) as [HighlightColor, string][];
+
+export const VerseHighlightSheet = (props: SheetProps<'verse-highlight'>) => {
+  const {theme} = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const verseKey = props.payload?.verseKey ?? '';
+  const surahNumber = props.payload?.surahNumber ?? 0;
+  const ayahNumber = props.payload?.ayahNumber ?? 0;
+
+  const currentColor = useVerseAnnotationsStore(s => s.highlights[verseKey]);
+
+  const handleSelectColor = useCallback(
+    async (color: HighlightColor) => {
+      await verseAnnotationService.upsertHighlight(
+        verseKey,
+        surahNumber,
+        ayahNumber,
+        color,
+      );
+      useVerseAnnotationsStore.getState().setHighlight(verseKey, color);
+      SheetManager.hide('verse-highlight');
+      useVerseSelectionStore.getState().clearSelection();
+    },
+    [verseKey, surahNumber, ayahNumber],
+  );
+
+  const handleRemove = useCallback(async () => {
+    await verseAnnotationService.removeHighlight(verseKey);
+    useVerseAnnotationsStore.getState().removeHighlight(verseKey);
+    SheetManager.hide('verse-highlight');
+    useVerseSelectionStore.getState().clearSelection();
+  }, [verseKey]);
+
+  return (
+    <ActionSheet
+      id={props.sheetId}
+      containerStyle={styles.sheetContainer}
+      indicatorStyle={styles.indicator}
+      gestureEnabled={true}>
+      <View style={styles.container}>
+        <Text style={styles.title}>Highlight Color</Text>
+
+        <View style={styles.colorsGrid}>
+          {COLORS.map(([name, hex]) => {
+            const isActive = currentColor === name;
+            return (
+              <TouchableOpacity
+                key={name}
+                style={[
+                  styles.colorCircle,
+                  {backgroundColor: hex},
+                  isActive && styles.colorCircleActive,
+                ]}
+                onPress={() => handleSelectColor(name)}
+                activeOpacity={0.7}>
+                {isActive ? (
+                  <Feather name="check" size={moderateScale(22)} color="#333" />
+                ) : null}
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        {currentColor ? (
+          <TouchableOpacity
+            style={styles.removeButton}
+            onPress={handleRemove}
+            activeOpacity={1}>
+            <Feather name="x-circle" size={moderateScale(18)} color="#ff4444" />
+            <Text style={styles.removeButtonText}>Remove Highlight</Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+    </ActionSheet>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  ScaledSheet.create({
+    sheetContainer: {
+      backgroundColor: theme.colors.backgroundSecondary,
+      borderTopLeftRadius: moderateScale(20),
+      borderTopRightRadius: moderateScale(20),
+      paddingTop: moderateScale(8),
+    },
+    indicator: {
+      backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
+      width: moderateScale(40),
+    },
+    container: {
+      padding: moderateScale(16),
+      paddingBottom: moderateScale(40),
+    },
+    title: {
+      fontSize: moderateScale(20),
+      fontFamily: theme.fonts.bold,
+      color: theme.colors.text,
+      textAlign: 'center',
+      marginBottom: verticalScale(20),
+    },
+    colorsGrid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'center',
+      gap: moderateScale(16),
+      marginBottom: verticalScale(20),
+    },
+    colorCircle: {
+      width: moderateScale(48),
+      height: moderateScale(48),
+      borderRadius: moderateScale(24),
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderWidth: 2,
+      borderColor: Color(theme.colors.text).alpha(0.1).toString(),
+    },
+    colorCircleActive: {
+      borderColor: Color(theme.colors.text).alpha(0.5).toString(),
+      borderWidth: 3,
+    },
+    removeButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'rgba(255, 68, 68, 0.1)',
+      borderRadius: moderateScale(12),
+      paddingVertical: verticalScale(14),
+      gap: moderateScale(8),
+    },
+    removeButtonText: {
+      fontSize: moderateScale(16),
+      fontFamily: theme.fonts.semiBold,
+      color: '#ff4444',
+    },
+  });

--- a/components/sheets/VerseHighlightSheet.tsx
+++ b/components/sheets/VerseHighlightSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo, useCallback} from 'react';
-import {View, Text, TouchableOpacity} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {
   ScaledSheet,
   moderateScale,
@@ -16,7 +16,6 @@ import {Feather} from '@expo/vector-icons';
 import {HIGHLIGHT_COLORS, HighlightColor} from '@/types/verse-annotations';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
 import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
-import {useVerseSelectionStore} from '@/store/verseSelectionStore';
 
 const COLORS = Object.entries(HIGHLIGHT_COLORS) as [HighlightColor, string][];
 
@@ -39,8 +38,7 @@ export const VerseHighlightSheet = (props: SheetProps<'verse-highlight'>) => {
         color,
       );
       useVerseAnnotationsStore.getState().setHighlight(verseKey, color);
-      SheetManager.hide('verse-highlight');
-      useVerseSelectionStore.getState().clearSelection();
+      SheetManager.hideAll();
     },
     [verseKey, surahNumber, ayahNumber],
   );
@@ -48,8 +46,7 @@ export const VerseHighlightSheet = (props: SheetProps<'verse-highlight'>) => {
   const handleRemove = useCallback(async () => {
     await verseAnnotationService.removeHighlight(verseKey);
     useVerseAnnotationsStore.getState().removeHighlight(verseKey);
-    SheetManager.hide('verse-highlight');
-    useVerseSelectionStore.getState().clearSelection();
+    SheetManager.hideAll();
   }, [verseKey]);
 
   return (
@@ -65,31 +62,27 @@ export const VerseHighlightSheet = (props: SheetProps<'verse-highlight'>) => {
           {COLORS.map(([name, hex]) => {
             const isActive = currentColor === name;
             return (
-              <TouchableOpacity
+              <Pressable
                 key={name}
                 style={[
                   styles.colorCircle,
                   {backgroundColor: hex},
                   isActive && styles.colorCircleActive,
                 ]}
-                onPress={() => handleSelectColor(name)}
-                activeOpacity={0.7}>
+                onPress={() => handleSelectColor(name)}>
                 {isActive ? (
                   <Feather name="check" size={moderateScale(22)} color="#333" />
                 ) : null}
-              </TouchableOpacity>
+              </Pressable>
             );
           })}
         </View>
 
         {currentColor ? (
-          <TouchableOpacity
-            style={styles.removeButton}
-            onPress={handleRemove}
-            activeOpacity={1}>
+          <Pressable style={styles.removeButton} onPress={handleRemove}>
             <Feather name="x-circle" size={moderateScale(18)} color="#ff4444" />
             <Text style={styles.removeButtonText}>Remove Highlight</Text>
-          </TouchableOpacity>
+          </Pressable>
         ) : null}
       </View>
     </ActionSheet>

--- a/components/sheets/VerseHighlightSheet.tsx
+++ b/components/sheets/VerseHighlightSheet.tsx
@@ -16,6 +16,35 @@ import {Feather} from '@expo/vector-icons';
 import {HIGHLIGHT_COLORS, HighlightColor} from '@/types/verse-annotations';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
 import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
+import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
+
+// Build verse_key -> text lookup once at module scope
+interface QuranEntry {
+  verse_key: string;
+  text: string;
+}
+const quranRaw = require('@/data/quran.json') as Record<string, QuranEntry>;
+const qpcTextByKey: Record<string, string> = {};
+for (const key of Object.keys(quranRaw)) {
+  const entry = quranRaw[key];
+  if (entry?.verse_key) qpcTextByKey[entry.verse_key] = entry.text;
+}
+
+// Lazy-load Indopak data
+interface IndopakEntry {
+  text: string;
+}
+let indopakCache: Record<string, IndopakEntry> | null = null;
+function getIndopakData(): Record<string, IndopakEntry> | null {
+  if (!indopakCache) {
+    try {
+      indopakCache = require('@/data/IndopakNastaleeq.json');
+    } catch {
+      // not available
+    }
+  }
+  return indopakCache;
+}
 
 const COLORS = Object.entries(HIGHLIGHT_COLORS) as [HighlightColor, string][];
 
@@ -27,7 +56,14 @@ export const VerseHighlightSheet = (props: SheetProps<'verse-highlight'>) => {
   const surahNumber = props.payload?.surahNumber ?? 0;
   const ayahNumber = props.payload?.ayahNumber ?? 0;
 
+  const {arabicFontFamily} = useMushafSettingsStore();
+
   const currentColor = useVerseAnnotationsStore(s => s.highlights[verseKey]);
+
+  const isIndopak = arabicFontFamily === 'Indopak';
+  const arabicText = isIndopak
+    ? getIndopakData()?.[verseKey]?.text ?? ''
+    : qpcTextByKey[verseKey] ?? '';
 
   const handleSelectColor = useCallback(
     async (color: HighlightColor) => {
@@ -57,6 +93,14 @@ export const VerseHighlightSheet = (props: SheetProps<'verse-highlight'>) => {
       gestureEnabled={true}>
       <View style={styles.container}>
         <Text style={styles.title}>Highlight Color</Text>
+
+        {arabicText ? (
+          <View style={styles.ayahContainer}>
+            <Text style={[styles.ayahText, {fontFamily: arabicFontFamily}]}>
+              {arabicText}
+            </Text>
+          </View>
+        ) : null}
 
         <View style={styles.colorsGrid}>
           {COLORS.map(([name, hex]) => {
@@ -92,7 +136,7 @@ export const VerseHighlightSheet = (props: SheetProps<'verse-highlight'>) => {
 const createStyles = (theme: Theme) =>
   ScaledSheet.create({
     sheetContainer: {
-      backgroundColor: theme.colors.backgroundSecondary,
+      backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
@@ -110,7 +154,20 @@ const createStyles = (theme: Theme) =>
       fontFamily: theme.fonts.bold,
       color: theme.colors.text,
       textAlign: 'center',
+      marginBottom: verticalScale(12),
+    },
+    ayahContainer: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderRadius: moderateScale(12),
+      padding: moderateScale(16),
       marginBottom: verticalScale(20),
+    },
+    ayahText: {
+      fontSize: moderateScale(24),
+      color: theme.colors.text,
+      textAlign: 'right',
+      writingDirection: 'rtl',
+      lineHeight: moderateScale(48),
     },
     colorsGrid: {
       flexDirection: 'row',

--- a/components/sheets/VerseNoteSheet.tsx
+++ b/components/sheets/VerseNoteSheet.tsx
@@ -15,6 +15,35 @@ import Color from 'color';
 import {Feather} from '@expo/vector-icons';
 import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
+
+// Build verse_key -> text lookup once at module scope
+interface QuranEntry {
+  verse_key: string;
+  text: string;
+}
+const quranRaw = require('@/data/quran.json') as Record<string, QuranEntry>;
+const qpcTextByKey: Record<string, string> = {};
+for (const key of Object.keys(quranRaw)) {
+  const entry = quranRaw[key];
+  if (entry?.verse_key) qpcTextByKey[entry.verse_key] = entry.text;
+}
+
+// Lazy-load Indopak data
+interface IndopakEntry {
+  text: string;
+}
+let indopakCache: Record<string, IndopakEntry> | null = null;
+function getIndopakData(): Record<string, IndopakEntry> | null {
+  if (!indopakCache) {
+    try {
+      indopakCache = require('@/data/IndopakNastaleeq.json');
+    } catch {
+      // not available
+    }
+  }
+  return indopakCache;
+}
 
 export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
   const {theme} = useTheme();
@@ -25,14 +54,20 @@ export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
   const ayahNumber = props.payload?.ayahNumber ?? 0;
   const noteId = props.payload?.noteId;
 
+  const {arabicFontFamily} = useMushafSettingsStore();
+
   const [noteText, setNoteText] = useState('');
   const [isEditMode, setIsEditMode] = useState(false);
+
+  const isIndopak = arabicFontFamily === 'Indopak';
+  const arabicText = isIndopak
+    ? getIndopakData()?.[verseKey]?.text ?? ''
+    : qpcTextByKey[verseKey] ?? '';
 
   useEffect(() => {
     if (!verseKey) return;
 
     if (noteId) {
-      // Edit mode: load specific note by id
       verseAnnotationService.getNoteById(noteId).then(note => {
         if (note) {
           setNoteText(note.content);
@@ -84,6 +119,14 @@ export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
           {isEditMode ? 'Edit Note' : 'Note'} for {surahNumber}:{ayahNumber}
         </Text>
 
+        {arabicText ? (
+          <View style={styles.ayahContainer}>
+            <Text style={[styles.ayahText, {fontFamily: arabicFontFamily}]}>
+              {arabicText}
+            </Text>
+          </View>
+        ) : null}
+
         <TextInput
           style={styles.textInput}
           value={noteText}
@@ -127,7 +170,7 @@ export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
 const createStyles = (theme: Theme) =>
   ScaledSheet.create({
     sheetContainer: {
-      backgroundColor: theme.colors.backgroundSecondary,
+      backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
@@ -145,13 +188,26 @@ const createStyles = (theme: Theme) =>
       fontFamily: theme.fonts.bold,
       color: theme.colors.text,
       textAlign: 'center',
+      marginBottom: verticalScale(12),
+    },
+    ayahContainer: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderRadius: moderateScale(12),
+      padding: moderateScale(16),
       marginBottom: verticalScale(16),
+    },
+    ayahText: {
+      fontSize: moderateScale(24),
+      color: theme.colors.text,
+      textAlign: 'right',
+      writingDirection: 'rtl',
+      lineHeight: moderateScale(48),
     },
     textInput: {
       backgroundColor: theme.colors.card,
       borderRadius: moderateScale(12),
       padding: moderateScale(14),
-      minHeight: verticalScale(150),
+      minHeight: verticalScale(120),
       fontSize: moderateScale(15),
       fontFamily: theme.fonts.regular,
       color: theme.colors.text,

--- a/components/sheets/VerseNoteSheet.tsx
+++ b/components/sheets/VerseNoteSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useMemo, useCallback, useEffect} from 'react';
-import {View, Text, TextInput, TouchableOpacity} from 'react-native';
+import {View, Text, TextInput, Pressable} from 'react-native';
 import {
   ScaledSheet,
   moderateScale,
@@ -15,7 +15,6 @@ import Color from 'color';
 import {Feather} from '@expo/vector-icons';
 import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
-import {useVerseSelectionStore} from '@/store/verseSelectionStore';
 
 export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
   const {theme} = useTheme();
@@ -24,39 +23,53 @@ export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
   const verseKey = props.payload?.verseKey ?? '';
   const surahNumber = props.payload?.surahNumber ?? 0;
   const ayahNumber = props.payload?.ayahNumber ?? 0;
+  const noteId = props.payload?.noteId;
 
   const [noteText, setNoteText] = useState('');
-  const [hasExistingNote, setHasExistingNote] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(false);
 
   useEffect(() => {
     if (!verseKey) return;
-    verseAnnotationService.getNote(verseKey).then(note => {
-      if (note) {
-        setNoteText(note.content);
-        setHasExistingNote(true);
-      }
-    });
-  }, [verseKey]);
+
+    if (noteId) {
+      // Edit mode: load specific note by id
+      verseAnnotationService.getNoteById(noteId).then(note => {
+        if (note) {
+          setNoteText(note.content);
+          setIsEditMode(true);
+        }
+      });
+    }
+  }, [verseKey, noteId]);
 
   const handleSave = useCallback(async () => {
     if (!noteText.trim()) return;
-    await verseAnnotationService.upsertNote(
-      verseKey,
-      surahNumber,
-      ayahNumber,
-      noteText.trim(),
-    );
-    useVerseAnnotationsStore.getState().addNote(verseKey);
-    SheetManager.hide('verse-note');
-    useVerseSelectionStore.getState().clearSelection();
-  }, [verseKey, surahNumber, ayahNumber, noteText]);
+
+    if (isEditMode && noteId) {
+      await verseAnnotationService.updateNote(noteId, noteText.trim());
+    } else {
+      await verseAnnotationService.addNote(
+        verseKey,
+        surahNumber,
+        ayahNumber,
+        noteText.trim(),
+      );
+      useVerseAnnotationsStore.getState().addNote(verseKey);
+    }
+    SheetManager.hideAll();
+  }, [verseKey, surahNumber, ayahNumber, noteText, isEditMode, noteId]);
 
   const handleDelete = useCallback(async () => {
-    await verseAnnotationService.deleteNote(verseKey);
-    useVerseAnnotationsStore.getState().removeNote(verseKey);
-    SheetManager.hide('verse-note');
-    useVerseSelectionStore.getState().clearSelection();
-  }, [verseKey]);
+    if (!noteId) return;
+    await verseAnnotationService.deleteNoteById(noteId);
+    const remaining = await verseAnnotationService.getNotesCountForVerse(
+      verseKey,
+    );
+    if (remaining === 0) {
+      useVerseAnnotationsStore.getState().removeNote(verseKey);
+    }
+    SheetManager.hideAll();
+  }, [verseKey, noteId]);
 
   const canSave = noteText.trim().length > 0;
 
@@ -68,7 +81,7 @@ export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
       gestureEnabled={true}>
       <View style={styles.container}>
         <Text style={styles.title}>
-          Note for {surahNumber}:{ayahNumber}
+          {isEditMode ? 'Edit Note' : 'Note'} for {surahNumber}:{ayahNumber}
         </Text>
 
         <TextInput
@@ -82,35 +95,29 @@ export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
           autoFocus
         />
 
-        <TouchableOpacity
+        <Pressable
           style={[styles.saveButton, !canSave && styles.saveButtonDisabled]}
           onPress={handleSave}
-          activeOpacity={1}
           disabled={!canSave}>
           <Feather
             name="save"
             size={moderateScale(18)}
-            color={
-              canSave ? theme.colors.background : theme.colors.textSecondary
-            }
+            color={canSave ? theme.colors.text : theme.colors.textSecondary}
           />
           <Text
             style={[
               styles.saveButtonText,
               !canSave && styles.saveButtonTextDisabled,
             ]}>
-            Save Note
+            {isEditMode ? 'Update Note' : 'Save Note'}
           </Text>
-        </TouchableOpacity>
+        </Pressable>
 
-        {hasExistingNote ? (
-          <TouchableOpacity
-            style={styles.deleteButton}
-            onPress={handleDelete}
-            activeOpacity={1}>
+        {isEditMode && noteId ? (
+          <Pressable style={styles.deleteButton} onPress={handleDelete}>
             <Feather name="trash-2" size={moderateScale(18)} color="#ff4444" />
             <Text style={styles.deleteButtonText}>Delete Note</Text>
-          </TouchableOpacity>
+          </Pressable>
         ) : null}
       </View>
     </ActionSheet>
@@ -154,9 +161,9 @@ const createStyles = (theme: Theme) =>
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'center',
-      backgroundColor: theme.colors.text,
+      backgroundColor: Color(theme.colors.text).alpha(0.1).toString(),
       borderRadius: moderateScale(12),
-      paddingVertical: verticalScale(14),
+      paddingVertical: verticalScale(12),
       gap: moderateScale(8),
     },
     saveButtonDisabled: {
@@ -165,7 +172,7 @@ const createStyles = (theme: Theme) =>
     saveButtonText: {
       fontSize: moderateScale(16),
       fontFamily: theme.fonts.semiBold,
-      color: theme.colors.background,
+      color: theme.colors.text,
     },
     saveButtonTextDisabled: {
       color: theme.colors.textSecondary,

--- a/components/sheets/VerseNoteSheet.tsx
+++ b/components/sheets/VerseNoteSheet.tsx
@@ -1,0 +1,188 @@
+import React, {useState, useMemo, useCallback, useEffect} from 'react';
+import {View, Text, TextInput, TouchableOpacity} from 'react-native';
+import {
+  ScaledSheet,
+  moderateScale,
+  verticalScale,
+} from 'react-native-size-matters';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import ActionSheet, {
+  SheetProps,
+  SheetManager,
+} from 'react-native-actions-sheet';
+import Color from 'color';
+import {Feather} from '@expo/vector-icons';
+import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {useVerseSelectionStore} from '@/store/verseSelectionStore';
+
+export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
+  const {theme} = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const verseKey = props.payload?.verseKey ?? '';
+  const surahNumber = props.payload?.surahNumber ?? 0;
+  const ayahNumber = props.payload?.ayahNumber ?? 0;
+
+  const [noteText, setNoteText] = useState('');
+  const [hasExistingNote, setHasExistingNote] = useState(false);
+
+  useEffect(() => {
+    if (!verseKey) return;
+    verseAnnotationService.getNote(verseKey).then(note => {
+      if (note) {
+        setNoteText(note.content);
+        setHasExistingNote(true);
+      }
+    });
+  }, [verseKey]);
+
+  const handleSave = useCallback(async () => {
+    if (!noteText.trim()) return;
+    await verseAnnotationService.upsertNote(
+      verseKey,
+      surahNumber,
+      ayahNumber,
+      noteText.trim(),
+    );
+    useVerseAnnotationsStore.getState().addNote(verseKey);
+    SheetManager.hide('verse-note');
+    useVerseSelectionStore.getState().clearSelection();
+  }, [verseKey, surahNumber, ayahNumber, noteText]);
+
+  const handleDelete = useCallback(async () => {
+    await verseAnnotationService.deleteNote(verseKey);
+    useVerseAnnotationsStore.getState().removeNote(verseKey);
+    SheetManager.hide('verse-note');
+    useVerseSelectionStore.getState().clearSelection();
+  }, [verseKey]);
+
+  const canSave = noteText.trim().length > 0;
+
+  return (
+    <ActionSheet
+      id={props.sheetId}
+      containerStyle={styles.sheetContainer}
+      indicatorStyle={styles.indicator}
+      gestureEnabled={true}>
+      <View style={styles.container}>
+        <Text style={styles.title}>
+          Note for {surahNumber}:{ayahNumber}
+        </Text>
+
+        <TextInput
+          style={styles.textInput}
+          value={noteText}
+          onChangeText={setNoteText}
+          placeholder="Write your note here..."
+          placeholderTextColor={theme.colors.textSecondary}
+          multiline
+          textAlignVertical="top"
+          autoFocus
+        />
+
+        <TouchableOpacity
+          style={[styles.saveButton, !canSave && styles.saveButtonDisabled]}
+          onPress={handleSave}
+          activeOpacity={1}
+          disabled={!canSave}>
+          <Feather
+            name="save"
+            size={moderateScale(18)}
+            color={
+              canSave ? theme.colors.background : theme.colors.textSecondary
+            }
+          />
+          <Text
+            style={[
+              styles.saveButtonText,
+              !canSave && styles.saveButtonTextDisabled,
+            ]}>
+            Save Note
+          </Text>
+        </TouchableOpacity>
+
+        {hasExistingNote ? (
+          <TouchableOpacity
+            style={styles.deleteButton}
+            onPress={handleDelete}
+            activeOpacity={1}>
+            <Feather name="trash-2" size={moderateScale(18)} color="#ff4444" />
+            <Text style={styles.deleteButtonText}>Delete Note</Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+    </ActionSheet>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  ScaledSheet.create({
+    sheetContainer: {
+      backgroundColor: theme.colors.backgroundSecondary,
+      borderTopLeftRadius: moderateScale(20),
+      borderTopRightRadius: moderateScale(20),
+      paddingTop: moderateScale(8),
+    },
+    indicator: {
+      backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
+      width: moderateScale(40),
+    },
+    container: {
+      padding: moderateScale(16),
+      paddingBottom: moderateScale(40),
+    },
+    title: {
+      fontSize: moderateScale(20),
+      fontFamily: theme.fonts.bold,
+      color: theme.colors.text,
+      textAlign: 'center',
+      marginBottom: verticalScale(16),
+    },
+    textInput: {
+      backgroundColor: theme.colors.card,
+      borderRadius: moderateScale(12),
+      padding: moderateScale(14),
+      minHeight: verticalScale(150),
+      fontSize: moderateScale(15),
+      fontFamily: theme.fonts.regular,
+      color: theme.colors.text,
+      marginBottom: verticalScale(16),
+    },
+    saveButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.text,
+      borderRadius: moderateScale(12),
+      paddingVertical: verticalScale(14),
+      gap: moderateScale(8),
+    },
+    saveButtonDisabled: {
+      backgroundColor: Color(theme.colors.textSecondary).alpha(0.2).toString(),
+    },
+    saveButtonText: {
+      fontSize: moderateScale(16),
+      fontFamily: theme.fonts.semiBold,
+      color: theme.colors.background,
+    },
+    saveButtonTextDisabled: {
+      color: theme.colors.textSecondary,
+    },
+    deleteButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'rgba(255, 68, 68, 0.1)',
+      borderRadius: moderateScale(12),
+      paddingVertical: verticalScale(14),
+      gap: moderateScale(8),
+      marginTop: verticalScale(10),
+    },
+    deleteButtonText: {
+      fontSize: moderateScale(16),
+      fontFamily: theme.fonts.semiBold,
+      color: '#ff4444',
+    },
+  });

--- a/components/sheets/VerseTranslationSheet.tsx
+++ b/components/sheets/VerseTranslationSheet.tsx
@@ -10,6 +10,7 @@ import {Theme} from '@/utils/themeUtils';
 import ActionSheet, {SheetProps} from 'react-native-actions-sheet';
 import Color from 'color';
 import type {QuranData} from '@/types/quran';
+import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 
 const saheehData =
   require('@/data/SaheehInternational.translation-with-footnote-tags.json') as Record<
@@ -44,6 +45,8 @@ export const VerseTranslationSheet = (
 
   const verseKey = props.payload?.verseKey ?? '';
   const arabicText = props.payload?.arabicText ?? '';
+
+  const {arabicFontFamily} = useMushafSettingsStore();
 
   const [source, setSource] = useState<TranslationSource>('saheeh');
 
@@ -101,7 +104,9 @@ export const VerseTranslationSheet = (
           showsVerticalScrollIndicator={false}
           bounces={true}>
           {arabicText ? (
-            <Text style={styles.arabicText}>{arabicText}</Text>
+            <Text style={[styles.arabicText, {fontFamily: arabicFontFamily}]}>
+              {arabicText}
+            </Text>
           ) : null}
 
           {translationText ? (
@@ -118,7 +123,7 @@ export const VerseTranslationSheet = (
 const createStyles = (theme: Theme) =>
   ScaledSheet.create({
     sheetContainer: {
-      backgroundColor: theme.colors.backgroundSecondary,
+      backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
@@ -168,7 +173,6 @@ const createStyles = (theme: Theme) =>
     },
     arabicText: {
       fontSize: moderateScale(24),
-      fontFamily: 'QPC',
       color: theme.colors.text,
       textAlign: 'right',
       writingDirection: 'rtl',

--- a/components/sheets/VerseTranslationSheet.tsx
+++ b/components/sheets/VerseTranslationSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useMemo} from 'react';
-import {View, Text, TouchableOpacity, ScrollView} from 'react-native';
+import {View, Text, Pressable, ScrollView} from 'react-native';
 import {
   ScaledSheet,
   moderateScale,
@@ -72,10 +72,9 @@ export const VerseTranslationSheet = (
         <Text style={styles.title}>Translation</Text>
 
         <View style={styles.tabRow}>
-          <TouchableOpacity
+          <Pressable
             style={[styles.tab, source === 'saheeh' && styles.tabActive]}
-            onPress={() => setSource('saheeh')}
-            activeOpacity={0.7}>
+            onPress={() => setSource('saheeh')}>
             <Text
               style={[
                 styles.tabText,
@@ -83,11 +82,10 @@ export const VerseTranslationSheet = (
               ]}>
               Saheeh International
             </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
+          </Pressable>
+          <Pressable
             style={[styles.tab, source === 'clear-quran' && styles.tabActive]}
-            onPress={() => setSource('clear-quran')}
-            activeOpacity={0.7}>
+            onPress={() => setSource('clear-quran')}>
             <Text
               style={[
                 styles.tabText,
@@ -95,7 +93,7 @@ export const VerseTranslationSheet = (
               ]}>
               Clear Quran
             </Text>
-          </TouchableOpacity>
+          </Pressable>
         </View>
 
         <ScrollView

--- a/components/sheets/VerseTranslationSheet.tsx
+++ b/components/sheets/VerseTranslationSheet.tsx
@@ -1,0 +1,193 @@
+import React, {useState, useMemo} from 'react';
+import {View, Text, TouchableOpacity, ScrollView} from 'react-native';
+import {
+  ScaledSheet,
+  moderateScale,
+  verticalScale,
+} from 'react-native-size-matters';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import ActionSheet, {SheetProps} from 'react-native-actions-sheet';
+import Color from 'color';
+import type {QuranData} from '@/types/quran';
+
+const saheehData =
+  require('@/data/SaheehInternational.translation-with-footnote-tags.json') as Record<
+    string,
+    {t: string}
+  >;
+const clearQuranData = require('@/data/clear-quran-translation.json') as {
+  translations: {resource_id: number; text: string}[];
+};
+const quranData = require('@/data/quran.json') as QuranData;
+
+// Build verse_key -> id lookup once at module scope
+const verseKeyToId: Record<string, number> = {};
+for (const key of Object.keys(quranData)) {
+  const verse = quranData[key];
+  if (verse?.verse_key) {
+    verseKeyToId[verse.verse_key] = verse.id;
+  }
+}
+
+function stripHtml(text: string): string {
+  return text.replace(/<[^>]*>/g, '');
+}
+
+type TranslationSource = 'saheeh' | 'clear-quran';
+
+export const VerseTranslationSheet = (
+  props: SheetProps<'verse-translation'>,
+) => {
+  const {theme} = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const verseKey = props.payload?.verseKey ?? '';
+  const arabicText = props.payload?.arabicText ?? '';
+
+  const [source, setSource] = useState<TranslationSource>('saheeh');
+
+  const translationText = useMemo(() => {
+    if (!verseKey) return '';
+
+    if (source === 'saheeh') {
+      const entry = saheehData[verseKey];
+      return entry ? stripHtml(entry.t) : '';
+    }
+
+    // Clear Quran: look up verse id, then index into translations array
+    const verseId = verseKeyToId[verseKey];
+    if (verseId == null) return '';
+    const entry = clearQuranData.translations[verseId - 1];
+    return entry ? stripHtml(entry.text) : '';
+  }, [verseKey, source]);
+
+  return (
+    <ActionSheet
+      id={props.sheetId}
+      containerStyle={styles.sheetContainer}
+      indicatorStyle={styles.indicator}
+      gestureEnabled={true}>
+      <View style={styles.container}>
+        <Text style={styles.title}>Translation</Text>
+
+        <View style={styles.tabRow}>
+          <TouchableOpacity
+            style={[styles.tab, source === 'saheeh' && styles.tabActive]}
+            onPress={() => setSource('saheeh')}
+            activeOpacity={0.7}>
+            <Text
+              style={[
+                styles.tabText,
+                source === 'saheeh' && styles.tabTextActive,
+              ]}>
+              Saheeh International
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.tab, source === 'clear-quran' && styles.tabActive]}
+            onPress={() => setSource('clear-quran')}
+            activeOpacity={0.7}>
+            <Text
+              style={[
+                styles.tabText,
+                source === 'clear-quran' && styles.tabTextActive,
+              ]}>
+              Clear Quran
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView
+          style={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+          bounces={true}>
+          {arabicText ? (
+            <Text style={styles.arabicText}>{arabicText}</Text>
+          ) : null}
+
+          {translationText ? (
+            <Text style={styles.translationText}>{translationText}</Text>
+          ) : (
+            <Text style={styles.noTranslation}>Translation not available</Text>
+          )}
+        </ScrollView>
+      </View>
+    </ActionSheet>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  ScaledSheet.create({
+    sheetContainer: {
+      backgroundColor: theme.colors.backgroundSecondary,
+      borderTopLeftRadius: moderateScale(20),
+      borderTopRightRadius: moderateScale(20),
+      paddingTop: moderateScale(8),
+      maxHeight: '80%',
+    },
+    indicator: {
+      backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
+      width: moderateScale(40),
+    },
+    container: {
+      padding: moderateScale(16),
+      paddingBottom: moderateScale(40),
+    },
+    title: {
+      fontSize: moderateScale(20),
+      fontFamily: theme.fonts.bold,
+      color: theme.colors.text,
+      textAlign: 'center',
+      marginBottom: verticalScale(16),
+    },
+    tabRow: {
+      flexDirection: 'row',
+      backgroundColor: theme.colors.card,
+      borderRadius: moderateScale(10),
+      padding: moderateScale(4),
+      marginBottom: verticalScale(20),
+    },
+    tab: {
+      flex: 1,
+      paddingVertical: verticalScale(10),
+      borderRadius: moderateScale(8),
+      alignItems: 'center',
+    },
+    tabActive: {
+      backgroundColor: theme.colors.text,
+    },
+    tabText: {
+      fontSize: moderateScale(13),
+      fontFamily: theme.fonts.semiBold,
+      color: theme.colors.textSecondary,
+    },
+    tabTextActive: {
+      color: theme.colors.background,
+    },
+    scrollContent: {
+      maxHeight: verticalScale(400),
+    },
+    arabicText: {
+      fontSize: moderateScale(24),
+      fontFamily: 'QPC',
+      color: theme.colors.text,
+      textAlign: 'right',
+      writingDirection: 'rtl',
+      lineHeight: moderateScale(48),
+      marginBottom: verticalScale(20),
+    },
+    translationText: {
+      fontSize: moderateScale(16),
+      fontFamily: theme.fonts.regular,
+      color: theme.colors.textSecondary,
+      lineHeight: moderateScale(26),
+    },
+    noTranslation: {
+      fontSize: moderateScale(15),
+      fontFamily: theme.fonts.regular,
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
+      marginTop: verticalScale(20),
+    },
+  });

--- a/components/sheets/sheets.tsx
+++ b/components/sheets/sheets.tsx
@@ -25,6 +25,11 @@ import {UploadOptionsSheet} from './UploadOptionsSheet';
 import {AddToCollectionSheet} from './AddToCollectionSheet';
 import {AmbientSoundsSheet} from './AmbientSoundsSheet';
 import {CollectionOptionsSheet} from './CollectionOptionsSheet';
+import {VerseActionsSheet} from './VerseActionsSheet';
+import {VerseCopySheet} from './VerseCopySheet';
+import {VerseHighlightSheet} from './VerseHighlightSheet';
+import {VerseNoteSheet} from './VerseNoteSheet';
+import {VerseTranslationSheet} from './VerseTranslationSheet';
 
 // Register all sheets
 registerSheet('surah-options', SurahOptionsSheet);
@@ -46,6 +51,11 @@ registerSheet('upload-options', UploadOptionsSheet);
 registerSheet('add-to-collection', AddToCollectionSheet);
 registerSheet('ambient-sounds', AmbientSoundsSheet);
 registerSheet('collection-options', CollectionOptionsSheet);
+registerSheet('verse-actions', VerseActionsSheet);
+registerSheet('verse-copy', VerseCopySheet);
+registerSheet('verse-highlight', VerseHighlightSheet);
+registerSheet('verse-note', VerseNoteSheet);
+registerSheet('verse-translation', VerseTranslationSheet);
 
 // Type definitions for payloads
 declare module 'react-native-actions-sheet' {
@@ -175,6 +185,46 @@ declare module 'react-native-actions-sheet' {
           disabled?: boolean;
           customIcon?: React.ReactNode;
         }>;
+      };
+    }>;
+    'verse-actions': SheetDefinition<{
+      payload: {
+        verseKey: string;
+        surahNumber: number;
+        ayahNumber: number;
+        arabicText: string;
+        translation: string;
+      };
+    }>;
+    'verse-copy': SheetDefinition<{
+      payload: {
+        verseKey: string;
+        surahNumber: number;
+        ayahNumber: number;
+        arabicText: string;
+        translation: string;
+      };
+    }>;
+    'verse-highlight': SheetDefinition<{
+      payload: {
+        verseKey: string;
+        surahNumber: number;
+        ayahNumber: number;
+      };
+    }>;
+    'verse-note': SheetDefinition<{
+      payload: {
+        verseKey: string;
+        surahNumber: number;
+        ayahNumber: number;
+      };
+    }>;
+    'verse-translation': SheetDefinition<{
+      payload: {
+        verseKey: string;
+        surahNumber: number;
+        ayahNumber: number;
+        arabicText: string;
       };
     }>;
   }

--- a/components/sheets/sheets.tsx
+++ b/components/sheets/sheets.tsx
@@ -194,6 +194,7 @@ declare module 'react-native-actions-sheet' {
         ayahNumber: number;
         arabicText: string;
         translation: string;
+        transliteration?: string;
       };
     }>;
     'verse-copy': SheetDefinition<{
@@ -203,6 +204,7 @@ declare module 'react-native-actions-sheet' {
         ayahNumber: number;
         arabicText: string;
         translation: string;
+        transliteration?: string;
       };
     }>;
     'verse-highlight': SheetDefinition<{

--- a/components/sheets/sheets.tsx
+++ b/components/sheets/sheets.tsx
@@ -217,6 +217,7 @@ declare module 'react-native-actions-sheet' {
         verseKey: string;
         surahNumber: number;
         ayahNumber: number;
+        noteId?: string;
       };
     }>;
     'verse-translation': SheetDefinition<{

--- a/hooks/useVerseActions.ts
+++ b/hooks/useVerseActions.ts
@@ -28,13 +28,13 @@ export function useVerseActions() {
         }
       },
 
-      upsertNote: async (
+      addNote: async (
         verseKey: string,
         surahNumber: number,
         ayahNumber: number,
         content: string,
       ) => {
-        await verseAnnotationService.upsertNote(
+        await verseAnnotationService.addNote(
           verseKey,
           surahNumber,
           ayahNumber,
@@ -43,9 +43,14 @@ export function useVerseActions() {
         useVerseAnnotationsStore.getState().addNote(verseKey);
       },
 
-      deleteNote: async (verseKey: string) => {
-        await verseAnnotationService.deleteNote(verseKey);
-        useVerseAnnotationsStore.getState().removeNote(verseKey);
+      deleteNoteById: async (noteId: string, verseKey: string) => {
+        await verseAnnotationService.deleteNoteById(noteId);
+        const remaining = await verseAnnotationService.getNotesCountForVerse(
+          verseKey,
+        );
+        if (remaining === 0) {
+          useVerseAnnotationsStore.getState().removeNote(verseKey);
+        }
       },
 
       setHighlight: async (

--- a/hooks/useVerseActions.ts
+++ b/hooks/useVerseActions.ts
@@ -1,0 +1,73 @@
+import {useMemo} from 'react';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
+import type {HighlightColor} from '@/types/verse-annotations';
+
+/**
+ * Zero-re-render action hook for verse annotations.
+ * All actions use getState() — no subscription, no re-renders.
+ */
+export function useVerseActions() {
+  return useMemo(
+    () => ({
+      toggleBookmark: async (
+        verseKey: string,
+        surahNumber: number,
+        ayahNumber: number,
+      ) => {
+        const wasAdded = await verseAnnotationService.toggleBookmark(
+          verseKey,
+          surahNumber,
+          ayahNumber,
+        );
+        const store = useVerseAnnotationsStore.getState();
+        if (wasAdded) {
+          store.addBookmark(verseKey);
+        } else {
+          store.removeBookmark(verseKey);
+        }
+      },
+
+      upsertNote: async (
+        verseKey: string,
+        surahNumber: number,
+        ayahNumber: number,
+        content: string,
+      ) => {
+        await verseAnnotationService.upsertNote(
+          verseKey,
+          surahNumber,
+          ayahNumber,
+          content,
+        );
+        useVerseAnnotationsStore.getState().addNote(verseKey);
+      },
+
+      deleteNote: async (verseKey: string) => {
+        await verseAnnotationService.deleteNote(verseKey);
+        useVerseAnnotationsStore.getState().removeNote(verseKey);
+      },
+
+      setHighlight: async (
+        verseKey: string,
+        surahNumber: number,
+        ayahNumber: number,
+        color: HighlightColor,
+      ) => {
+        await verseAnnotationService.setHighlight(
+          verseKey,
+          surahNumber,
+          ayahNumber,
+          color,
+        );
+        useVerseAnnotationsStore.getState().setHighlight(verseKey, color);
+      },
+
+      removeHighlight: async (verseKey: string) => {
+        await verseAnnotationService.removeHighlight(verseKey);
+        useVerseAnnotationsStore.getState().removeHighlight(verseKey);
+      },
+    }),
+    [],
+  );
+}

--- a/hooks/useVerseAnnotations.ts
+++ b/hooks/useVerseAnnotations.ts
@@ -1,0 +1,36 @@
+import {useCallback, useEffect} from 'react';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import type {HighlightColor} from '@/types/verse-annotations';
+
+export function useVerseAnnotations(surahNumber: number) {
+  const loadAnnotationsForSurah = useVerseAnnotationsStore(
+    s => s.loadAnnotationsForSurah,
+  );
+  const bookmarkedVerseKeys = useVerseAnnotationsStore(
+    s => s.bookmarkedVerseKeys,
+  );
+  const notedVerseKeys = useVerseAnnotationsStore(s => s.notedVerseKeys);
+  const highlights = useVerseAnnotationsStore(s => s.highlights);
+  const loading = useVerseAnnotationsStore(s => s.loading);
+
+  useEffect(() => {
+    loadAnnotationsForSurah(surahNumber);
+  }, [surahNumber, loadAnnotationsForSurah]);
+
+  const isBookmarked = useCallback(
+    (verseKey: string) => bookmarkedVerseKeys.has(verseKey),
+    [bookmarkedVerseKeys],
+  );
+
+  const hasNote = useCallback(
+    (verseKey: string) => notedVerseKeys.has(verseKey),
+    [notedVerseKeys],
+  );
+
+  const getHighlightColor = useCallback(
+    (verseKey: string): HighlightColor | null => highlights[verseKey] ?? null,
+    [highlights],
+  );
+
+  return {isBookmarked, hasNote, getHighlightColor, loading};
+}

--- a/hooks/useVerseSelection.ts
+++ b/hooks/useVerseSelection.ts
@@ -1,0 +1,15 @@
+import {useCallback} from 'react';
+import {useVerseSelectionStore} from '@/store/verseSelectionStore';
+
+export function useVerseSelection() {
+  const selectedVerseKey = useVerseSelectionStore(s => s.selectedVerseKey);
+  const selectVerse = useVerseSelectionStore(s => s.selectVerse);
+  const clearSelection = useVerseSelectionStore(s => s.clearSelection);
+
+  const isSelected = useCallback(
+    (verseKey: string) => selectedVerseKey === verseKey,
+    [selectedVerseKey],
+  );
+
+  return {selectedVerseKey, selectVerse, clearSelection, isSelected};
+}

--- a/services/AppInitializer.ts
+++ b/services/AppInitializer.ts
@@ -2,6 +2,7 @@ import {databaseService} from '@/services/database/DatabaseService';
 import {adhkarService} from '@/services/adhkar/AdhkarService';
 import {playlistService} from '@/services/playlist/PlaylistService';
 import {uploadsService} from '@/services/uploads/UploadsService';
+import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
 import {useAdhkarStore} from '@/store/adhkarStore';
 import {usePlaylistsStore} from '@/store/playlistsStore';
 import {useUploadsStore} from '@/store/uploadsStore';
@@ -275,5 +276,19 @@ appInitializer.registerService({
     await useUploadsStore.getState().loadRecitations();
     await useUploadsStore.getState().loadCustomReciters();
     await uploadsService.maybeRunOrphanCleanup();
+  },
+});
+
+/**
+ * Verse Annotations Service (Priority 7)
+ * Initializes the verse annotations database for bookmarks, notes, highlights
+ * Non-critical - app can function without verse annotations
+ */
+appInitializer.registerService({
+  name: 'Verse Annotations',
+  priority: 7,
+  critical: false,
+  initialize: async () => {
+    await verseAnnotationService.initialize();
   },
 });

--- a/services/database/VerseAnnotationDatabaseService.ts
+++ b/services/database/VerseAnnotationDatabaseService.ts
@@ -122,7 +122,7 @@ class VerseAnnotationDatabaseService {
     await this.db.execAsync(`
       CREATE TABLE IF NOT EXISTS notes (
         id TEXT PRIMARY KEY,
-        verse_key TEXT NOT NULL UNIQUE,
+        verse_key TEXT NOT NULL,
         surah_number INTEGER NOT NULL,
         ayah_number INTEGER NOT NULL,
         content TEXT NOT NULL,
@@ -130,6 +130,44 @@ class VerseAnnotationDatabaseService {
         updated_at INTEGER NOT NULL
       );
     `);
+
+    // Migration: drop UNIQUE constraint if it exists from older schema
+    // SQLite doesn't support ALTER TABLE DROP CONSTRAINT, so we check and recreate
+    try {
+      const tableInfo = (await this.db.getAllAsync(
+        `PRAGMA index_list(notes)`,
+      )) as Array<{name: string; unique: number}>;
+      const hasUniqueIndex = tableInfo.some(
+        idx =>
+          idx.unique === 1 &&
+          idx.name !== 'sqlite_autoindex_notes_1' &&
+          idx.name.includes('verse_key'),
+      );
+      // If there's a sqlite autoindex from UNIQUE constraint, recreate table
+      const hasAutoIndex = tableInfo.some(
+        idx => idx.name === 'sqlite_autoindex_notes_1',
+      );
+      if (hasAutoIndex || hasUniqueIndex) {
+        await this.db.execAsync(`
+          CREATE TABLE IF NOT EXISTS notes_new (
+            id TEXT PRIMARY KEY,
+            verse_key TEXT NOT NULL,
+            surah_number INTEGER NOT NULL,
+            ayah_number INTEGER NOT NULL,
+            content TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+          );
+        `);
+        await this.db.execAsync(`
+          INSERT OR IGNORE INTO notes_new SELECT * FROM notes;
+        `);
+        await this.db.execAsync(`DROP TABLE notes;`);
+        await this.db.execAsync(`ALTER TABLE notes_new RENAME TO notes;`);
+      }
+    } catch {
+      // Migration already done or not needed
+    }
 
     await this.db.execAsync(`
       CREATE INDEX IF NOT EXISTS idx_notes_surah
@@ -218,7 +256,7 @@ class VerseAnnotationDatabaseService {
   }
 
   // Note operations
-  async upsertNote(
+  async addNote(
     verseKey: string,
     surahNumber: number,
     ayahNumber: number,
@@ -231,8 +269,7 @@ class VerseAnnotationDatabaseService {
 
     await this.db.runAsync(
       `INSERT INTO notes (id, verse_key, surah_number, ayah_number, content, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(verse_key) DO UPDATE SET content = excluded.content, updated_at = excluded.updated_at`,
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
       [id, verseKey, surahNumber, ayahNumber, content, now, now],
     );
 
@@ -247,18 +284,52 @@ class VerseAnnotationDatabaseService {
     };
   }
 
-  async getNote(verseKey: string): Promise<VerseNote | null> {
+  async updateNote(noteId: string, content: string): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+    await this.db.runAsync(
+      `UPDATE notes SET content = ?, updated_at = ? WHERE id = ?`,
+      [content, Date.now(), noteId],
+    );
+  }
+
+  async getNoteById(noteId: string): Promise<VerseNote | null> {
     if (!this.db) throw new Error('Database not initialized');
     const row = (await this.db.getFirstAsync(
-      `SELECT * FROM notes WHERE verse_key = ?`,
-      [verseKey],
+      `SELECT * FROM notes WHERE id = ?`,
+      [noteId],
     )) as NoteRow | null;
     return row ? mapNoteRow(row) : null;
   }
 
-  async deleteNote(verseKey: string): Promise<void> {
+  async getNotesForVerse(verseKey: string): Promise<VerseNote[]> {
     if (!this.db) throw new Error('Database not initialized');
-    await this.db.runAsync(`DELETE FROM notes WHERE verse_key = ?`, [verseKey]);
+    const rows = (await this.db.getAllAsync(
+      `SELECT * FROM notes WHERE verse_key = ? ORDER BY created_at DESC`,
+      [verseKey],
+    )) as NoteRow[];
+    return rows.map(mapNoteRow);
+  }
+
+  async deleteNoteById(noteId: string): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+    await this.db.runAsync(`DELETE FROM notes WHERE id = ?`, [noteId]);
+  }
+
+  async getNotesCountForVerse(verseKey: string): Promise<number> {
+    if (!this.db) throw new Error('Database not initialized');
+    const row = (await this.db.getFirstAsync(
+      `SELECT COUNT(*) as count FROM notes WHERE verse_key = ?`,
+      [verseKey],
+    )) as {count: number} | null;
+    return row?.count ?? 0;
+  }
+
+  async getAllNotes(): Promise<VerseNote[]> {
+    if (!this.db) throw new Error('Database not initialized');
+    const rows = (await this.db.getAllAsync(
+      `SELECT * FROM notes ORDER BY updated_at DESC`,
+    )) as NoteRow[];
+    return rows.map(mapNoteRow);
   }
 
   async getNotesBySurah(surahNumber: number): Promise<VerseNote[]> {

--- a/services/database/VerseAnnotationDatabaseService.ts
+++ b/services/database/VerseAnnotationDatabaseService.ts
@@ -1,0 +1,341 @@
+import * as SQLite from 'expo-sqlite';
+import type {
+  VerseBookmark,
+  VerseNote,
+  VerseHighlight,
+  HighlightColor,
+} from '@/types/verse-annotations';
+
+// Database row types (snake_case)
+interface BookmarkRow {
+  id: string;
+  verse_key: string;
+  surah_number: number;
+  ayah_number: number;
+  created_at: number;
+}
+
+interface NoteRow {
+  id: string;
+  verse_key: string;
+  surah_number: number;
+  ayah_number: number;
+  content: string;
+  created_at: number;
+  updated_at: number;
+}
+
+interface HighlightRow {
+  id: string;
+  verse_key: string;
+  surah_number: number;
+  ayah_number: number;
+  color: string;
+  created_at: number;
+}
+
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2);
+}
+
+function mapBookmarkRow(row: BookmarkRow): VerseBookmark {
+  return {
+    id: row.id,
+    verseKey: row.verse_key,
+    surahNumber: row.surah_number,
+    ayahNumber: row.ayah_number,
+    createdAt: row.created_at,
+  };
+}
+
+function mapNoteRow(row: NoteRow): VerseNote {
+  return {
+    id: row.id,
+    verseKey: row.verse_key,
+    surahNumber: row.surah_number,
+    ayahNumber: row.ayah_number,
+    content: row.content,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapHighlightRow(row: HighlightRow): VerseHighlight {
+  return {
+    id: row.id,
+    verseKey: row.verse_key,
+    surahNumber: row.surah_number,
+    ayahNumber: row.ayah_number,
+    color: row.color as HighlightColor,
+    createdAt: row.created_at,
+  };
+}
+
+class VerseAnnotationDatabaseService {
+  private db: SQLite.SQLiteDatabase | null = null;
+  private initPromise: Promise<void> | null = null;
+
+  async initialize(): Promise<void> {
+    if (this.db) return;
+
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+
+    this.initPromise = (async () => {
+      try {
+        this.db = await SQLite.openDatabaseAsync('verse-annotations.db');
+        await this.createTables();
+      } catch (error) {
+        console.error(
+          'Failed to initialize verse annotations database:',
+          error,
+        );
+        this.initPromise = null;
+        throw error;
+      }
+    })();
+
+    return this.initPromise;
+  }
+
+  private async createTables(): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    await this.db.execAsync('PRAGMA journal_mode = WAL;');
+
+    await this.db.execAsync(`
+      CREATE TABLE IF NOT EXISTS bookmarks (
+        id TEXT PRIMARY KEY,
+        verse_key TEXT NOT NULL UNIQUE,
+        surah_number INTEGER NOT NULL,
+        ayah_number INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+    `);
+
+    await this.db.execAsync(`
+      CREATE INDEX IF NOT EXISTS idx_bookmarks_surah
+      ON bookmarks(surah_number);
+    `);
+
+    await this.db.execAsync(`
+      CREATE TABLE IF NOT EXISTS notes (
+        id TEXT PRIMARY KEY,
+        verse_key TEXT NOT NULL UNIQUE,
+        surah_number INTEGER NOT NULL,
+        ayah_number INTEGER NOT NULL,
+        content TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+    `);
+
+    await this.db.execAsync(`
+      CREATE INDEX IF NOT EXISTS idx_notes_surah
+      ON notes(surah_number);
+    `);
+
+    await this.db.execAsync(`
+      CREATE TABLE IF NOT EXISTS highlights (
+        id TEXT PRIMARY KEY,
+        verse_key TEXT NOT NULL UNIQUE,
+        surah_number INTEGER NOT NULL,
+        ayah_number INTEGER NOT NULL,
+        color TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+    `);
+
+    await this.db.execAsync(`
+      CREATE INDEX IF NOT EXISTS idx_highlights_surah
+      ON highlights(surah_number);
+    `);
+  }
+
+  // Bookmark operations
+  async addBookmark(
+    verseKey: string,
+    surahNumber: number,
+    ayahNumber: number,
+  ): Promise<VerseBookmark> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const bookmark: VerseBookmark = {
+      id: generateId(),
+      verseKey,
+      surahNumber,
+      ayahNumber,
+      createdAt: Date.now(),
+    };
+
+    await this.db.runAsync(
+      `INSERT INTO bookmarks (id, verse_key, surah_number, ayah_number, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      [
+        bookmark.id,
+        bookmark.verseKey,
+        bookmark.surahNumber,
+        bookmark.ayahNumber,
+        bookmark.createdAt,
+      ],
+    );
+
+    return bookmark;
+  }
+
+  async removeBookmark(verseKey: string): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+    await this.db.runAsync(`DELETE FROM bookmarks WHERE verse_key = ?`, [
+      verseKey,
+    ]);
+  }
+
+  async getBookmarksBySurah(surahNumber: number): Promise<VerseBookmark[]> {
+    if (!this.db) throw new Error('Database not initialized');
+    const rows = (await this.db.getAllAsync(
+      `SELECT * FROM bookmarks WHERE surah_number = ? ORDER BY ayah_number`,
+      [surahNumber],
+    )) as BookmarkRow[];
+    return rows.map(mapBookmarkRow);
+  }
+
+  async getAllBookmarks(): Promise<VerseBookmark[]> {
+    if (!this.db) throw new Error('Database not initialized');
+    const rows = (await this.db.getAllAsync(
+      `SELECT * FROM bookmarks ORDER BY created_at DESC`,
+    )) as BookmarkRow[];
+    return rows.map(mapBookmarkRow);
+  }
+
+  async isBookmarked(verseKey: string): Promise<boolean> {
+    if (!this.db) throw new Error('Database not initialized');
+    const row = await this.db.getFirstAsync(
+      `SELECT id FROM bookmarks WHERE verse_key = ?`,
+      [verseKey],
+    );
+    return row !== null;
+  }
+
+  // Note operations
+  async upsertNote(
+    verseKey: string,
+    surahNumber: number,
+    ayahNumber: number,
+    content: string,
+  ): Promise<VerseNote> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const now = Date.now();
+    const id = generateId();
+
+    await this.db.runAsync(
+      `INSERT INTO notes (id, verse_key, surah_number, ayah_number, content, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(verse_key) DO UPDATE SET content = excluded.content, updated_at = excluded.updated_at`,
+      [id, verseKey, surahNumber, ayahNumber, content, now, now],
+    );
+
+    return {
+      id,
+      verseKey,
+      surahNumber,
+      ayahNumber,
+      content,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async getNote(verseKey: string): Promise<VerseNote | null> {
+    if (!this.db) throw new Error('Database not initialized');
+    const row = (await this.db.getFirstAsync(
+      `SELECT * FROM notes WHERE verse_key = ?`,
+      [verseKey],
+    )) as NoteRow | null;
+    return row ? mapNoteRow(row) : null;
+  }
+
+  async deleteNote(verseKey: string): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+    await this.db.runAsync(`DELETE FROM notes WHERE verse_key = ?`, [verseKey]);
+  }
+
+  async getNotesBySurah(surahNumber: number): Promise<VerseNote[]> {
+    if (!this.db) throw new Error('Database not initialized');
+    const rows = (await this.db.getAllAsync(
+      `SELECT * FROM notes WHERE surah_number = ? ORDER BY ayah_number`,
+      [surahNumber],
+    )) as NoteRow[];
+    return rows.map(mapNoteRow);
+  }
+
+  // Highlight operations
+  async upsertHighlight(
+    verseKey: string,
+    surahNumber: number,
+    ayahNumber: number,
+    color: HighlightColor,
+  ): Promise<VerseHighlight> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    const now = Date.now();
+    const id = generateId();
+
+    await this.db.runAsync(
+      `INSERT INTO highlights (id, verse_key, surah_number, ayah_number, color, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(verse_key) DO UPDATE SET color = excluded.color`,
+      [id, verseKey, surahNumber, ayahNumber, color, now],
+    );
+
+    return {
+      id,
+      verseKey,
+      surahNumber,
+      ayahNumber,
+      color,
+      createdAt: now,
+    };
+  }
+
+  async removeHighlight(verseKey: string): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+    await this.db.runAsync(`DELETE FROM highlights WHERE verse_key = ?`, [
+      verseKey,
+    ]);
+  }
+
+  async getHighlightsBySurah(surahNumber: number): Promise<VerseHighlight[]> {
+    if (!this.db) throw new Error('Database not initialized');
+    const rows = (await this.db.getAllAsync(
+      `SELECT * FROM highlights WHERE surah_number = ? ORDER BY ayah_number`,
+      [surahNumber],
+    )) as HighlightRow[];
+    return rows.map(mapHighlightRow);
+  }
+
+  // Batch fetch for a surah
+  async getAnnotationsForSurah(surahNumber: number): Promise<{
+    bookmarks: VerseBookmark[];
+    notes: VerseNote[];
+    highlights: VerseHighlight[];
+  }> {
+    const [bookmarks, notes, highlights] = await Promise.all([
+      this.getBookmarksBySurah(surahNumber),
+      this.getNotesBySurah(surahNumber),
+      this.getHighlightsBySurah(surahNumber),
+    ]);
+    return {bookmarks, notes, highlights};
+  }
+
+  async close(): Promise<void> {
+    if (this.db) {
+      await this.db.closeAsync();
+      this.db = null;
+    }
+  }
+}
+
+export const verseAnnotationDatabaseService =
+  new VerseAnnotationDatabaseService();

--- a/services/verse-annotations/VerseAnnotationService.ts
+++ b/services/verse-annotations/VerseAnnotationService.ts
@@ -34,16 +34,32 @@ class VerseAnnotationService {
     verseAnnotationDatabaseService,
   );
 
-  upsertNote = verseAnnotationDatabaseService.upsertNote.bind(
+  addNote = verseAnnotationDatabaseService.addNote.bind(
     verseAnnotationDatabaseService,
   );
-  getNote = verseAnnotationDatabaseService.getNote.bind(
+  updateNote = verseAnnotationDatabaseService.updateNote.bind(
     verseAnnotationDatabaseService,
   );
-  deleteNote = verseAnnotationDatabaseService.deleteNote.bind(
+  getNoteById = verseAnnotationDatabaseService.getNoteById.bind(
+    verseAnnotationDatabaseService,
+  );
+  getNotesForVerse = verseAnnotationDatabaseService.getNotesForVerse.bind(
+    verseAnnotationDatabaseService,
+  );
+  deleteNoteById = verseAnnotationDatabaseService.deleteNoteById.bind(
+    verseAnnotationDatabaseService,
+  );
+  getNotesCountForVerse =
+    verseAnnotationDatabaseService.getNotesCountForVerse.bind(
+      verseAnnotationDatabaseService,
+    );
+  getAllNotes = verseAnnotationDatabaseService.getAllNotes.bind(
     verseAnnotationDatabaseService,
   );
   getNotesBySurah = verseAnnotationDatabaseService.getNotesBySurah.bind(
+    verseAnnotationDatabaseService,
+  );
+  removeBookmark = verseAnnotationDatabaseService.removeBookmark.bind(
     verseAnnotationDatabaseService,
   );
 

--- a/services/verse-annotations/VerseAnnotationService.ts
+++ b/services/verse-annotations/VerseAnnotationService.ts
@@ -1,0 +1,81 @@
+import {verseAnnotationDatabaseService} from '@/services/database/VerseAnnotationDatabaseService';
+import type {HighlightColor} from '@/types/verse-annotations';
+
+class VerseAnnotationService {
+  async initialize(): Promise<void> {
+    await verseAnnotationDatabaseService.initialize();
+  }
+
+  async toggleBookmark(
+    verseKey: string,
+    surahNumber: number,
+    ayahNumber: number,
+  ): Promise<boolean> {
+    const exists = await verseAnnotationDatabaseService.isBookmarked(verseKey);
+    if (exists) {
+      await verseAnnotationDatabaseService.removeBookmark(verseKey);
+      return false;
+    }
+    await verseAnnotationDatabaseService.addBookmark(
+      verseKey,
+      surahNumber,
+      ayahNumber,
+    );
+    return true;
+  }
+
+  getBookmarksBySurah = verseAnnotationDatabaseService.getBookmarksBySurah.bind(
+    verseAnnotationDatabaseService,
+  );
+  getAllBookmarks = verseAnnotationDatabaseService.getAllBookmarks.bind(
+    verseAnnotationDatabaseService,
+  );
+  isBookmarked = verseAnnotationDatabaseService.isBookmarked.bind(
+    verseAnnotationDatabaseService,
+  );
+
+  upsertNote = verseAnnotationDatabaseService.upsertNote.bind(
+    verseAnnotationDatabaseService,
+  );
+  getNote = verseAnnotationDatabaseService.getNote.bind(
+    verseAnnotationDatabaseService,
+  );
+  deleteNote = verseAnnotationDatabaseService.deleteNote.bind(
+    verseAnnotationDatabaseService,
+  );
+  getNotesBySurah = verseAnnotationDatabaseService.getNotesBySurah.bind(
+    verseAnnotationDatabaseService,
+  );
+
+  upsertHighlight = verseAnnotationDatabaseService.upsertHighlight.bind(
+    verseAnnotationDatabaseService,
+  );
+  removeHighlight = verseAnnotationDatabaseService.removeHighlight.bind(
+    verseAnnotationDatabaseService,
+  );
+  getHighlightsBySurah =
+    verseAnnotationDatabaseService.getHighlightsBySurah.bind(
+      verseAnnotationDatabaseService,
+    );
+
+  getAnnotationsForSurah =
+    verseAnnotationDatabaseService.getAnnotationsForSurah.bind(
+      verseAnnotationDatabaseService,
+    );
+
+  async setHighlight(
+    verseKey: string,
+    surahNumber: number,
+    ayahNumber: number,
+    color: HighlightColor,
+  ) {
+    return verseAnnotationDatabaseService.upsertHighlight(
+      verseKey,
+      surahNumber,
+      ayahNumber,
+      color,
+    );
+  }
+}
+
+export const verseAnnotationService = new VerseAnnotationService();

--- a/store/verseAnnotationsStore.ts
+++ b/store/verseAnnotationsStore.ts
@@ -1,0 +1,111 @@
+import {create} from 'zustand';
+import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
+import type {HighlightColor} from '@/types/verse-annotations';
+
+interface VerseAnnotationsState {
+  loadedSurah: number | null;
+  bookmarkedVerseKeys: Set<string>;
+  notedVerseKeys: Set<string>;
+  highlights: Record<string, HighlightColor>;
+  loading: boolean;
+
+  loadAnnotationsForSurah: (surahNumber: number) => Promise<void>;
+
+  // Optimistic mutations
+  addBookmark: (verseKey: string) => void;
+  removeBookmark: (verseKey: string) => void;
+  addNote: (verseKey: string) => void;
+  removeNote: (verseKey: string) => void;
+  setHighlight: (verseKey: string, color: HighlightColor) => void;
+  removeHighlight: (verseKey: string) => void;
+
+  // Query helpers
+  isBookmarked: (verseKey: string) => boolean;
+  hasNote: (verseKey: string) => boolean;
+  getHighlightColor: (verseKey: string) => HighlightColor | null;
+}
+
+export const useVerseAnnotationsStore = create<VerseAnnotationsState>()(
+  (set, get) => ({
+    loadedSurah: null,
+    bookmarkedVerseKeys: new Set<string>(),
+    notedVerseKeys: new Set<string>(),
+    highlights: {},
+    loading: false,
+
+    loadAnnotationsForSurah: async (surahNumber: number) => {
+      const state = get();
+      if (state.loading || state.loadedSurah === surahNumber) return;
+
+      set({loading: true});
+
+      try {
+        const {bookmarks, notes, highlights} =
+          await verseAnnotationService.getAnnotationsForSurah(surahNumber);
+
+        const bookmarkedVerseKeys = new Set(bookmarks.map(b => b.verseKey));
+        const notedVerseKeys = new Set(notes.map(n => n.verseKey));
+        const highlightsRecord: Record<string, HighlightColor> = {};
+        highlights.forEach(h => {
+          highlightsRecord[h.verseKey] = h.color;
+        });
+
+        set({
+          loadedSurah: surahNumber,
+          bookmarkedVerseKeys,
+          notedVerseKeys,
+          highlights: highlightsRecord,
+          loading: false,
+        });
+      } catch (error) {
+        console.error(
+          '[VerseAnnotationsStore] Failed to load annotations:',
+          error,
+        );
+        set({loading: false});
+      }
+    },
+
+    // Optimistic mutations
+    addBookmark: (verseKey: string) => {
+      const newSet = new Set(get().bookmarkedVerseKeys);
+      newSet.add(verseKey);
+      set({bookmarkedVerseKeys: newSet});
+    },
+
+    removeBookmark: (verseKey: string) => {
+      const newSet = new Set(get().bookmarkedVerseKeys);
+      newSet.delete(verseKey);
+      set({bookmarkedVerseKeys: newSet});
+    },
+
+    addNote: (verseKey: string) => {
+      const newSet = new Set(get().notedVerseKeys);
+      newSet.add(verseKey);
+      set({notedVerseKeys: newSet});
+    },
+
+    removeNote: (verseKey: string) => {
+      const newSet = new Set(get().notedVerseKeys);
+      newSet.delete(verseKey);
+      set({notedVerseKeys: newSet});
+    },
+
+    setHighlight: (verseKey: string, color: HighlightColor) => {
+      set({highlights: {...get().highlights, [verseKey]: color}});
+    },
+
+    removeHighlight: (verseKey: string) => {
+      const newHighlights = {...get().highlights};
+      delete newHighlights[verseKey];
+      set({highlights: newHighlights});
+    },
+
+    // Query helpers (O(1))
+    isBookmarked: (verseKey: string) => get().bookmarkedVerseKeys.has(verseKey),
+
+    hasNote: (verseKey: string) => get().notedVerseKeys.has(verseKey),
+
+    getHighlightColor: (verseKey: string) => get().highlights[verseKey] ?? null,
+  }),
+);

--- a/store/verseSelectionStore.ts
+++ b/store/verseSelectionStore.ts
@@ -1,0 +1,33 @@
+import {create} from 'zustand';
+
+interface VerseSelectionState {
+  selectedVerseKey: string | null;
+  selectedSurahNumber: number | null;
+  selectedAyahNumber: number | null;
+  selectVerse: (
+    verseKey: string,
+    surahNumber: number,
+    ayahNumber: number,
+  ) => void;
+  clearSelection: () => void;
+}
+
+export const useVerseSelectionStore = create<VerseSelectionState>()(set => ({
+  selectedVerseKey: null,
+  selectedSurahNumber: null,
+  selectedAyahNumber: null,
+
+  selectVerse: (verseKey, surahNumber, ayahNumber) =>
+    set({
+      selectedVerseKey: verseKey,
+      selectedSurahNumber: surahNumber,
+      selectedAyahNumber: ayahNumber,
+    }),
+
+  clearSelection: () =>
+    set({
+      selectedVerseKey: null,
+      selectedSurahNumber: null,
+      selectedAyahNumber: null,
+    }),
+}));

--- a/types/verse-annotations.ts
+++ b/types/verse-annotations.ts
@@ -1,16 +1,9 @@
-export type HighlightColor =
-  | 'yellow'
-  | 'green'
-  | 'blue'
-  | 'pink'
-  | 'orange'
-  | 'purple';
+export type HighlightColor = 'yellow' | 'green' | 'blue' | 'orange' | 'purple';
 
 export const HIGHLIGHT_COLORS: Record<HighlightColor, string> = {
   yellow: '#FFF3B0',
   green: '#B8F0C0',
   blue: '#B0D4FF',
-  pink: '#FFB0D4',
   orange: '#FFD4B0',
   purple: '#D4B0FF',
 };

--- a/types/verse-annotations.ts
+++ b/types/verse-annotations.ts
@@ -1,0 +1,43 @@
+export type HighlightColor =
+  | 'yellow'
+  | 'green'
+  | 'blue'
+  | 'pink'
+  | 'orange'
+  | 'purple';
+
+export const HIGHLIGHT_COLORS: Record<HighlightColor, string> = {
+  yellow: '#FFF3B0',
+  green: '#B8F0C0',
+  blue: '#B0D4FF',
+  pink: '#FFB0D4',
+  orange: '#FFD4B0',
+  purple: '#D4B0FF',
+};
+
+export interface VerseBookmark {
+  id: string;
+  verseKey: string;
+  surahNumber: number;
+  ayahNumber: number;
+  createdAt: number;
+}
+
+export interface VerseNote {
+  id: string;
+  verseKey: string;
+  surahNumber: number;
+  ayahNumber: number;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface VerseHighlight {
+  id: string;
+  verseKey: string;
+  surahNumber: number;
+  ayahNumber: number;
+  color: HighlightColor;
+  createdAt: number;
+}


### PR DESCRIPTION
## Summary

- **Verse annotations system**: bookmark, highlight, note, copy, share, and translation actions accessible via long-press on any verse in the Quran player
- **Collection screens**: dedicated Bookmarks and Notes screens with manuscript-style card components (surah glyph ornament, verse pill tag, Arabic text with mushaf-type awareness)
- **Action sheets**: VerseActionsSheet menu with sub-sheets for Copy (Arabic, transliteration, translation, reference), Highlight (color picker), Note (create/edit/delete), and Translation (Saheeh International / Clear Quran toggle)
- **Data layer**: SQLite-backed VerseAnnotationDatabaseService, VerseAnnotationService, and Zustand stores for bookmarks, highlights, and notes
- **DhikrListItem**: updated to use neutral theme colors matching the new card design system
- **UX polish**: full-row verse highlighting, consistent sheet backgrounds, no opacity flash on options buttons, multi-note support

## Test plan

- [ ] Long-press a verse in the Quran player → VerseActionsSheet opens with all options
- [ ] Bookmark a verse → appears in Collection > Bookmarks screen
- [ ] Highlight a verse with a color → full verse row shows highlight background
- [ ] Add multiple notes to a verse → each accessible from Collection > Notes
- [ ] Copy a verse with Arabic, transliteration, translation, and reference checked
- [ ] Verify Arabic text renders correctly in BookmarkItem/NoteItem cards (QPC and Indopak fonts)
- [ ] Verify all sheets use consistent background color and show Arabic ayah text
- [ ] Check DhikrListItem uses neutral theme colors (no parchment/gold)
- [ ] Verify dark mode appearance across all new components

🤖 Generated with [Claude Code](https://claude.com/claude-code)