### PR TITLE
Bake QuranView header: persistent zero-remount header and basmala

### DIFF
--- a/components/player/v2/PlayerContent/QuranView/BasmalaHeader.tsx
+++ b/components/player/v2/PlayerContent/QuranView/BasmalaHeader.tsx
@@ -1,5 +1,5 @@
-import React, {useMemo, useState, useCallback} from 'react';
-import {View, Text, StyleSheet, type LayoutChangeEvent} from 'react-native';
+import React, {useMemo} from 'react';
+import {View, Text, StyleSheet} from 'react-native';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {
   Canvas,
@@ -20,7 +20,75 @@ const paragraphStyle = {
   textDirection: TextDirection.RTL,
 };
 
+// Module-scope cache for basmala paragraph + layout metrics
+interface BasmalaCacheEntry {
+  key: string;
+  paragraph: ReturnType<ReturnType<typeof Skia.ParagraphBuilder.Make>['build']>;
+  height: number;
+  xPos: number;
+  maxWidth: number;
+}
+let basmalaCache: BasmalaCacheEntry | null = null;
+
+function getOrBuildBasmala(
+  fontMgr: SkTypefaceFontProvider,
+  width: number,
+  textColor: string,
+  dkFontFamily: string,
+  fontSize: number,
+  charToRule: Map<number, string> | null,
+  showTajweed: boolean,
+): BasmalaCacheEntry {
+  const cacheKey = `${width}:${textColor}:${dkFontFamily}:${fontSize}:${showTajweed}`;
+  if (basmalaCache?.key === cacheKey) return basmalaCache;
+
+  const color = Skia.Color(textColor);
+  const baseStyle: SkTextStyle = {
+    color,
+    fontFamilies: [dkFontFamily],
+    fontSize,
+    fontFeatures: [{name: 'basm', value: 1}],
+  };
+
+  const builder = Skia.ParagraphBuilder.Make(paragraphStyle, fontMgr);
+  builder.pushStyle(baseStyle);
+
+  for (let i = 0; i < BASMALLAH_TEXT.length; i++) {
+    const char = BASMALLAH_TEXT.charAt(i);
+    const rule = charToRule?.get(i);
+
+    if (rule && tajweedColors[rule]) {
+      const charStyle: SkTextStyle = {
+        ...baseStyle,
+        color: Skia.Color(tajweedColors[rule]),
+      };
+      builder.pushStyle(charStyle);
+      builder.addText(char);
+      builder.pop();
+    } else {
+      builder.addText(char);
+    }
+  }
+
+  builder.pop();
+  const p = builder.build();
+  const maxWidth = width * 2;
+  p.layout(maxWidth);
+  const lineWidth = p.getLongestLine();
+
+  basmalaCache = {
+    key: cacheKey,
+    paragraph: p,
+    height: p.getHeight(),
+    xPos: -(maxWidth - width + (width - lineWidth) / 2),
+    maxWidth,
+  };
+  return basmalaCache;
+}
+
 interface BasmalaHeaderProps {
+  visible: boolean;
+  width: number;
   textColor: string;
   showTajweed: boolean;
   fontMgr: SkTypefaceFontProvider | null;
@@ -30,6 +98,8 @@ interface BasmalaHeaderProps {
 }
 
 const BasmalaHeader: React.FC<BasmalaHeaderProps> = ({
+  visible,
+  width,
   textColor,
   showTajweed,
   fontMgr,
@@ -37,12 +107,6 @@ const BasmalaHeader: React.FC<BasmalaHeaderProps> = ({
   arabicFontSize,
   indexedTajweedData,
 }) => {
-  const [containerWidth, setContainerWidth] = useState(0);
-  const handleLayout = useCallback((e: LayoutChangeEvent) => {
-    const w = e.nativeEvent.layout.width;
-    setContainerWidth(prev => (Math.abs(prev - w) > 1 ? w : prev));
-  }, []);
-
   const charToRule = useMemo(() => {
     if (!showTajweed || !indexedTajweedData) return null;
     return getBasmalaTajweedMap(indexedTajweedData);
@@ -50,47 +114,50 @@ const BasmalaHeader: React.FC<BasmalaHeaderProps> = ({
 
   const fontSize = moderateScale(arabicFontSize);
 
-  // Skia paragraph for DK path
-  const paragraph = useMemo(() => {
-    if (!fontMgr || containerWidth <= 0) return null;
+  const containerStyle = visible
+    ? styles.container
+    : [styles.container, styles.hidden];
 
-    const color = Skia.Color(textColor);
-    const baseStyle: SkTextStyle = {
-      color,
-      fontFamilies: [dkFontFamily],
+  // Skia rendering path — width is known synchronously, cache returns instantly on surah change
+  if (fontMgr && width > 0) {
+    const {paragraph, height, xPos, maxWidth} = getOrBuildBasmala(
+      fontMgr,
+      width,
+      textColor,
+      dkFontFamily,
       fontSize,
-      fontFeatures: [{name: 'basm', value: 1}],
-    };
+      charToRule,
+      showTajweed,
+    );
+    return (
+      <View style={containerStyle}>
+        <Canvas style={{width, height, direction: 'rtl'}}>
+          <Paragraph paragraph={paragraph} x={xPos} y={0} width={maxWidth} />
+        </Canvas>
+      </View>
+    );
+  }
 
-    const builder = Skia.ParagraphBuilder.Make(paragraphStyle, fontMgr);
-    builder.pushStyle(baseStyle);
+  // Text-based fallback
+  return (
+    <View style={containerStyle}>
+      <BasmalaFallbackText
+        indexedTajweedData={indexedTajweedData}
+        showTajweed={showTajweed}
+        textColor={textColor}
+        fontSize={fontSize}
+      />
+    </View>
+  );
+};
 
-    for (let i = 0; i < BASMALLAH_TEXT.length; i++) {
-      const char = BASMALLAH_TEXT.charAt(i);
-      const rule = charToRule?.get(i);
-
-      if (rule && tajweedColors[rule]) {
-        const charStyle: SkTextStyle = {
-          ...baseStyle,
-          color: Skia.Color(tajweedColors[rule]),
-        };
-        builder.pushStyle(charStyle);
-        builder.addText(char);
-        builder.pop();
-      } else {
-        builder.addText(char);
-      }
-    }
-
-    builder.pop();
-    const p = builder.build();
-    // Layout wide then center manually (same technique as SkiaLine.tsx)
-    const maxWidth = containerWidth * 2;
-    p.layout(maxWidth);
-    return p;
-  }, [fontMgr, containerWidth, textColor, dkFontFamily, fontSize, charToRule]);
-
-  // Text-based tajweed fallback nodes
+// Extracted fallback to keep the main component body lean
+const BasmalaFallbackText: React.FC<{
+  indexedTajweedData: IndexedTajweedData | null;
+  showTajweed: boolean;
+  textColor: string;
+  fontSize: number;
+}> = ({indexedTajweedData, showTajweed, textColor, fontSize}) => {
   const fallbackNodes = useMemo(() => {
     if (!indexedTajweedData) return null;
     const tajweedWords = indexedTajweedData['1:1'];
@@ -134,45 +201,22 @@ const BasmalaHeader: React.FC<BasmalaHeaderProps> = ({
     return nodes;
   }, [indexedTajweedData, showTajweed, textColor]);
 
-  // Skia rendering path
-  if (fontMgr) {
-    const height = paragraph ? paragraph.getHeight() : 0;
-    const maxWidth = containerWidth * 2;
-    const lineWidth = paragraph ? paragraph.getLongestLine() : 0;
-    const xPos = -(
-      maxWidth -
-      containerWidth +
-      (containerWidth - lineWidth) / 2
-    );
-
+  if (fallbackNodes) {
     return (
-      <View style={styles.container} onLayout={handleLayout}>
-        {paragraph && containerWidth > 0 && (
-          <Canvas style={{width: containerWidth, height, direction: 'rtl'}}>
-            <Paragraph paragraph={paragraph} x={xPos} y={0} width={maxWidth} />
-          </Canvas>
-        )}
-      </View>
+      <Text style={[styles.fallbackText, {fontSize, fontFamily: 'Uthmani'}]}>
+        {fallbackNodes}
+      </Text>
     );
   }
 
-  // Text-based fallback
   return (
-    <View style={styles.container}>
-      {fallbackNodes ? (
-        <Text style={[styles.fallbackText, {fontSize, fontFamily: 'Uthmani'}]}>
-          {fallbackNodes}
-        </Text>
-      ) : (
-        <Text
-          style={[
-            styles.fallbackText,
-            {color: textColor, fontSize, fontFamily: 'Uthmani'},
-          ]}>
-          {BASMALLAH_TEXT}
-        </Text>
-      )}
-    </View>
+    <Text
+      style={[
+        styles.fallbackText,
+        {color: textColor, fontSize, fontFamily: 'Uthmani'},
+      ]}>
+      {BASMALLAH_TEXT}
+    </Text>
   );
 };
 
@@ -182,6 +226,10 @@ const styles = StyleSheet.create({
     paddingVertical: verticalScale(0),
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  hidden: {
+    height: 0,
+    overflow: 'hidden' as const,
   },
   fallbackText: {
     textAlign: 'center',

--- a/components/player/v2/PlayerContent/QuranView/SurahDivider.tsx
+++ b/components/player/v2/PlayerContent/QuranView/SurahDivider.tsx
@@ -1,12 +1,15 @@
-import React, {useMemo, useState, useCallback} from 'react';
-import {View, Text, StyleSheet, type LayoutChangeEvent} from 'react-native';
+import React from 'react';
+import {View, Text, StyleSheet} from 'react-native';
 import {verticalScale} from 'react-native-size-matters';
-import {Canvas, Skia, useFont, useFonts} from '@shopify/react-native-skia';
+import {Canvas, Skia, useFonts} from '@shopify/react-native-skia';
 import {SURAH_DIVIDER_CHAR} from '@/constants/surahNameGlyphs';
 import SkiaSurahHeader from '@/components/mushaf/skia/SkiaSurahHeader';
+import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import type {SkFont} from '@shopify/react-native-skia';
 
 const REFERENCE_SIZE = 100;
 const NAME_SCALE = 0.5;
+const DIVIDER_PADDING_V = verticalScale(4);
 
 const fallbackSurahNames: Record<number, string> = {};
 (require('@/data/surahData.json') as Array<{id: number; name: string}>).forEach(
@@ -15,7 +18,48 @@ const fallbackSurahNames: Record<number, string> = {};
   },
 );
 
+// Module-scope font cache — recomputed only when width changes (device rotation)
+interface DividerFontCache {
+  width: number;
+  font: SkFont;
+  nameFontSize: number;
+  divHeight: number;
+}
+let dividerFontCache: DividerFontCache | null = null;
+
+function getOrBuildDividerFont(width: number): DividerFontCache | null {
+  if (width <= 0) return null;
+  if (dividerFontCache?.width === width) return dividerFontCache;
+
+  const qcTypeface = mushafPreloadService.quranCommonTypeface;
+  if (!qcTypeface) return null;
+
+  const refFont = Skia.Font(qcTypeface, REFERENCE_SIZE);
+  const ids = refFont.getGlyphIDs(SURAH_DIVIDER_CHAR);
+  const widths = refFont.getGlyphWidths(ids);
+  const measuredW = widths[0] || 1;
+  const scaledSize = (width / measuredW) * REFERENCE_SIZE;
+
+  const font = Skia.Font(qcTypeface, scaledSize);
+  const metrics = font.getMetrics();
+  const divHeight = Math.abs(metrics.ascent) + metrics.descent;
+
+  dividerFontCache = {
+    width,
+    font,
+    nameFontSize: scaledSize * NAME_SCALE,
+    divHeight,
+  };
+  return dividerFontCache;
+}
+
+export function computeDividerTotalHeight(width: number): number {
+  const cache = getOrBuildDividerFont(width);
+  return cache ? cache.divHeight + 2 * DIVIDER_PADDING_V : 0;
+}
+
 interface SurahDividerProps {
+  width: number;
   surahNumber: number;
   textColor: string;
   nameColor: string;
@@ -23,57 +67,29 @@ interface SurahDividerProps {
 }
 
 const SurahDivider: React.FC<SurahDividerProps> = ({
+  width,
   surahNumber,
   textColor,
   nameColor,
   variant = 'withIcon',
 }) => {
-  const [containerWidth, setContainerWidth] = useState(0);
-  const handleLayout = useCallback((e: LayoutChangeEvent) => {
-    const w = e.nativeEvent.layout.width;
-    setContainerWidth(prev => (Math.abs(prev - w) > 1 ? w : prev));
-  }, []);
-
-  const refDividerFont = useFont(
-    require('@/data/mushaf/quran-common.ttf'),
-    REFERENCE_SIZE,
-  );
-
-  const nameFontMgr = useFonts({
+  // Keep useFonts hook as fallback (can't conditionally call hooks).
+  // Prefer preloaded fontMgr from MushafPreloadService — ready synchronously.
+  const hookFontMgr = useFonts({
     SurahNameV4: [require('@/data/mushaf/surah-name-v4.ttf')],
     SurahNameQCF: [require('@/data/mushaf/surah-name-qcf.ttf')],
   });
+  const nameFontMgr = mushafPreloadService.fontMgr || hookFontMgr;
 
-  // Compute scaled divider font + name size from container width
-  const scaledDividerFont = useMemo(() => {
-    if (!refDividerFont || containerWidth <= 0) return null;
-
-    const dividerTypeface = refDividerFont.getTypeface();
-    if (!dividerTypeface) return null;
-
-    const ids = refDividerFont.getGlyphIDs(SURAH_DIVIDER_CHAR);
-    const widths = refDividerFont.getGlyphWidths(ids);
-    const measuredW = widths[0] || 1;
-    const scaledSize = (containerWidth / measuredW) * REFERENCE_SIZE;
-
-    const font = Skia.Font(dividerTypeface, scaledSize);
-    const metrics = font.getMetrics();
-    const divHeight = Math.abs(metrics.ascent) + metrics.descent;
-
-    return {
-      font,
-      nameFontSize: scaledSize * NAME_SCALE,
-      divHeight,
-    };
-  }, [refDividerFont, containerWidth]);
+  const scaledDividerFont = getOrBuildDividerFont(width);
 
   // Skia rendering path — delegates to shared SkiaSurahHeader
-  if (scaledDividerFont && nameFontMgr && containerWidth > 0) {
+  if (scaledDividerFont && nameFontMgr && width > 0) {
     return (
-      <View style={styles.container} onLayout={handleLayout}>
+      <View style={styles.container}>
         <Canvas
           style={{
-            width: containerWidth,
+            width,
             height: scaledDividerFont.divHeight,
           }}>
           <SkiaSurahHeader
@@ -82,7 +98,7 @@ const SurahDivider: React.FC<SurahDividerProps> = ({
             nameFontSize={scaledDividerFont.nameFontSize}
             surahNumber={surahNumber}
             yPos={0}
-            pageWidth={containerWidth}
+            pageWidth={width}
             dividerColor={textColor}
             nameColor={nameColor}
             lineHeight={scaledDividerFont.divHeight}
@@ -95,7 +111,7 @@ const SurahDivider: React.FC<SurahDividerProps> = ({
 
   // Text-based fallback (fonts not loaded yet)
   return (
-    <View style={styles.container} onLayout={handleLayout}>
+    <View style={styles.container}>
       <Text style={[styles.fallbackText, {color: nameColor}]}>
         {fallbackSurahNames[surahNumber] || `Surah ${surahNumber}`}
       </Text>
@@ -106,7 +122,7 @@ const SurahDivider: React.FC<SurahDividerProps> = ({
 const styles = StyleSheet.create({
   container: {
     width: '100%',
-    paddingVertical: verticalScale(4),
+    paddingVertical: DIVIDER_PADDING_V,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/components/player/v2/PlayerContent/QuranView/index.tsx
+++ b/components/player/v2/PlayerContent/QuranView/index.tsx
@@ -1,11 +1,11 @@
-import React, {useCallback, useMemo, useRef, useEffect, useState} from 'react';
-import {View, StyleSheet, LayoutChangeEvent} from 'react-native';
+import React, {useCallback, useRef, useEffect} from 'react';
+import {View, StyleSheet, useWindowDimensions} from 'react-native';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Surah, QuranData, Verse} from '@/types/quran';
 import {VerseItem} from './VerseItem';
 import BasmalaHeader from './BasmalaHeader';
-import SurahDivider from './SurahDivider';
+import SurahDivider, {computeDividerTotalHeight} from './SurahDivider';
 import {FlashList, type FlashListRef} from '@shopify/flash-list';
 import {useBottomSheetScrollableCreator} from '@gorhom/bottom-sheet';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
@@ -13,6 +13,8 @@ import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import {useTajweedStore} from '@/store/tajweedStore';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
 import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
+import type {SkTypefaceFontProvider} from '@shopify/react-native-skia';
+import type {IndexedTajweedData} from '@/utils/tajweedLoader';
 
 // Import data with type safety - move outside component to load only once
 const quranData = require('@/data/quran.json') as QuranData;
@@ -57,6 +59,67 @@ Object.values(versesBySurah).forEach(arr =>
   arr.sort((a, b) => a.ayah_number - b.ayah_number),
 );
 
+// Pre-build enhanced verse arrays with translations at module scope — zero computation per surah change
+const enhancedVersesBySurah: Record<number, EnhancedVerse[]> = {};
+for (const [surahStr, surahVerses] of Object.entries(versesBySurah)) {
+  enhancedVersesBySurah[Number(surahStr)] = surahVerses.map(verse => {
+    const verseKey = `${verse.surah_number}:${verse.ayah_number}`;
+    return {
+      ...verse,
+      translation: saheehDataCache?.[verseKey]?.t || '',
+      transliteration: transliterationDataCache?.[verseKey]?.t || '',
+    };
+  });
+}
+
+// Module-scope header — stable component identity prevents FlashList unmount/remount
+interface QuranListHeaderProps {
+  surahNumber: number;
+  showBismillah: boolean;
+  width: number;
+  textColor: string;
+  nameColor: string;
+  showTajweed: boolean;
+  fontMgr: SkTypefaceFontProvider | null;
+  dkFontFamily: string;
+  arabicFontSize: number;
+  indexedTajweedData: IndexedTajweedData | null;
+}
+
+const QuranListHeader = React.memo<QuranListHeaderProps>(
+  ({
+    surahNumber,
+    showBismillah,
+    width,
+    textColor,
+    nameColor,
+    showTajweed,
+    fontMgr,
+    dkFontFamily,
+    arabicFontSize,
+    indexedTajweedData,
+  }) => (
+    <>
+      <SurahDivider
+        width={width}
+        surahNumber={surahNumber}
+        textColor={textColor}
+        nameColor={nameColor}
+      />
+      <BasmalaHeader
+        visible={showBismillah}
+        width={width}
+        textColor={nameColor}
+        showTajweed={showTajweed}
+        fontMgr={fontMgr}
+        dkFontFamily={dkFontFamily}
+        arabicFontSize={arabicFontSize}
+        indexedTajweedData={indexedTajweedData}
+      />
+    </>
+  ),
+);
+
 interface QuranViewProps {
   currentSurah: number;
   onVersePress: (verseKey: string) => void;
@@ -81,7 +144,8 @@ export const QuranView: React.FC<QuranViewProps> = ({
   contentPaddingBottom,
 }) => {
   const {theme} = useTheme();
-  const [dividerHeight, setDividerHeight] = useState(0);
+  const {width: screenWidth} = useWindowDimensions();
+  const contentWidth = screenWidth - 2 * moderateScale(20);
   const listRef = useRef<FlashListRef<EnhancedVerse>>(null);
   const renderScrollComponent = useBottomSheetScrollableCreator();
   const surah = surahData.find(s => s.id === currentSurah);
@@ -112,20 +176,8 @@ export const QuranView: React.FC<QuranViewProps> = ({
     loadAnnotationsForSurah(currentSurah);
   }, [currentSurah, loadAnnotationsForSurah]);
 
-  // Memoize verses array — only recomputed when surah changes
-  const verses = useMemo(() => {
-    const surahVerses = versesBySurah[currentSurah];
-    if (!surahVerses) return [];
-
-    return surahVerses.map(verse => {
-      const verseKey = `${verse.surah_number}:${verse.ayah_number}`;
-      return {
-        ...verse,
-        translation: saheehDataCache?.[verseKey]?.t || '',
-        transliteration: transliterationDataCache?.[verseKey]?.t || '',
-      };
-    });
-  }, [currentSurah]);
+  // Direct lookup from module-scope pre-built arrays — zero computation per surah change
+  const verses = enhancedVersesBySurah[currentSurah] ?? [];
 
   // Reset scroll position when currentSurah changes
   useEffect(() => {
@@ -133,47 +185,6 @@ export const QuranView: React.FC<QuranViewProps> = ({
       listRef.current.scrollToOffset({offset: 0, animated: false});
     }
   }, [currentSurah]);
-
-  const handleDividerLayout = useCallback(
-    (e: LayoutChangeEvent) => setDividerHeight(e.nativeEvent.layout.height),
-    [],
-  );
-
-  // Render the surah divider + optional bismillah as list header
-  const renderHeader = useCallback(() => {
-    return (
-      <>
-        <View onLayout={handleDividerLayout}>
-          <SurahDivider
-            surahNumber={currentSurah}
-            textColor={theme.colors.textSecondary}
-            nameColor={theme.colors.text}
-          />
-        </View>
-        {surah?.bismillah_pre && (
-          <BasmalaHeader
-            textColor={theme.colors.text}
-            showTajweed={showTajweed}
-            fontMgr={fontMgr}
-            dkFontFamily={dkFontFamily}
-            arabicFontSize={arabicFontSize}
-            indexedTajweedData={indexedTajweedData}
-          />
-        )}
-      </>
-    );
-  }, [
-    currentSurah,
-    surah?.bismillah_pre,
-    theme.colors.textSecondary,
-    theme.colors.text,
-    showTajweed,
-    fontMgr,
-    dkFontFamily,
-    arabicFontSize,
-    indexedTajweedData,
-    handleDividerLayout,
-  ]);
 
   // Render verse items — annotations handled inside VerseItem via per-key selectors
   const renderItem = useCallback(
@@ -216,7 +227,7 @@ export const QuranView: React.FC<QuranViewProps> = ({
 
   const effectivePaddingTop = Math.max(
     0,
-    (contentPaddingTop || 0) - dividerHeight,
+    (contentPaddingTop || 0) - computeDividerTotalHeight(contentWidth),
   );
 
   const effectivePaddingBottom =
@@ -233,7 +244,20 @@ export const QuranView: React.FC<QuranViewProps> = ({
         data={verses}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        ListHeaderComponent={renderHeader}
+        ListHeaderComponent={
+          <QuranListHeader
+            surahNumber={currentSurah}
+            showBismillah={!!surah?.bismillah_pre}
+            width={contentWidth}
+            textColor={theme.colors.textSecondary}
+            nameColor={theme.colors.text}
+            showTajweed={showTajweed}
+            fontMgr={fontMgr}
+            dkFontFamily={dkFontFamily}
+            arabicFontSize={arabicFontSize}
+            indexedTajweedData={indexedTajweedData}
+          />
+        }
         contentContainerStyle={{
           paddingTop: effectivePaddingTop,
           paddingBottom: effectivePaddingBottom,


### PR DESCRIPTION
## Summary

- **Eliminate header unmount/remount on surah change** by defining a module-scope `QuranListHeader` (`React.memo`) and passing it as a JSX element to `ListHeaderComponent` — FlashList returns it as-is via `React.isValidElement()`, so React reconciles props in-place instead of unmounting
- **Replace BasmalaHeader conditional mount/unmount** with a `visible` prop that toggles `height: 0 + overflow: hidden` — keeps the Skia Canvas surface alive and paragraph cache warm
- **Move SurahDivider width measurement to a module-scope font cache** (`getOrBuildDividerFont`) — eliminates `useState(0)` + `onLayout` self-measurement; export `computeDividerTotalHeight()` for synchronous padding in QuranView

## What this eliminates

| Before | After |
|--------|-------|
| Header unmount/remount on surah change | Props-in-place update (never unmounts) |
| BasmalaHeader conditional mount/unmount | Always mounted, visibility toggle |
| 3× `useState` (widths + dividerHeight) → 6 extra renders | 0 extra renders |
| 3× `onLayout` handlers | 0 layout handlers |
| `renderHeader` useCallback with 12 deps | Eliminated |
| `handleDividerLayout` useCallback | Eliminated |

## Test plan

- [ ] Play a surah, open player — header + basmala appear instantly on first frame
- [ ] Skip between surahs (including to/from Tawbah) — no flicker, no empty flash
- [ ] Tajweed toggle — colors change in-place (no remount)
- [ ] Switch DK v1/v2 renderer — still works
- [ ] Rotate device — header resizes correctly
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx prettier --write` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)