### PR TITLE
Fix minor UI issues: blur, spacing, icons

### DIFF
--- a/app/(tabs)/(a.home)/index.tsx
+++ b/app/(tabs)/(a.home)/index.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useCallback} from 'react';
-import {View, Pressable, ScrollView, StyleSheet, Platform} from 'react-native';
+import {View, Pressable, ScrollView, StyleSheet} from 'react-native';
 import {AntDesign} from '@expo/vector-icons';
 import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
@@ -16,7 +16,6 @@ import TabSelector from '@/components/TabSelector';
 import {useSettings} from '@/hooks/useSettings';
 import {useReciterStore} from '@/store/reciterStore';
 import {TOTAL_BOTTOM_PADDING} from '@/utils/constants';
-import {BlurView} from '@react-native-community/blur';
 import Animated from 'react-native-reanimated';
 import {Theme} from '@/utils/themeUtils';
 import {EdgeInsets} from 'react-native-safe-area-context';
@@ -50,15 +49,6 @@ const Header = React.memo(
         right: 0,
         zIndex: 100,
       },
-      blurContainer: {
-        overflow: 'hidden',
-        borderWidth: 0.1,
-        borderColor: 'rgba(255, 255, 255, 0.1)',
-      },
-      overlay: {
-        ...StyleSheet.absoluteFillObject,
-        opacity: 0.85,
-      },
       header: {
         flexDirection: 'row',
         alignItems: 'center',
@@ -88,40 +78,12 @@ const Header = React.memo(
 
     return (
       <Animated.View style={[headerStyles.container, {paddingTop: insets.top}]}>
-        {Platform.OS === 'ios' ? (
-          <BlurView
-            blurAmount={20}
-            blurType={theme.isDarkMode ? 'dark' : 'light'}
-            style={[StyleSheet.absoluteFill, headerStyles.blurContainer]}>
-            <View
-              style={[
-                headerStyles.overlay,
-                {
-                  backgroundColor: theme.colors.background,
-                },
-              ]}
-            />
-          </BlurView>
-        ) : (
-          <View
-            style={[
-              StyleSheet.absoluteFill,
-              headerStyles.blurContainer,
-              {
-                backgroundColor: theme.colors.background,
-                opacity: 0.95,
-              },
-            ]}>
-            <View
-              style={[
-                headerStyles.overlay,
-                {
-                  backgroundColor: theme.colors.background,
-                },
-              ]}
-            />
-          </View>
-        )}
+        <View
+          style={[
+            StyleSheet.absoluteFill,
+            {backgroundColor: theme.colors.background},
+          ]}
+        />
         <View style={headerStyles.header}>
           <View style={headerStyles.leftPlaceholder}>
             {/* You can add a logo or other icon here if needed */}

--- a/app/(tabs)/(c.collection)/index.tsx
+++ b/app/(tabs)/(c.collection)/index.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {View, ScrollView, Platform, Text, Pressable} from 'react-native';
+import {View, ScrollView, Text, Pressable} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
@@ -8,7 +8,6 @@ import {Feather} from '@expo/vector-icons';
 import {useFavoriteReciters} from '@/hooks/useFavoriteReciters';
 import {useLoved} from '@/hooks/useLoved';
 import {Theme} from '@/utils/themeUtils';
-import {BlurView} from '@react-native-community/blur';
 import Color from 'color';
 
 import {CollectionHeader} from '@/components/collection/CollectionHeader';
@@ -144,39 +143,12 @@ export default function CollectionScreen() {
   return (
     <View style={styles.container}>
       <View style={[styles.header, {paddingTop: 0}]}>
-        {Platform.OS === 'ios' ? (
-          <BlurView
-            blurAmount={10}
-            blurType={theme.isDarkMode ? 'dark' : 'light'}
-            style={[styles.blurContainer]}>
-            <View
-              style={[
-                styles.overlay,
-                {
-                  backgroundColor: theme.colors.background,
-                },
-              ]}
-            />
-          </BlurView>
-        ) : (
-          <View
-            style={[
-              styles.blurContainer,
-              {
-                backgroundColor: theme.colors.background,
-                opacity: 0.95,
-              },
-            ]}>
-            <View
-              style={[
-                styles.overlay,
-                {
-                  backgroundColor: theme.colors.background,
-                },
-              ]}
-            />
-          </View>
-        )}
+        <View
+          style={[
+            styles.blurContainer,
+            {backgroundColor: theme.colors.background},
+          ]}
+        />
       </View>
 
       <ScrollView
@@ -277,14 +249,6 @@ const createStyles = (theme: Theme) =>
       right: 0,
       bottom: 0,
     },
-    overlay: {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      opacity: 0.85,
-    },
     content: {
       flex: 1,
     },
@@ -309,7 +273,7 @@ const createStyles = (theme: Theme) =>
     categoryRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(12),
+      paddingVertical: moderateScale(8),
     },
     categoryIcon: {
       width: moderateScale(46),

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import {View, Text, Pressable, ViewStyle, Platform} from 'react-native';
+import {View, Text, Pressable, ViewStyle, StyleSheet} from 'react-native';
 import {Feather} from '@expo/vector-icons';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
-import {BlurView} from '@react-native-community/blur';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 interface HeaderProps {
@@ -30,40 +29,14 @@ export const Header: React.FC<HeaderProps> = ({
 
   return (
     <View style={[styles.header, {paddingTop: insets.top}, containerStyle]}>
-      {showBlur &&
-        (Platform.OS === 'ios' ? (
-          <BlurView
-            blurAmount={10}
-            blurType={theme.isDarkMode ? 'dark' : 'light'}
-            style={styles.blurContainer}>
-            <View
-              style={[
-                styles.overlay,
-                {
-                  backgroundColor: theme.colors.background,
-                },
-              ]}
-            />
-          </BlurView>
-        ) : (
-          <View
-            style={[
-              styles.blurContainer,
-              {
-                backgroundColor: theme.colors.background,
-                opacity: 0.9,
-              },
-            ]}>
-            <View
-              style={[
-                styles.overlay,
-                {
-                  backgroundColor: theme.colors.background,
-                },
-              ]}
-            />
-          </View>
-        ))}
+      {showBlur && (
+        <View
+          style={[
+            StyleSheet.absoluteFill,
+            {backgroundColor: theme.colors.background},
+          ]}
+        />
+      )}
       <View style={styles.headerContent}>
         <Pressable
           style={[styles.backButton, backButtonStyle]}
@@ -88,24 +61,6 @@ const createStyles = (theme: Theme) =>
       left: 0,
       right: 0,
       zIndex: 100,
-    },
-    blurContainer: {
-      overflow: 'hidden',
-      borderWidth: 0.1,
-      borderColor: 'rgba(255, 255, 255, 0.1)',
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-    },
-    overlay: {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      opacity: 0.85,
     },
     headerContent: {
       height: moderateScale(56),

--- a/components/browse/BrowseReciterCard.tsx
+++ b/components/browse/BrowseReciterCard.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo} from 'react';
-import {View, Text, TouchableOpacity, StyleSheet} from 'react-native';
+import {View, Text, TouchableOpacity, StyleSheet, Platform} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {Reciter} from '@/data/reciterData';
 import {Theme} from '@/utils/themeUtils';
@@ -138,26 +138,28 @@ const BrowseReciterCard = React.memo(
         onPressIn={handlePressIn}
         onPressOut={handlePressOut}
         style={[styles.container, animatedStyle]}>
-        {/* Background blurred image — uses expo-image native blur instead of BlurView */}
-        <View style={styles.backgroundImageContainer}>
-          <ReciterImage
-            imageUrl={reciter.image_url || undefined}
-            reciterName={reciter.name}
-            style={styles.backgroundImage}
-            profileIconSize={moderateScale(40)}
-            blurRadius={20}
-          />
-          <View
-            style={[
-              StyleSheet.absoluteFill,
-              {
-                backgroundColor: theme.isDarkMode
-                  ? 'rgba(0,0,0,0.3)'
-                  : 'rgba(255,255,255,0.3)',
-              },
-            ]}
-          />
-        </View>
+        {/* Background blurred image — iOS only (doesn't look good on Android) */}
+        {Platform.OS === 'ios' && (
+          <View style={styles.backgroundImageContainer}>
+            <ReciterImage
+              imageUrl={reciter.image_url || undefined}
+              reciterName={reciter.name}
+              style={styles.backgroundImage}
+              profileIconSize={moderateScale(40)}
+              blurRadius={20}
+            />
+            <View
+              style={[
+                StyleSheet.absoluteFill,
+                {
+                  backgroundColor: theme.isDarkMode
+                    ? 'rgba(0,0,0,0.3)'
+                    : 'rgba(255,255,255,0.3)',
+                },
+              ]}
+            />
+          </View>
+        )}
 
         {/* Foreground clear image */}
         <View style={styles.foregroundImageContainer}>

--- a/components/sheets/OrganizeRecitationSheet.tsx
+++ b/components/sheets/OrganizeRecitationSheet.tsx
@@ -889,16 +889,6 @@ export const OrganizeRecitationSheet = (
                       prev === opt.id ? null : (opt.id as RecordingType),
                     )
                   }>
-                  <Feather
-                    name={opt.icon}
-                    size={moderateScale(12)}
-                    color={
-                      recordingType === opt.id
-                        ? theme.colors.text
-                        : theme.colors.textSecondary
-                    }
-                    style={{marginRight: moderateScale(6)}}
-                  />
                   <Text
                     style={[
                       styles.chipText,


### PR DESCRIPTION
## Summary
- Remove blurred background image on Android in `BrowseReciterCard` (kept on iOS)
- Replace `BlurView` with simple opaque background in home, settings, and collection screen headers
- Reduce vertical spacing in collection screen category list (`paddingVertical` 12→8)
- Remove icons from recording type chips (Studio/Salah) in `OrganizeRecitationSheet`

## Test plan
- [ ] **Android:** BrowseReciterCard shows no blurred background, just foreground image + content overlay
- [ ] **iOS:** BrowseReciterCard still shows the blurred background image
- [ ] **All platforms:** Home, settings, and collection headers use opaque background (no blur)
- [ ] **Collection screen:** Category rows are slightly tighter vertically
- [ ] **Organize Recitation Sheet:** Studio and Salah chips show only text labels, no icons
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)