### PR TITLE
Replace QuranView basmala with mushaf-style rendering + tajweed

### DIFF
--- a/components/player/v2/PlayerContent/QuranView/BasmalaHeader.tsx
+++ b/components/player/v2/PlayerContent/QuranView/BasmalaHeader.tsx
@@ -1,0 +1,191 @@
+import React, {useMemo, useState, useCallback} from 'react';
+import {View, Text, StyleSheet, type LayoutChangeEvent} from 'react-native';
+import {moderateScale, verticalScale} from 'react-native-size-matters';
+import {
+  Canvas,
+  Paragraph,
+  Skia,
+  TextHeightBehavior,
+  TextDirection,
+  type SkTypefaceFontProvider,
+  type SkTextStyle,
+} from '@shopify/react-native-skia';
+import {BASMALLAH_TEXT} from '@/services/mushaf/DigitalKhattDataService';
+import {getBasmalaTajweedMap} from '@/services/mushaf/DigitalKhattVerseTajweedService';
+import {tajweedColors} from '@/constants/tajweedColors';
+import type {IndexedTajweedData} from '@/utils/tajweedLoader';
+
+const paragraphStyle = {
+  textHeightBehavior: TextHeightBehavior.DisableAll,
+  textDirection: TextDirection.RTL,
+};
+
+interface BasmalaHeaderProps {
+  textColor: string;
+  showTajweed: boolean;
+  fontMgr: SkTypefaceFontProvider | null;
+  dkFontFamily: string;
+  arabicFontSize: number;
+  indexedTajweedData: IndexedTajweedData | null;
+}
+
+const BasmalaHeader: React.FC<BasmalaHeaderProps> = ({
+  textColor,
+  showTajweed,
+  fontMgr,
+  dkFontFamily,
+  arabicFontSize,
+  indexedTajweedData,
+}) => {
+  const [containerWidth, setContainerWidth] = useState(0);
+  const handleLayout = useCallback((e: LayoutChangeEvent) => {
+    const w = e.nativeEvent.layout.width;
+    setContainerWidth(prev => (Math.abs(prev - w) > 1 ? w : prev));
+  }, []);
+
+  const charToRule = useMemo(() => {
+    if (!showTajweed || !indexedTajweedData) return null;
+    return getBasmalaTajweedMap(indexedTajweedData);
+  }, [showTajweed, indexedTajweedData]);
+
+  const fontSize = moderateScale(arabicFontSize);
+
+  // Skia paragraph for DK path
+  const paragraph = useMemo(() => {
+    if (!fontMgr || containerWidth <= 0) return null;
+
+    const color = Skia.Color(textColor);
+    const baseStyle: SkTextStyle = {
+      color,
+      fontFamilies: [dkFontFamily],
+      fontSize,
+      fontFeatures: [{name: 'basm', value: 1}],
+    };
+
+    const builder = Skia.ParagraphBuilder.Make(paragraphStyle, fontMgr);
+    builder.pushStyle(baseStyle);
+
+    for (let i = 0; i < BASMALLAH_TEXT.length; i++) {
+      const char = BASMALLAH_TEXT.charAt(i);
+      const rule = charToRule?.get(i);
+
+      if (rule && tajweedColors[rule]) {
+        const charStyle: SkTextStyle = {
+          ...baseStyle,
+          color: Skia.Color(tajweedColors[rule]),
+        };
+        builder.pushStyle(charStyle);
+        builder.addText(char);
+        builder.pop();
+      } else {
+        builder.addText(char);
+      }
+    }
+
+    builder.pop();
+    const p = builder.build();
+    // Layout wide then center manually (same technique as SkiaLine.tsx)
+    const maxWidth = containerWidth * 2;
+    p.layout(maxWidth);
+    return p;
+  }, [fontMgr, containerWidth, textColor, dkFontFamily, fontSize, charToRule]);
+
+  // Text-based tajweed fallback nodes
+  const fallbackNodes = useMemo(() => {
+    if (!indexedTajweedData) return null;
+    const tajweedWords = indexedTajweedData['1:1'];
+    if (!tajweedWords) return null;
+
+    const basmalaWords = BASMALLAH_TEXT.split(' ');
+    const nodes: React.ReactNode[] = [];
+
+    for (let i = 0; i < basmalaWords.length; i++) {
+      const wordPosition = i + 1;
+      const tajweedWord = tajweedWords.find(w => {
+        const pos = parseInt(w.location.split(':')[2], 10);
+        return pos === wordPosition;
+      });
+
+      if (tajweedWord) {
+        tajweedWord.segments.forEach((segment, segIndex) => {
+          const color =
+            showTajweed && segment.rule
+              ? tajweedColors[segment.rule] || textColor
+              : textColor;
+          nodes.push(
+            <Text key={`basm-${i}-${segIndex}`} style={{color}}>
+              {segment.text}
+            </Text>,
+          );
+        });
+      } else {
+        nodes.push(
+          <Text key={`basm-${i}`} style={{color: textColor}}>
+            {basmalaWords[i]}
+          </Text>,
+        );
+      }
+
+      if (i < basmalaWords.length - 1) {
+        nodes.push(<Text key={`basm-sp-${i}`}> </Text>);
+      }
+    }
+
+    return nodes;
+  }, [indexedTajweedData, showTajweed, textColor]);
+
+  // Skia rendering path
+  if (fontMgr) {
+    const height = paragraph ? paragraph.getHeight() : 0;
+    const maxWidth = containerWidth * 2;
+    const lineWidth = paragraph ? paragraph.getLongestLine() : 0;
+    const xPos = -(
+      maxWidth -
+      containerWidth +
+      (containerWidth - lineWidth) / 2
+    );
+
+    return (
+      <View style={styles.container} onLayout={handleLayout}>
+        {paragraph && containerWidth > 0 && (
+          <Canvas style={{width: containerWidth, height, direction: 'rtl'}}>
+            <Paragraph paragraph={paragraph} x={xPos} y={0} width={maxWidth} />
+          </Canvas>
+        )}
+      </View>
+    );
+  }
+
+  // Text-based fallback
+  return (
+    <View style={styles.container}>
+      {fallbackNodes ? (
+        <Text style={[styles.fallbackText, {fontSize, fontFamily: 'Uthmani'}]}>
+          {fallbackNodes}
+        </Text>
+      ) : (
+        <Text
+          style={[
+            styles.fallbackText,
+            {color: textColor, fontSize, fontFamily: 'Uthmani'},
+          ]}>
+          {BASMALLAH_TEXT}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    paddingVertical: verticalScale(20),
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  fallbackText: {
+    textAlign: 'center',
+  },
+});
+
+export default React.memo(BasmalaHeader);

--- a/components/player/v2/PlayerContent/QuranView/index.tsx
+++ b/components/player/v2/PlayerContent/QuranView/index.tsx
@@ -1,9 +1,10 @@
 import React, {useCallback, useMemo, useRef, useEffect} from 'react';
-import {View, Text, StyleSheet} from 'react-native';
+import {View, StyleSheet} from 'react-native';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Surah, QuranData, Verse} from '@/types/quran';
 import {VerseItem} from './VerseItem';
+import BasmalaHeader from './BasmalaHeader';
 import {FlashList, type FlashListRef} from '@shopify/flash-list';
 import {useBottomSheetScrollableCreator} from '@gorhom/bottom-sheet';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
@@ -135,11 +136,24 @@ export const QuranView: React.FC<QuranViewProps> = ({
   const renderHeader = useCallback(() => {
     if (!surah?.bismillah_pre) return null;
     return (
-      <View style={styles.bismillahContainer}>
-        <Text style={[styles.bismillah, {color: theme.colors.text}]}>﷽</Text>
-      </View>
+      <BasmalaHeader
+        textColor={theme.colors.text}
+        showTajweed={showTajweed}
+        fontMgr={fontMgr}
+        dkFontFamily={dkFontFamily}
+        arabicFontSize={arabicFontSize}
+        indexedTajweedData={indexedTajweedData}
+      />
     );
-  }, [surah?.bismillah_pre, theme.colors.text]);
+  }, [
+    surah?.bismillah_pre,
+    theme.colors.text,
+    showTajweed,
+    fontMgr,
+    dkFontFamily,
+    arabicFontSize,
+    indexedTajweedData,
+  ]);
 
   // Render verse items — annotations handled inside VerseItem via per-key selectors
   const renderItem = useCallback(
@@ -213,16 +227,5 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     borderRadius: moderateScale(15),
     overflow: 'hidden',
-  },
-  bismillahContainer: {
-    width: '100%',
-    paddingVertical: verticalScale(20),
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  bismillah: {
-    fontSize: moderateScale(30),
-    fontFamily: 'Uthmani',
-    textAlign: 'center',
   },
 });

