### PR TITLE
Hide FloatingPlayer on Mushaf screen

### DIFF
--- a/components/player/v2/FloatingPlayer/index.tsx
+++ b/components/player/v2/FloatingPlayer/index.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useEffect, useMemo} from 'react';
 import {View, Text, Pressable, StyleSheet, Platform} from 'react-native';
+import {usePathname} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import Animated, {
@@ -109,6 +110,8 @@ export const FloatingPlayer: React.FC = React.memo(function FloatingPlayer() {
   const scale = useSharedValue(1);
   const heartScale = useSharedValue(1);
   const insets = useSafeAreaInsets();
+  const pathname = usePathname();
+  const isMushafActive = pathname === '/mushaf';
   // Create styles using insets
   const styles = useMemo(() => createStyles(insets.bottom), [insets.bottom]);
 
@@ -133,8 +136,8 @@ export const FloatingPlayer: React.FC = React.memo(function FloatingPlayer() {
   }, [trackLoading, playbackState, currentTrack?.id]);
 
   const shouldShow = useMemo(
-    () => !stateRestoring && !!currentTrack,
-    [stateRestoring, currentTrack],
+    () => !stateRestoring && !!currentTrack && !isMushafActive,
+    [stateRestoring, currentTrack, isMushafActive],
   );
 
   const surahNumber = useMemo(() => {


### PR DESCRIPTION
## Summary
- Detect `/mushaf` route via `usePathname()` inside `FloatingPlayer`
- Fold `isMushafActive` into the existing `shouldShow` memo so the player hides during immersive reading
- Component stays mounted (audio keeps playing); only visibility changes

## Test plan
- [ ] Navigate to Mushaf with the floating player visible — it should disappear
- [ ] Navigate back — it should reappear
- [ ] Audio continues playing while the player is hidden
- [ ] Deep link to `/mushaf?surah=2` also hides the player

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI visibility change gated on a single route check; no changes to audio control or data handling.
> 
> **Overview**
> Hides the `FloatingPlayer` UI while the user is on the `/mushaf` screen.
> 
> `FloatingPlayer` now reads the current route via `usePathname()` and folds a new `isMushafActive` check into `shouldShow`, preventing the component from being shown during mushaf reading without changing playback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f02bd78b474bf7ce3cffb49729b92b7c764a0cb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->