### PR TITLE
fix: resolve race condition in verse annotations DB init

### DIFF
--- a/services/database/VerseAnnotationDatabaseService.ts
+++ b/services/database/VerseAnnotationDatabaseService.ts
@@ -74,9 +74,10 @@ function mapHighlightRow(row: HighlightRow): VerseHighlight {
 class VerseAnnotationDatabaseService {
   private db: SQLite.SQLiteDatabase | null = null;
   private initPromise: Promise<void> | null = null;
+  private ready = false;
 
   async initialize(): Promise<void> {
-    if (this.db) return;
+    if (this.ready) return;
 
     if (this.initPromise) {
       return this.initPromise;
@@ -86,6 +87,7 @@ class VerseAnnotationDatabaseService {
       try {
         this.db = await SQLite.openDatabaseAsync('verse-annotations.db');
         await this.createTables();
+        this.ready = true;
       } catch (error) {
         console.error(
           'Failed to initialize verse annotations database:',
@@ -97,6 +99,16 @@ class VerseAnnotationDatabaseService {
     })();
 
     return this.initPromise;
+  }
+
+  private async ensureReady(): Promise<SQLite.SQLiteDatabase> {
+    if (!this.ready && this.initPromise) {
+      await this.initPromise;
+    }
+    if (!this.db || !this.ready) {
+      throw new Error('Database not initialized');
+    }
+    return this.db;
   }
 
   private async createTables(): Promise<void> {
@@ -197,7 +209,7 @@ class VerseAnnotationDatabaseService {
     surahNumber: number,
     ayahNumber: number,
   ): Promise<VerseBookmark> {
-    if (!this.db) throw new Error('Database not initialized');
+    const db = await this.ensureReady();
 
     const bookmark: VerseBookmark = {
       id: generateId(),
@@ -207,7 +219,7 @@ class VerseAnnotationDatabaseService {
       createdAt: Date.now(),
     };
 
-    await this.db.runAsync(
+    await db.runAsync(
       `INSERT INTO bookmarks (id, verse_key, surah_number, ayah_number, created_at)
        VALUES (?, ?, ?, ?, ?)`,
       [
@@ -223,15 +235,13 @@ class VerseAnnotationDatabaseService {
   }
 
   async removeBookmark(verseKey: string): Promise<void> {
-    if (!this.db) throw new Error('Database not initialized');
-    await this.db.runAsync(`DELETE FROM bookmarks WHERE verse_key = ?`, [
-      verseKey,
-    ]);
+    const db = await this.ensureReady();
+    await db.runAsync(`DELETE FROM bookmarks WHERE verse_key = ?`, [verseKey]);
   }
 
   async getBookmarksBySurah(surahNumber: number): Promise<VerseBookmark[]> {
-    if (!this.db) throw new Error('Database not initialized');
-    const rows = (await this.db.getAllAsync(
+    const db = await this.ensureReady();
+    const rows = (await db.getAllAsync(
       `SELECT * FROM bookmarks WHERE surah_number = ? ORDER BY ayah_number`,
       [surahNumber],
     )) as BookmarkRow[];
@@ -239,16 +249,16 @@ class VerseAnnotationDatabaseService {
   }
 
   async getAllBookmarks(): Promise<VerseBookmark[]> {
-    if (!this.db) throw new Error('Database not initialized');
-    const rows = (await this.db.getAllAsync(
+    const db = await this.ensureReady();
+    const rows = (await db.getAllAsync(
       `SELECT * FROM bookmarks ORDER BY created_at DESC`,
     )) as BookmarkRow[];
     return rows.map(mapBookmarkRow);
   }
 
   async isBookmarked(verseKey: string): Promise<boolean> {
-    if (!this.db) throw new Error('Database not initialized');
-    const row = await this.db.getFirstAsync(
+    const db = await this.ensureReady();
+    const row = await db.getFirstAsync(
       `SELECT id FROM bookmarks WHERE verse_key = ?`,
       [verseKey],
     );
@@ -262,12 +272,12 @@ class VerseAnnotationDatabaseService {
     ayahNumber: number,
     content: string,
   ): Promise<VerseNote> {
-    if (!this.db) throw new Error('Database not initialized');
+    const db = await this.ensureReady();
 
     const now = Date.now();
     const id = generateId();
 
-    await this.db.runAsync(
+    await db.runAsync(
       `INSERT INTO notes (id, verse_key, surah_number, ayah_number, content, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
       [id, verseKey, surahNumber, ayahNumber, content, now, now],
@@ -285,25 +295,24 @@ class VerseAnnotationDatabaseService {
   }
 
   async updateNote(noteId: string, content: string): Promise<void> {
-    if (!this.db) throw new Error('Database not initialized');
-    await this.db.runAsync(
+    const db = await this.ensureReady();
+    await db.runAsync(
       `UPDATE notes SET content = ?, updated_at = ? WHERE id = ?`,
       [content, Date.now(), noteId],
     );
   }
 
   async getNoteById(noteId: string): Promise<VerseNote | null> {
-    if (!this.db) throw new Error('Database not initialized');
-    const row = (await this.db.getFirstAsync(
-      `SELECT * FROM notes WHERE id = ?`,
-      [noteId],
-    )) as NoteRow | null;
+    const db = await this.ensureReady();
+    const row = (await db.getFirstAsync(`SELECT * FROM notes WHERE id = ?`, [
+      noteId,
+    ])) as NoteRow | null;
     return row ? mapNoteRow(row) : null;
   }
 
   async getNotesForVerse(verseKey: string): Promise<VerseNote[]> {
-    if (!this.db) throw new Error('Database not initialized');
-    const rows = (await this.db.getAllAsync(
+    const db = await this.ensureReady();
+    const rows = (await db.getAllAsync(
       `SELECT * FROM notes WHERE verse_key = ? ORDER BY created_at DESC`,
       [verseKey],
     )) as NoteRow[];
@@ -311,13 +320,13 @@ class VerseAnnotationDatabaseService {
   }
 
   async deleteNoteById(noteId: string): Promise<void> {
-    if (!this.db) throw new Error('Database not initialized');
-    await this.db.runAsync(`DELETE FROM notes WHERE id = ?`, [noteId]);
+    const db = await this.ensureReady();
+    await db.runAsync(`DELETE FROM notes WHERE id = ?`, [noteId]);
   }
 
   async getNotesCountForVerse(verseKey: string): Promise<number> {
-    if (!this.db) throw new Error('Database not initialized');
-    const row = (await this.db.getFirstAsync(
+    const db = await this.ensureReady();
+    const row = (await db.getFirstAsync(
       `SELECT COUNT(*) as count FROM notes WHERE verse_key = ?`,
       [verseKey],
     )) as {count: number} | null;
@@ -325,16 +334,16 @@ class VerseAnnotationDatabaseService {
   }
 
   async getAllNotes(): Promise<VerseNote[]> {
-    if (!this.db) throw new Error('Database not initialized');
-    const rows = (await this.db.getAllAsync(
+    const db = await this.ensureReady();
+    const rows = (await db.getAllAsync(
       `SELECT * FROM notes ORDER BY updated_at DESC`,
     )) as NoteRow[];
     return rows.map(mapNoteRow);
   }
 
   async getNotesBySurah(surahNumber: number): Promise<VerseNote[]> {
-    if (!this.db) throw new Error('Database not initialized');
-    const rows = (await this.db.getAllAsync(
+    const db = await this.ensureReady();
+    const rows = (await db.getAllAsync(
       `SELECT * FROM notes WHERE surah_number = ? ORDER BY ayah_number`,
       [surahNumber],
     )) as NoteRow[];
@@ -348,12 +357,12 @@ class VerseAnnotationDatabaseService {
     ayahNumber: number,
     color: HighlightColor,
   ): Promise<VerseHighlight> {
-    if (!this.db) throw new Error('Database not initialized');
+    const db = await this.ensureReady();
 
     const now = Date.now();
     const id = generateId();
 
-    await this.db.runAsync(
+    await db.runAsync(
       `INSERT INTO highlights (id, verse_key, surah_number, ayah_number, color, created_at)
        VALUES (?, ?, ?, ?, ?, ?)
        ON CONFLICT(verse_key) DO UPDATE SET color = excluded.color`,
@@ -371,15 +380,13 @@ class VerseAnnotationDatabaseService {
   }
 
   async removeHighlight(verseKey: string): Promise<void> {
-    if (!this.db) throw new Error('Database not initialized');
-    await this.db.runAsync(`DELETE FROM highlights WHERE verse_key = ?`, [
-      verseKey,
-    ]);
+    const db = await this.ensureReady();
+    await db.runAsync(`DELETE FROM highlights WHERE verse_key = ?`, [verseKey]);
   }
 
   async getHighlightsBySurah(surahNumber: number): Promise<VerseHighlight[]> {
-    if (!this.db) throw new Error('Database not initialized');
-    const rows = (await this.db.getAllAsync(
+    const db = await this.ensureReady();
+    const rows = (await db.getAllAsync(
       `SELECT * FROM highlights WHERE surah_number = ? ORDER BY ayah_number`,
       [surahNumber],
     )) as HighlightRow[];


### PR DESCRIPTION
## Summary
- Fix "no such table: notes" error on app load caused by a race condition in `VerseAnnotationDatabaseService`
- `this.db` was set before `createTables()` finished, so concurrent queries from the store passed the null check but hit missing tables
- All public methods now call `ensureReady()` which awaits the full init promise (including table creation) before querying

## Test plan
- [ ] Cold launch the app — no "no such table" console error
- [ ] Navigate to a surah — annotations load without error
- [ ] Bookmark/highlight/note operations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)