--- a/services/mushaf/DigitalKhattDataService.ts
+++ b/services/mushaf/DigitalKhattDataService.ts
@@ -4,7 +4,7 @@ const TOTAL_PAGES = 604;
 
 // Basmallah text is always the same 4 words — hardcoded to avoid DB lookup
 // (layout DB has NULL word IDs for basmallah lines)
-const BASMALLAH_TEXT = 'بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ';
+export const BASMALLAH_TEXT = 'بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ';
 
 export interface DKLine {
   page_number: number;

--- a/services/mushaf/DigitalKhattVerseTajweedService.ts
+++ b/services/mushaf/DigitalKhattVerseTajweedService.ts
@@ -1,4 +1,7 @@
-import {digitalKhattDataService} from './DigitalKhattDataService';
+import {
+  digitalKhattDataService,
+  BASMALLAH_TEXT,
+} from './DigitalKhattDataService';
 import {alignWordTajweed, detectWordTafkhim} from './TajweedAlignmentService';
 import type {IndexedTajweedData} from '@/utils/tajweedLoader';
 
@@ -48,6 +51,49 @@ export function getVerseTajweedMap(
     charOffset += dkWord.text.length;
     // Add 1 for the space between words (except after the last word)
     if (i < dkWords.length - 1) charOffset += 1;
+  }
+
+  return charToRule.size > 0 ? charToRule : null;
+}
+
+/**
+ * Maps tajweed rules onto the 4-word BASMALLAH_TEXT string.
+ *
+ * The basmala IS verse 1:1, so we look up tajweed data for '1:1' and
+ * align the first 4 words (positions 1-4) onto the hardcoded text,
+ * skipping position 5 (the verse-end marker ١).
+ */
+export function getBasmalaTajweedMap(
+  indexedTajweedData: IndexedTajweedData,
+): Map<number, string> | null {
+  const tajweedWords = indexedTajweedData['1:1'];
+  if (!tajweedWords) return null;
+
+  const basmalaWords = BASMALLAH_TEXT.split(' ');
+  const charToRule = new Map<number, string>();
+
+  let charOffset = 0;
+  for (let i = 0; i < basmalaWords.length; i++) {
+    const wordText = basmalaWords[i];
+    const wordPosition = i + 1; // 1-based positions 1-4
+
+    const tajweedWord = tajweedWords.find(w => {
+      const pos = parseInt(w.location.split(':')[2], 10);
+      return pos === wordPosition;
+    });
+
+    const wordRules = tajweedWord
+      ? alignWordTajweed(wordText, tajweedWord.segments)
+      : detectWordTafkhim(wordText);
+
+    if (wordRules) {
+      for (const [charIdx, rule] of wordRules) {
+        charToRule.set(charOffset + charIdx, rule);
+      }
+    }
+
+    charOffset += wordText.length;
+    if (i < basmalaWords.length - 1) charOffset += 1;
   }
 
   return charToRule.size > 0 ? charToRule : null;


### PR DESCRIPTION
## Summary
- Replace the single `﷽` Unicode ligature in QuranView's basmala header with full `بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ` text using Digital Khatt fonts and the `basm` OpenType feature
- Add per-character tajweed coloring to the basmala (ham_wasl, laam_shamsiyah, madda_normal, madda_permissible, tafkhim)
- New `BasmalaHeader` component with dual rendering: Skia/DK path (centered via `getLongestLine()`) and Text-based fallback with QPC tajweed nodes
- Export `BASMALLAH_TEXT` constant and add `getBasmalaTajweedMap()` service function

## Test plan
- [ ] Open QuranView for any surah with basmala (e.g., Al-Baqarah) — should render with DK font styling
- [ ] Toggle between 1405 (V1) and 1421 (V2) mushaf settings — basmala font should switch
- [ ] Enable tajweed — basmala should show colored characters
- [ ] Disable tajweed — basmala should render in plain text color
- [ ] Check multiple surahs (2, 3, 67, 112) for consistency
- [ ] Verify Al-Fatiha (surah 1) and At-Tawbah (surah 9) have no basmala header

🤖 Generated with [Claude Code](https://claude.com/claude-code)