### PR TITLE
feat(player): immersive reading mode

### DIFF
--- a/components/player/v2/PlayerContent/QuranView/index.tsx
+++ b/components/player/v2/PlayerContent/QuranView/index.tsx
@@ -60,6 +60,8 @@ interface QuranViewProps {
   transliterationFontSize: number;
   translationFontSize: number;
   arabicFontSize: number;
+  contentPaddingTop?: number;
+  contentPaddingBottom?: number;
 }
 
 export const QuranView: React.FC<QuranViewProps> = ({
@@ -70,6 +72,8 @@ export const QuranView: React.FC<QuranViewProps> = ({
   transliterationFontSize,
   translationFontSize,
   arabicFontSize,
+  contentPaddingTop,
+  contentPaddingBottom,
 }) => {
   const {theme} = useTheme();
   const listRef = useRef<FlashListRef<EnhancedVerse>>(null);
@@ -168,7 +172,10 @@ export const QuranView: React.FC<QuranViewProps> = ({
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         ListHeaderComponent={renderHeader}
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={{
+          paddingTop: contentPaddingTop,
+          paddingBottom: (contentPaddingBottom || 0) + verticalScale(20),
+        }}
         renderScrollComponent={renderScrollComponent}
         showsVerticalScrollIndicator={false}
         bounces={true}
@@ -186,9 +193,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     borderRadius: moderateScale(15),
     overflow: 'hidden',
-  },
-  scrollContent: {
-    paddingBottom: verticalScale(20),
   },
   bismillahContainer: {
     width: '100%',

--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -1,11 +1,17 @@
 import React, {useState, useCallback, useEffect} from 'react';
-import {View, StyleSheet} from 'react-native';
+import {View, StyleSheet, LayoutChangeEvent} from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated';
 import {QueueList} from './QueueList';
 import {QuranView} from './QuranView';
 import {TrackInfo} from './TrackInfo';
 import {PlaybackControls} from './PlaybackControls';
 import {ControlButtons} from './ControlButtons';
 import {UploadPlaceholder} from './UploadPlaceholder';
+import {Header} from './Header';
 import {moderateScale} from 'react-native-size-matters';
 import {usePlayerActions} from '@/hooks/usePlayerActions';
 import {usePlayerStore} from '@/services/player/store/playerStore';
@@ -13,25 +19,38 @@ import {useVerseSelectionStore} from '@/store/verseSelectionStore';
 import {useTheme} from '@/hooks/useTheme';
 import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import Color from 'color';
 
 interface PlayerContentProps {
   onSpeedPress: () => void;
   onSleepTimerPress: () => void;
   onMushafLayoutPress: () => void;
   onAmbientPress: () => void;
+  onOptionsPress: () => void;
 }
+
+const ANIMATION_DURATION = 300;
+const DEFAULT_HEADER_HEIGHT = 100;
+const DEFAULT_CONTROLS_HEIGHT = 250;
 
 const PlayerContent: React.FC<PlayerContentProps> = ({
   onSpeedPress,
   onSleepTimerPress,
   onMushafLayoutPress,
   onAmbientPress,
+  onOptionsPress,
 }) => {
-  useTheme();
+  const {theme} = useTheme();
   const [showQueue, setShowQueue] = useState(false);
-  const {updateQueue, removeFromQueue, play} = usePlayerActions();
+  const {updateQueue, removeFromQueue, play, toggleImmersive, setImmersive} =
+    usePlayerActions();
   const queue = usePlayerStore(s => s.queue);
+  const isImmersive = usePlayerStore(s => s.isImmersive);
   const insets = useSafeAreaInsets();
+
+  // Overlay height measurement
+  const [headerHeight, setHeaderHeight] = useState(DEFAULT_HEADER_HEIGHT);
+  const [controlsHeight, setControlsHeight] = useState(DEFAULT_CONTROLS_HEIGHT);
 
   // Granular mushaf settings selectors (avoid full-store subscription)
   const showTranslation = useMushafSettingsStore(s => s.showTranslation);
@@ -45,6 +64,27 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
   const transliterationFontSize = useMushafSettingsStore(
     s => s.transliterationFontSize,
   );
+
+  // Reanimated shared value for overlay opacity
+  const overlayOpacity = useSharedValue(1);
+
+  // Animate overlay opacity when immersive state changes
+  useEffect(() => {
+    overlayOpacity.value = withTiming(isImmersive ? 0 : 1, {
+      duration: ANIMATION_DURATION,
+    });
+  }, [isImmersive, overlayOpacity]);
+
+  const overlayAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: overlayOpacity.value,
+  }));
+
+  // Exit immersive when queue opens
+  useEffect(() => {
+    if (showQueue) {
+      setImmersive(false);
+    }
+  }, [showQueue, setImmersive]);
 
   const handleQueuePress = useCallback(() => {
     setShowQueue(prev => !prev);
@@ -73,12 +113,16 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
     [removeFromQueue],
   );
 
-  const handleVersePress = useCallback(async (verseKey: string) => {
-    const [surahId, verseNumber] = verseKey
-      .split(':')
-      .map(num => parseInt(num, 10));
-    // TODO: Implement verse selection logic
-    console.log('Selected verse:', surahId, verseNumber);
+  const handleVersePress = useCallback(() => {
+    toggleImmersive();
+  }, [toggleImmersive]);
+
+  const handleHeaderLayout = useCallback((e: LayoutChangeEvent) => {
+    setHeaderHeight(e.nativeEvent.layout.height);
+  }, []);
+
+  const handleControlsLayout = useCallback((e: LayoutChangeEvent) => {
+    setControlsHeight(e.nativeEvent.layout.height);
   }, []);
 
   const currentTrack = queue?.tracks?.[queue?.currentIndex ?? -1];
@@ -94,16 +138,17 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
 
   return (
     <View style={styles.container}>
-      <View style={styles.viewsContainer}>
+      {/* QuranView / QueueList fills the entire area */}
+      <View style={StyleSheet.absoluteFill}>
         {showQueue ? (
-          <View style={styles.viewWrapper}>
+          <View style={styles.fullArea}>
             <QueueList
               onQueueItemPress={handleQueueItemPress}
               onRemoveQueueItem={handleRemoveQueueItem}
             />
           </View>
         ) : (
-          <View style={styles.viewWrapper}>
+          <View style={styles.fullArea}>
             {isUntaggedUpload ? (
               <UploadPlaceholder currentTrack={currentTrack} />
             ) : (
@@ -115,16 +160,48 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
                 transliterationFontSize={transliterationFontSize}
                 translationFontSize={translationFontSize}
                 arabicFontSize={arabicFontSize}
+                contentPaddingTop={headerHeight}
+                contentPaddingBottom={controlsHeight}
               />
             )}
           </View>
         )}
       </View>
-      <View
+
+      {/* Header overlay — absolute positioned at top */}
+      <Animated.View
         style={[
-          styles.controlsContainer,
-          {paddingBottom: insets.bottom || moderateScale(20)},
-        ]}>
+          styles.headerOverlay,
+          overlayAnimatedStyle,
+          {backgroundColor: theme.colors.background},
+        ]}
+        pointerEvents={isImmersive ? 'none' : 'auto'}
+        onLayout={handleHeaderLayout}>
+        <View style={styles.handleContainer}>
+          <View
+            style={[
+              styles.handle,
+              {
+                backgroundColor: Color(theme.colors.text).alpha(0.2).toString(),
+              },
+            ]}
+          />
+        </View>
+        <Header onOptionsPress={onOptionsPress} />
+      </Animated.View>
+
+      {/* Controls overlay — absolute positioned at bottom */}
+      <Animated.View
+        style={[
+          styles.controlsOverlay,
+          overlayAnimatedStyle,
+          {
+            backgroundColor: theme.colors.background,
+            paddingBottom: insets.bottom || moderateScale(20),
+          },
+        ]}
+        pointerEvents={isImmersive ? 'none' : 'auto'}
+        onLayout={handleControlsLayout}>
         <TrackInfo />
         <PlaybackControls />
         <ControlButtons
@@ -135,7 +212,7 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
           onMushafLayoutPress={onMushafLayoutPress}
           onAmbientPress={onAmbientPress}
         />
-      </View>
+      </Animated.View>
     </View>
   );
 };
@@ -145,22 +222,32 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: 'transparent',
   },
-  viewsContainer: {
+  fullArea: {
     flex: 1,
-    width: '100%',
-    marginTop: moderateScale(5),
-    position: 'relative',
+    paddingHorizontal: moderateScale(20),
   },
-  viewWrapper: {
-    height: '100%',
+  headerOverlay: {
     position: 'absolute',
     top: 0,
     left: 0,
     right: 0,
-    paddingHorizontal: moderateScale(20),
+    alignItems: 'center',
+    paddingTop: moderateScale(12),
   },
-  controlsContainer: {
+  handleContainer: {
+    alignItems: 'center',
     width: '100%',
+  },
+  handle: {
+    width: 40,
+    height: 5,
+    borderRadius: 3,
+  },
+  controlsOverlay: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
     paddingHorizontal: moderateScale(20),
     paddingTop: moderateScale(10),
   },

--- a/components/player/v2/PlayerSheet.tsx
+++ b/components/player/v2/PlayerSheet.tsx
@@ -9,7 +9,6 @@ import {usePlayerActions} from '@/hooks/usePlayerActions';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {useTheme} from '@/hooks/useTheme';
 import PlayerContent from './PlayerContent';
-import {Header} from './PlayerContent/Header';
 import Color from 'color';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {SURAHS} from '@/data/surahData';
@@ -23,10 +22,12 @@ export const PlayerSheet = () => {
   const [remainingTime, setRemainingTime] = useState<number | null>(null);
   const {navigateToReciterProfile} = useReciterNavigation();
 
-  const {setSheetMode, setRate, updateSettings} = usePlayerActions();
+  const {setSheetMode, setRate, updateSettings, setImmersive} =
+    usePlayerActions();
   const queue = usePlayerStore(s => s.queue);
   const loading = usePlayerStore(s => s.loading);
   const sheetMode = usePlayerStore(s => s.sheetMode);
+  const isImmersive = usePlayerStore(s => s.isImmersive);
   const playbackRate = usePlayerStore(s => s.playback.rate);
   const settings = usePlayerStore(s => s.settings);
 
@@ -36,10 +37,14 @@ export const PlayerSheet = () => {
 
     const handleBackPress = () => {
       if (sheetMode === 'full') {
+        if (isImmersive) {
+          setImmersive(false);
+          return true;
+        }
         setSheetMode('hidden');
-        return true; // Prevent default behavior
+        return true;
       }
-      return false; // Let default behavior happen
+      return false;
     };
 
     const subscription = BackHandler.addEventListener(
@@ -48,7 +53,7 @@ export const PlayerSheet = () => {
     );
 
     return () => subscription.remove();
-  }, [sheetMode, setSheetMode]);
+  }, [sheetMode, isImmersive, setSheetMode, setImmersive]);
 
   // Effect to handle sleep timer remaining time
   useEffect(() => {
@@ -91,11 +96,12 @@ export const PlayerSheet = () => {
 
     const sheet = bottomSheetRef.current;
     if (sheetMode === 'hidden') {
+      setImmersive(false);
       sheet.close();
     } else if (sheetMode === 'full') {
       sheet.expand();
     }
-  }, [sheetMode]);
+  }, [sheetMode, setImmersive]);
 
   const currentTrack = queue?.tracks?.[queue?.currentIndex ?? -1];
   const shouldShow = !loading?.stateRestoring && !!currentTrack;
@@ -220,19 +226,9 @@ export const PlayerSheet = () => {
 
   const renderHandleComponent = useCallback(
     (_props: BottomSheetHandleProps) => (
-      <View style={[styles.handleContainer, {paddingTop: insets.top + 12}]}>
-        <View
-          style={[
-            styles.handle,
-            {
-              backgroundColor: Color(theme.colors.text).alpha(0.2).toString(),
-            },
-          ]}
-        />
-        <Header onOptionsPress={handleShowOptionsSheet} />
-      </View>
+      <View style={{paddingTop: insets.top}} />
     ),
-    [insets.top, theme.colors.text, handleShowOptionsSheet],
+    [insets.top],
   );
 
   // Only render modals once settings are loaded to prevent hydration issues
@@ -247,7 +243,11 @@ export const PlayerSheet = () => {
   return (
     <>
       {sheetMode === 'full' && (
-        <StatusBar barStyle={isLightText ? 'light-content' : 'dark-content'} />
+        <StatusBar
+          barStyle={isLightText ? 'light-content' : 'dark-content'}
+          hidden={isImmersive}
+          animated
+        />
       )}
       <BottomSheet
         ref={bottomSheetRef}
@@ -270,6 +270,7 @@ export const PlayerSheet = () => {
           onSleepTimerPress={handleShowSleepTimerSheet}
           onMushafLayoutPress={handleShowMushafLayoutSheet}
           onAmbientPress={handleShowAmbientSheet}
+          onOptionsPress={handleShowOptionsSheet}
         />
       </BottomSheet>
     </>
@@ -284,13 +285,5 @@ const styles = StyleSheet.create({
   background: {
     borderTopLeftRadius: 45,
     borderTopRightRadius: 45,
-  },
-  handleContainer: {
-    alignItems: 'center',
-  },
-  handle: {
-    width: 40,
-    height: 5,
-    borderRadius: 3,
   },
 });

--- a/hooks/usePlayerActions.ts
+++ b/hooks/usePlayerActions.ts
@@ -37,6 +37,9 @@ export function usePlayerActions() {
 
       setSheetMode: (mode: 'hidden' | 'full') =>
         usePlayerStore.getState().setSheetMode(mode),
+      toggleImmersive: () => usePlayerStore.getState().toggleImmersive(),
+      setImmersive: (value: boolean) =>
+        usePlayerStore.getState().setImmersive(value),
       setRepeatMode: (mode: PlaybackSettings['repeatMode']) =>
         usePlayerStore.getState().setRepeatMode(mode),
       toggleShuffle: () => usePlayerStore.getState().toggleShuffle(),

--- a/services/player/store/playerStore.ts
+++ b/services/player/store/playerStore.ts
@@ -34,9 +34,12 @@ type StorePlaybackState =
 export interface PlayerStoreState extends Omit<UnifiedPlayerState, 'ui'> {
   // UI State
   sheetMode: UIState['sheetMode'];
+  isImmersive: boolean;
 
   // UI Actions
   setSheetMode: (mode: UIState['sheetMode']) => void;
+  toggleImmersive: () => void;
+  setImmersive: (value: boolean) => void;
 
   // Playback Actions
   play: () => Promise<void>;
@@ -114,6 +117,7 @@ export const usePlayerStore = create<PlayerStoreState>()(
       ...createDefaultUnifiedPlayerState(),
       // Add UI state
       sheetMode: 'hidden' as const,
+      isImmersive: false,
 
       // UI Actions
       setSheetMode: (mode: UIState['sheetMode']) => {
@@ -127,6 +131,16 @@ export const usePlayerStore = create<PlayerStoreState>()(
           });
 
         set({sheetMode: mode});
+      },
+
+      toggleImmersive: () => {
+        set(state => ({isImmersive: !state.isImmersive}));
+      },
+
+      setImmersive: (value: boolean) => {
+        if (get().isImmersive !== value) {
+          set({isImmersive: value});
+        }
       },
 
       // Playback Actions

--- a/services/player/store/validation.ts
+++ b/services/player/store/validation.ts
@@ -384,6 +384,7 @@ export function createDefaultUnifiedPlayerState(): UnifiedPlayerState {
     ui: {
       sheetMode: 'hidden',
       isTransitioning: false,
+      isImmersive: false,
     },
   };
 }
@@ -395,5 +396,6 @@ export function createDefaultUIState(): UIState {
   return {
     sheetMode: 'hidden',
     isTransitioning: false,
+    isImmersive: false,
   };
 }

--- a/services/player/types/state.ts
+++ b/services/player/types/state.ts
@@ -108,6 +108,7 @@ export interface PlaybackSettings {
 export interface UIState {
   sheetMode: 'hidden' | 'full';
   isTransitioning: boolean;
+  isImmersive: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds tap-to-hide-chrome immersive mode on the Quran player screen
- Restructures PlayerContent to an overlay architecture — QuranView fills the entire area, header/controls are absolute-positioned overlays that fade in/out with reanimated
- Verse text stays perfectly still during transitions (no layout shift)

## Test plan
- [ ] Open player → tap any verse → header, controls, drag handle, status bar all fade out (300ms)
- [ ] Verse text stays still during transition
- [ ] Tap again → everything fades back in
- [ ] Long-press a verse → verse actions sheet opens (immersive unaffected)
- [ ] Toggle queue → immersive auto-exits
- [ ] Android back button in immersive → exits immersive first
- [ ] Close player → immersive resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)