### PR TITLE
perf(quran-view): eliminate scroll lag with memoization and FlashList tuning

### DIFF
--- a/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
+++ b/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
@@ -1,12 +1,16 @@
-import React, {memo, useCallback, useState} from 'react';
+import React, {memo, useCallback, useEffect, useMemo, useState} from 'react';
 import {StyleSheet, Pressable, Text, View} from 'react-native';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {Verse} from '@/types/quran';
 import Color from 'color';
 import FormattedTextRenderer from '@/components/utils/FormattedText';
 import {Feather, Ionicons} from '@expo/vector-icons';
-import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import {useTajweedStore} from '@/store/tajweedStore';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {useVerseSelectionStore} from '@/store/verseSelectionStore';
+import {HIGHLIGHT_COLORS} from '@/types/verse-annotations';
+import {SheetManager} from 'react-native-actions-sheet';
+import {mediumHaptics} from '@/utils/haptics';
 
 // ---> Lazy-load Indopak JSON data (1.7MB — only loaded when Indopak font is selected)
 interface IndopakNastaleeqData {
@@ -89,20 +93,16 @@ const saheehDataForFootnotes =
 
 interface VerseItemProps {
   verse: Verse & {translation?: string; transliteration?: string};
-  onPress: () => void;
+  onVersePress: (verseKey: string) => void;
   textColor: string;
   borderColor: string;
   showTranslation?: boolean;
   showTransliteration?: boolean;
+  showTajweed: boolean;
+  arabicFontFamily: 'QPC' | 'Indopak';
   transliterationFontSize: number;
   translationFontSize: number;
   arabicFontSize: number;
-  isSelected?: boolean;
-  highlightColor?: string | null;
-  hasBookmark?: boolean;
-  hasNote?: boolean;
-  onLongPress?: () => void;
-  onOptionsPress?: () => void;
 }
 
 /**
@@ -117,54 +117,44 @@ TajweedSegment.displayName = 'TajweedSegment';
 export const VerseItem = memo<VerseItemProps>(
   ({
     verse,
-    onPress,
+    onVersePress,
     textColor,
     borderColor,
-    showTranslation: propShowTranslation,
-    showTransliteration: propShowTransliteration,
-    transliterationFontSize: propTransliterationFontSize,
-    translationFontSize: propTranslationFontSize,
-    arabicFontSize: propArabicFontSize,
-    isSelected,
-    highlightColor,
-    hasBookmark,
-    hasNote,
-    onLongPress,
-    onOptionsPress,
+    showTranslation,
+    showTransliteration,
+    showTajweed,
+    arabicFontFamily,
+    transliterationFontSize,
+    translationFontSize,
+    arabicFontSize,
   }) => {
-    // Get settings from the store
-    const {
-      showTranslation: storeShowTranslation,
-      showTransliteration: storeShowTransliteration,
-      showTajweed, // Used for conditional coloring
-      arabicFontSize: storeArabicFontSize,
-      translationFontSize: storeTranslationFontSize,
-      transliterationFontSize: storeTransliterationFontSize,
-      arabicFontFamily,
-    } = useMushafSettingsStore();
+    const verseKey = verse.verse_key;
+
+    // Per-verse-key annotation selectors — Zustand skips re-render when
+    // THIS verse's specific value didn't change
+    const isSelected = useVerseSelectionStore(
+      useCallback(s => s.selectedVerseKey === verseKey, [verseKey]),
+    );
+    const selectVerse = useVerseSelectionStore(s => s.selectVerse);
+
+    const isBookmarked = useVerseAnnotationsStore(
+      useCallback(s => s.bookmarkedVerseKeys.has(verseKey), [verseKey]),
+    );
+    const hasNote = useVerseAnnotationsStore(
+      useCallback(s => s.notedVerseKeys.has(verseKey), [verseKey]),
+    );
+    const highlightColorKey = useVerseAnnotationsStore(
+      useCallback(s => s.highlights[verseKey] ?? null, [verseKey]),
+    );
+    const highlightColor = highlightColorKey
+      ? HIGHLIGHT_COLORS[highlightColorKey]
+      : null;
 
     // Fetch tajweed data directly from store — granular selector means only
     // the ~10 visible VerseItems re-render when tajweed finishes loading
     const processedTajweedAyahData = useTajweedStore(
-      s => s.indexedTajweedData?.[verse.verse_key],
+      s => s.indexedTajweedData?.[verseKey],
     );
-
-    // Use prop values if provided, otherwise use store values
-    const showTranslation =
-      propShowTranslation !== undefined
-        ? propShowTranslation
-        : storeShowTranslation;
-    const showTransliteration =
-      propShowTransliteration !== undefined
-        ? propShowTransliteration
-        : storeShowTransliteration;
-
-    const transliterationFontSize =
-      propTransliterationFontSize || storeTransliterationFontSize;
-
-    const translationFontSize =
-      propTranslationFontSize || storeTranslationFontSize;
-    const arabicFontSize = propArabicFontSize || storeArabicFontSize;
 
     // Determine font selection
     const isIndopakSelected = arabicFontFamily === 'Indopak';
@@ -174,8 +164,25 @@ export const VerseItem = memo<VerseItemProps>(
       null,
     );
 
-    const bgColor = Color(textColor).alpha(0.08).toString();
-    const footnoteBgColor = Color(textColor).alpha(0.1).toString();
+    // Reset footnote when cell is recycled by FlashList
+    useEffect(() => {
+      setActiveFootnote(null);
+    }, [verseKey]);
+
+    // Batch all Color() derivations — only recomputed on theme or highlight change
+    const derivedColors = useMemo(
+      () => ({
+        bg: Color(textColor).alpha(0.08).toString(),
+        footnoteBg: Color(textColor).alpha(0.1).toString(),
+        selectedBg: Color(textColor).alpha(0.06).toString(),
+        optionsIcon: Color(textColor).alpha(0.5).toString(),
+        translationSource: Color(textColor).alpha(0.6).toString(),
+        highlightBg: highlightColor
+          ? Color(highlightColor).alpha(0.3).toString()
+          : undefined,
+      }),
+      [textColor, highlightColor],
+    );
 
     // Handle footnote press - uses module-scope cached data
     const handleFootnotePress = useCallback(
@@ -186,7 +193,7 @@ export const VerseItem = memo<VerseItemProps>(
           return;
         }
 
-        const verseData = saheehDataForFootnotes[verse.verse_key];
+        const verseData = saheehDataForFootnotes[verseKey];
 
         if (verseData?.f) {
           const footnoteContent = verseData.f[footnoteId];
@@ -212,7 +219,7 @@ export const VerseItem = memo<VerseItemProps>(
           });
         }
       },
-      [verse.verse_key, activeFootnote],
+      [verseKey, activeFootnote],
     );
 
     // Close the footnote display
@@ -220,74 +227,166 @@ export const VerseItem = memo<VerseItemProps>(
       setActiveFootnote(null);
     }, []);
 
+    // Long press → open verse actions sheet
+    const handleLongPress = useCallback(() => {
+      mediumHaptics();
+      selectVerse(verseKey, verse.surah_number, verse.ayah_number);
+      SheetManager.show('verse-actions', {
+        payload: {
+          verseKey,
+          surahNumber: verse.surah_number,
+          ayahNumber: verse.ayah_number,
+          arabicText: verse.text,
+          translation: verse.translation || '',
+          transliteration: verse.transliteration || '',
+        },
+      });
+    }, [verseKey, verse, selectVerse]);
+
+    // Options button → same as long press
+    const handleOptionsPress = useCallback(() => {
+      selectVerse(verseKey, verse.surah_number, verse.ayah_number);
+      SheetManager.show('verse-actions', {
+        payload: {
+          verseKey,
+          surahNumber: verse.surah_number,
+          ayahNumber: verse.ayah_number,
+          arabicText: verse.text,
+          translation: verse.translation || '',
+          transliteration: verse.transliteration || '',
+        },
+      });
+    }, [verseKey, verse, selectVerse]);
+
+    const handlePress = useCallback(() => {
+      onVersePress(verseKey);
+    }, [onVersePress, verseKey]);
+
     // --- Build Tajweed Nodes (Only if QPC and data available) ---
-    const tajweedNodes =
-      isQPCSelected && processedTajweedAyahData
-        ? (processedTajweedAyahData as ProcessedTajweedWord[]).flatMap(
-            (wordData, wordIndex) => {
-              const segments = wordData.segments.map((segment, segIndex) => {
-                // Apply color based on showTajweed state from store
-                const color =
-                  showTajweed && segment.rule
-                    ? tajweedColors[segment.rule] || textColor // Tajweed color or default
-                    : textColor; // Default color if tajweed off or no rule
-                return (
-                  <TajweedSegment
-                    key={`${wordData.location}-${wordIndex}-${segIndex}`}
-                    text={segment.text}
-                    color={color}
-                  />
-                );
-              });
-              // Add space between words
-              if (
-                wordIndex <
-                (processedTajweedAyahData as ProcessedTajweedWord[]).length - 1
-              ) {
-                segments.push(
-                  <Text key={`${wordData.location}-space`}> </Text>,
-                );
-              }
-              return segments;
-            },
-          )
-        : null;
+    const tajweedNodes = useMemo(() => {
+      if (!isQPCSelected || !processedTajweedAyahData) return null;
+      return (processedTajweedAyahData as ProcessedTajweedWord[]).flatMap(
+        (wordData, wordIndex) => {
+          const segments = wordData.segments.map((segment, segIndex) => {
+            // Apply color based on showTajweed state from store
+            const color =
+              showTajweed && segment.rule
+                ? tajweedColors[segment.rule] || textColor // Tajweed color or default
+                : textColor; // Default color if tajweed off or no rule
+            return (
+              <TajweedSegment
+                key={`${wordData.location}-${wordIndex}-${segIndex}`}
+                text={segment.text}
+                color={color}
+              />
+            );
+          });
+          // Add space between words
+          if (
+            wordIndex <
+            (processedTajweedAyahData as ProcessedTajweedWord[]).length - 1
+          ) {
+            segments.push(<Text key={`${wordData.location}-space`}> </Text>);
+          }
+          return segments;
+        },
+      );
+    }, [isQPCSelected, processedTajweedAyahData, showTajweed, textColor]);
     // --- End Building Nodes ---
 
     // ---> Get Indopak text if applicable (lazy-loaded)
     const indopakText = isIndopakSelected
-      ? getIndopakData()?.[verse.verse_key]?.text
+      ? getIndopakData()?.[verseKey]?.text
       : null;
     // <--- End Get Indopak text
 
-    const highlightBgColor = highlightColor
-      ? Color(highlightColor).alpha(0.3).toString()
-      : undefined;
+    // Memoize container style — avoids Pressable function-form re-evaluation every frame
+    const containerStyle = useMemo(
+      () => [
+        styles.container,
+        {borderBottomColor: borderColor},
+        isSelected && {
+          backgroundColor: derivedColors.selectedBg,
+          borderRadius: moderateScale(8),
+        },
+        derivedColors.highlightBg && {
+          backgroundColor: derivedColors.highlightBg,
+          borderRadius: moderateScale(8),
+        },
+      ],
+      [
+        borderColor,
+        isSelected,
+        derivedColors.selectedBg,
+        derivedColors.highlightBg,
+      ],
+    );
+
+    // Memoize inline text styles — only change on theme/settings switch, never during scroll
+    const arabicStyle = useMemo(
+      () => [
+        styles.arabicText,
+        {
+          color: textColor,
+          fontSize: moderateScale(arabicFontSize),
+          fontFamily: arabicFontFamily,
+        },
+      ],
+      [textColor, arabicFontSize, arabicFontFamily],
+    );
+
+    const arabicStyleNoColor = useMemo(
+      () => [
+        styles.arabicText,
+        {
+          fontSize: moderateScale(arabicFontSize),
+          fontFamily: arabicFontFamily,
+        },
+      ],
+      [arabicFontSize, arabicFontFamily],
+    );
+
+    const transliterationStyle = useMemo(
+      () => [
+        styles.transliterationText,
+        {color: textColor, fontSize: moderateScale(transliterationFontSize)},
+      ],
+      [textColor, transliterationFontSize],
+    );
+
+    const translationStyle = useMemo(
+      () => [
+        styles.translationText,
+        {color: textColor, fontSize: moderateScale(translationFontSize)},
+      ],
+      [textColor, translationFontSize],
+    );
+
+    const translationSourceStyle = useMemo(
+      () => [
+        styles.translationSource,
+        {color: derivedColors.translationSource},
+      ],
+      [derivedColors.translationSource],
+    );
 
     return (
       <Pressable
-        style={() => [
-          styles.container,
-          {borderBottomColor: borderColor},
-          isSelected && {
-            backgroundColor: Color(textColor).alpha(0.06).toString(),
-            borderRadius: moderateScale(8),
-          },
-          highlightBgColor && {
-            backgroundColor: highlightBgColor,
-            borderRadius: moderateScale(8),
-          },
-        ]}
-        onPress={onPress}
-        onLongPress={onLongPress}>
+        style={containerStyle}
+        onPress={handlePress}
+        onLongPress={handleLongPress}>
         <View style={styles.verseInfoContainer}>
           <View style={styles.verseInfoRow}>
-            <View style={[styles.verseInfoPill, {backgroundColor: bgColor}]}>
+            <View
+              style={[
+                styles.verseInfoPill,
+                {backgroundColor: derivedColors.bg},
+              ]}>
               <Text style={[styles.verseInfo, {color: textColor}]}>
                 {verse.surah_number}:{verse.ayah_number}
               </Text>
             </View>
-            {hasBookmark && (
+            {isBookmarked && (
               <Feather
                 name="bookmark"
                 size={moderateScale(12)}
@@ -304,13 +403,13 @@ export const VerseItem = memo<VerseItemProps>(
               />
             )}
             <Pressable
-              onPress={onOptionsPress}
+              onPress={handleOptionsPress}
               hitSlop={8}
               style={styles.optionsButton}>
               <Feather
                 name="more-horizontal"
                 size={moderateScale(18)}
-                color={Color(textColor).alpha(0.5).toString()}
+                color={derivedColors.optionsIcon}
               />
             </Pressable>
           </View>
@@ -319,81 +418,35 @@ export const VerseItem = memo<VerseItemProps>(
         <View>
           {isIndopakSelected ? (
             // Indopak Rendering
-            <Text
-              style={[
-                styles.arabicText,
-                {
-                  color: textColor,
-                  fontSize: moderateScale(arabicFontSize),
-                  fontFamily: arabicFontFamily, // 'Indopak'
-                },
-              ]}>
+            <Text style={arabicStyle}>
               {indopakText || 'Loading Indopak...'}
             </Text>
           ) : isQPCSelected && tajweedNodes ? (
             // QPC Rendering: Always use generated tajweedNodes
-            <Text
-              style={[
-                styles.arabicText,
-                {
-                  fontSize: moderateScale(arabicFontSize),
-                  fontFamily: arabicFontFamily, // 'QPC'
-                },
-              ]}>
-              {tajweedNodes}
-            </Text>
+            <Text style={arabicStyleNoColor}>{tajweedNodes}</Text>
           ) : (
             // Fallback (e.g., QPC selected but data is loading/missing)
-            <Text
-              style={[
-                styles.arabicText,
-                {
-                  color: textColor,
-                  fontSize: moderateScale(arabicFontSize),
-                  fontFamily: arabicFontFamily, // Should be QPC here ideally
-                },
-              ]}>
-              {/* Display plain text or loading indicator */}
-              {verse.text || 'Loading...'}
-            </Text>
+            <Text style={arabicStyle}>{verse.text || 'Loading...'}</Text>
           )}
         </View>
         {/* ---> End Conditional Rendering <--- */}
         {showTransliteration && verse.transliteration && (
           <FormattedTextRenderer
             text={verse.transliteration}
-            baseStyle={[
-              styles.transliterationText,
-              {
-                color: textColor,
-                fontSize: moderateScale(transliterationFontSize),
-              },
-            ]}
+            baseStyle={transliterationStyle}
           />
         )}
         {showTranslation && verse.translation && (
           <View>
             <FormattedTextRenderer
               text={verse.translation}
-              baseStyle={[
-                styles.translationText,
-                {
-                  color: textColor,
-                  fontSize: moderateScale(translationFontSize),
-                },
-              ]}
+              baseStyle={translationStyle}
               onFootnotePress={handleFootnotePress}
             />
 
             {/* Display Translation Source */}
             {verse.translation && (
-              <Text
-                style={[
-                  styles.translationSource,
-                  {color: Color(textColor).alpha(0.6).toString()},
-                ]}>
-                Saheeh International
-              </Text>
+              <Text style={translationSourceStyle}>Saheeh International</Text>
             )}
           </View>
         )}
@@ -403,7 +456,7 @@ export const VerseItem = memo<VerseItemProps>(
           <View
             style={[
               styles.footnoteContainer,
-              {backgroundColor: footnoteBgColor},
+              {backgroundColor: derivedColors.footnoteBg},
             ]}>
             <View style={styles.footnoteHeader}>
               <Text style={[styles.footnoteTitle, {color: textColor}]}>

--- a/components/player/v2/PlayerContent/QuranView/index.tsx
+++ b/components/player/v2/PlayerContent/QuranView/index.tsx
@@ -1,20 +1,13 @@
-import React, {useCallback, useRef, useEffect} from 'react';
+import React, {useCallback, useMemo, useRef, useEffect} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Surah, QuranData, Verse} from '@/types/quran';
 import {VerseItem} from './VerseItem';
-import {
-  LegendList,
-  LegendListRef,
-  LegendListRenderItemProps,
-} from '@legendapp/list';
+import {FlashList, type FlashListRef} from '@shopify/flash-list';
 import {useBottomSheetScrollableCreator} from '@gorhom/bottom-sheet';
-import {useVerseSelectionStore} from '@/store/verseSelectionStore';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
-import {HIGHLIGHT_COLORS} from '@/types/verse-annotations';
-import {SheetManager} from 'react-native-actions-sheet';
-import {mediumHaptics} from '@/utils/haptics';
+import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 
 // Import data with type safety - move outside component to load only once
 const quranData = require('@/data/quran.json') as QuranData;
@@ -45,7 +38,7 @@ const transliterationDataCache =
   require('@/data/transliteration.json') as TransliterationData;
 
 // Enhanced verse type including translations and transliterations
-interface EnhancedVerse extends Verse {
+export interface EnhancedVerse extends Verse {
   translation?: string;
   transliteration?: string;
 }
@@ -64,7 +57,6 @@ interface QuranViewProps {
   onVersePress: (verseKey: string) => void;
   showTranslation?: boolean;
   showTransliteration?: boolean;
-  showTajweed?: boolean;
   transliterationFontSize: number;
   translationFontSize: number;
   arabicFontSize: number;
@@ -80,20 +72,15 @@ export const QuranView: React.FC<QuranViewProps> = ({
   arabicFontSize,
 }) => {
   const {theme} = useTheme();
-  const listRef = useRef<LegendListRef>(null);
+  const listRef = useRef<FlashListRef<EnhancedVerse>>(null);
   const renderScrollComponent = useBottomSheetScrollableCreator();
   const surah = surahData.find(s => s.id === currentSurah);
 
-  // Verse selection
-  const selectedVerseKey = useVerseSelectionStore(s => s.selectedVerseKey);
-  const selectVerse = useVerseSelectionStore(s => s.selectVerse);
+  // Granular mushaf settings selectors (avoid full-store subscription)
+  const showTajweed = useMushafSettingsStore(s => s.showTajweed);
+  const arabicFontFamily = useMushafSettingsStore(s => s.arabicFontFamily);
 
-  // Verse annotations
-  const bookmarkedVerseKeys = useVerseAnnotationsStore(
-    s => s.bookmarkedVerseKeys,
-  );
-  const notedVerseKeys = useVerseAnnotationsStore(s => s.notedVerseKeys);
-  const highlights = useVerseAnnotationsStore(s => s.highlights);
+  // Only need the loader — VerseItem subscribes to its own annotation data
   const loadAnnotationsForSurah = useVerseAnnotationsStore(
     s => s.loadAnnotationsForSurah,
   );
@@ -103,39 +90,20 @@ export const QuranView: React.FC<QuranViewProps> = ({
     loadAnnotationsForSurah(currentSurah);
   }, [currentSurah, loadAnnotationsForSurah]);
 
-  // Memoize the getVersesForSurah function — no tajweed dependency
-  const getVersesForSurahMemo = useCallback(() => {
+  // Memoize verses array — only recomputed when surah changes
+  const verses = useMemo(() => {
     const surahVerses = versesBySurah[currentSurah];
-    if (!surahVerses) {
-      return [];
-    }
+    if (!surahVerses) return [];
 
-    try {
-      return surahVerses.map(verse => {
-        const verseKey = `${verse.surah_number}:${verse.ayah_number}`;
-        let translationText = '';
-        if (saheehDataCache?.[verseKey]?.t) {
-          translationText = saheehDataCache[verseKey].t;
-        }
-        let transliterationText = '';
-        if (transliterationDataCache?.[verseKey]) {
-          transliterationText = transliterationDataCache[verseKey].t;
-        }
-
-        return {
-          ...verse,
-          translation: translationText,
-          transliteration: transliterationText,
-        };
-      });
-    } catch (error) {
-      console.error('Error processing verses:', error);
-      return [];
-    }
+    return surahVerses.map(verse => {
+      const verseKey = `${verse.surah_number}:${verse.ayah_number}`;
+      return {
+        ...verse,
+        translation: saheehDataCache?.[verseKey]?.t || '',
+        transliteration: transliterationDataCache?.[verseKey]?.t || '',
+      };
+    });
   }, [currentSurah]);
-
-  // Get verses data
-  const verses = getVersesForSurahMemo();
 
   // Reset scroll position when currentSurah changes
   useEffect(() => {
@@ -154,67 +122,34 @@ export const QuranView: React.FC<QuranViewProps> = ({
     );
   }, [surah?.bismillah_pre, theme.colors.text]);
 
-  // Open verse actions sheet for a given verse
-  const openVerseActions = useCallback(
-    (item: EnhancedVerse) => {
-      const vk = item.verse_key;
-      selectVerse(vk, item.surah_number, item.ayah_number);
-      SheetManager.show('verse-actions', {
-        payload: {
-          verseKey: vk,
-          surahNumber: item.surah_number,
-          ayahNumber: item.ayah_number,
-          arabicText: item.text,
-          translation: item.translation || '',
-          transliteration: item.transliteration || '',
-        },
-      });
-    },
-    [selectVerse],
-  );
-
-  // Render the verse items (optimized with LegendList)
+  // Render verse items — annotations handled inside VerseItem via per-key selectors
   const renderItem = useCallback(
-    ({item}: LegendListRenderItemProps<EnhancedVerse>) => {
-      const vk = item.verse_key;
-      const hlColor = highlights[vk];
-      return (
-        <VerseItem
-          verse={item}
-          onPress={() => onVersePress(vk)}
-          textColor={theme.colors.text}
-          borderColor={theme.colors.border}
-          showTranslation={showTranslation}
-          showTransliteration={showTransliteration}
-          transliterationFontSize={transliterationFontSize}
-          translationFontSize={translationFontSize}
-          arabicFontSize={arabicFontSize}
-          isSelected={selectedVerseKey === vk}
-          highlightColor={hlColor ? HIGHLIGHT_COLORS[hlColor] : null}
-          hasBookmark={bookmarkedVerseKeys.has(vk)}
-          hasNote={notedVerseKeys.has(vk)}
-          onLongPress={() => {
-            mediumHaptics();
-            openVerseActions(item);
-          }}
-          onOptionsPress={() => openVerseActions(item)}
-        />
-      );
-    },
+    ({item}: {item: EnhancedVerse}) => (
+      <VerseItem
+        verse={item}
+        onVersePress={onVersePress}
+        textColor={theme.colors.text}
+        borderColor={theme.colors.border}
+        showTranslation={showTranslation}
+        showTransliteration={showTransliteration}
+        showTajweed={showTajweed}
+        arabicFontFamily={arabicFontFamily}
+        transliterationFontSize={transliterationFontSize}
+        translationFontSize={translationFontSize}
+        arabicFontSize={arabicFontSize}
+      />
+    ),
     [
       onVersePress,
       theme.colors.text,
       theme.colors.border,
       showTranslation,
       showTransliteration,
+      showTajweed,
+      arabicFontFamily,
       transliterationFontSize,
       translationFontSize,
       arabicFontSize,
-      selectedVerseKey,
-      highlights,
-      bookmarkedVerseKeys,
-      notedVerseKeys,
-      openVerseActions,
     ],
   );
 
@@ -227,20 +162,18 @@ export const QuranView: React.FC<QuranViewProps> = ({
 
   return (
     <View style={styles.container}>
-      <LegendList
+      <FlashList
         ref={listRef}
         data={verses}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         ListHeaderComponent={renderHeader}
-        style={styles.list}
         contentContainerStyle={styles.scrollContent}
         renderScrollComponent={renderScrollComponent}
         showsVerticalScrollIndicator={false}
         bounces={true}
         overScrollMode="never"
-        recycleItems={true}
-        estimatedItemSize={150}
+        drawDistance={1500}
       />
     </View>
   );
@@ -251,10 +184,8 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     backgroundColor: 'transparent',
-  },
-  list: {
-    flex: 1,
     borderRadius: moderateScale(15),
+    overflow: 'hidden',
   },
   scrollContent: {
     paddingBottom: verticalScale(20),

--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -33,14 +33,18 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
   const queue = usePlayerStore(s => s.queue);
   const insets = useSafeAreaInsets();
 
-  // Get mushaf settings from the store
-  const {
-    showTranslation,
-    showTransliteration,
-    arabicFontSize,
-    translationFontSize,
-    transliterationFontSize,
-  } = useMushafSettingsStore();
+  // Granular mushaf settings selectors (avoid full-store subscription)
+  const showTranslation = useMushafSettingsStore(s => s.showTranslation);
+  const showTransliteration = useMushafSettingsStore(
+    s => s.showTransliteration,
+  );
+  const arabicFontSize = useMushafSettingsStore(s => s.arabicFontSize);
+  const translationFontSize = useMushafSettingsStore(
+    s => s.translationFontSize,
+  );
+  const transliterationFontSize = useMushafSettingsStore(
+    s => s.transliterationFontSize,
+  );
 
   const handleQueuePress = useCallback(() => {
     setShowQueue(prev => !prev);

--- a/components/utils/FormattedText.tsx
+++ b/components/utils/FormattedText.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {memo} from 'react';
 import {Text, StyleSheet, TextStyle, StyleProp, Platform} from 'react-native';
 
 interface FormattedTextProps {
@@ -7,7 +7,7 @@ interface FormattedTextProps {
   onFootnotePress?: (footnoteId: string, footnoteNumber: string) => void;
 }
 
-function FormattedTextRenderer({
+const FormattedTextRenderer = memo(function FormattedTextRenderer({
   text,
   baseStyle,
   onFootnotePress,
@@ -165,7 +165,9 @@ function FormattedTextRenderer({
       {elements}
     </Text>
   );
-}
+});
+
+FormattedTextRenderer.displayName = 'FormattedTextRenderer';
 
 const styles = StyleSheet.create({
   bold: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "bayaan",
       "version": "1.3.2",
+      "hasInstallScript": true,
       "dependencies": {
         "@babel/runtime": "^7.20.6",
         "@expo/server": "^0.1.0",
@@ -23,6 +24,7 @@
         "@react-navigation/native-stack": "^7.2.0",
         "@rneui/base": "^5.0.0",
         "@rneui/themed": "^5.0.0",
+        "@shopify/flash-list": "2.0.2",
         "@supabase/supabase-js": "^2.91.0",
         "burnt": "^0.13.0",
         "colorthief": "^2.4.0",
@@ -6734,6 +6736,20 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@shopify/flash-list": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@shopify/flash-list/-/flash-list-2.0.2.tgz",
+      "integrity": "sha512-zhlrhA9eiuEzja4wxVvotgXHtqd3qsYbXkQ3rsBfOgbFA9BVeErpDE/yEwtlIviRGEqpuFj/oU5owD6ByaNX+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "*",
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@react-navigation/native-stack": "^7.2.0",
     "@rneui/base": "^5.0.0",
     "@rneui/themed": "^5.0.0",
+    "@shopify/flash-list": "2.0.2",
     "@supabase/supabase-js": "^2.91.0",
     "burnt": "^0.13.0",
     "colorthief": "^2.4.0",


### PR DESCRIPTION
## Summary
- Batch all Color() allocations into a single `useMemo` in VerseItem (~50 calls/frame → 0 during scroll)
- Memoize tajweed node generation, container style, and all inline text styles
- Replace Pressable function-form style with static memoized style
- Wrap `FormattedTextRenderer` in `React.memo()`
- Add `drawDistance={1500}` to FlashList for pre-rendering items beyond viewport
- Migrate from LegendList to FlashList and use granular Zustand selectors in PlayerContent

## Test plan
- [ ] Fast scroll through Al-Baqarah (286 verses) — no blank areas visible
- [ ] Tajweed colors render correctly after scroll
- [ ] Translation/transliteration text displays correctly
- [ ] Footnotes still work (tap to open)
- [ ] Highlight colors, bookmarks, selection all render correctly
- [ ] Theme switching still updates all verses

🤖 Generated with [Claude Code](https://claude.com/claude-code)