### PR TITLE
fix(player): restore pan-down-to-close on overlay areas

### DIFF
--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -1,10 +1,12 @@
-import React, {useState, useCallback, useEffect} from 'react';
+import React, {useState, useCallback, useEffect, useMemo} from 'react';
 import {View, StyleSheet, LayoutChangeEvent} from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withTiming,
 } from 'react-native-reanimated';
+import {Gesture, GestureDetector} from 'react-native-gesture-handler';
+import {useBottomSheetGestureHandlers} from '@gorhom/bottom-sheet';
 import {QueueList} from './QueueList';
 import {QuranView} from './QuranView';
 import {TrackInfo} from './TrackInfo';
@@ -61,6 +63,21 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
   const queue = usePlayerStore(s => s.queue);
   const isImmersive = usePlayerStore(s => s.isImmersive);
   const insets = useSafeAreaInsets();
+
+  // Use the bottom-sheet handle gesture so overlay pans close the sheet
+  // regardless of the FlashList scroll offset
+  const {handlePanGestureHandler} = useBottomSheetGestureHandlers();
+  const sheetDragGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .onStart(handlePanGestureHandler.handleOnStart)
+        .onChange(handlePanGestureHandler.handleOnChange)
+        .onEnd(handlePanGestureHandler.handleOnEnd)
+        .onFinalize(handlePanGestureHandler.handleOnFinalize)
+        .shouldCancelWhenOutside(false)
+        .runOnJS(false),
+    [handlePanGestureHandler],
+  );
 
   // Overlay height measurement
   const [headerHeight, setHeaderHeight] = useState(DEFAULT_HEADER_HEIGHT);
@@ -209,53 +226,59 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
       </View>
 
       {/* Header overlay — absolute positioned at top */}
-      <Animated.View
-        style={[
-          styles.headerOverlay,
-          overlayAnimatedStyle,
-          {
-            backgroundColor: theme.colors.background,
-            paddingTop: insets.top + moderateScale(12),
-          },
-        ]}
-        pointerEvents={isImmersive ? 'none' : 'auto'}
-        onLayout={handleHeaderLayout}>
-        <View style={styles.handleContainer}>
-          <View
-            style={[
-              styles.handle,
-              {
-                backgroundColor: Color(theme.colors.text).alpha(0.2).toString(),
-              },
-            ]}
-          />
-        </View>
-        <Header onOptionsPress={onOptionsPress} />
-      </Animated.View>
+      <GestureDetector gesture={sheetDragGesture}>
+        <Animated.View
+          style={[
+            styles.headerOverlay,
+            overlayAnimatedStyle,
+            {
+              backgroundColor: theme.colors.background,
+              paddingTop: insets.top + moderateScale(12),
+            },
+          ]}
+          pointerEvents={isImmersive ? 'none' : 'auto'}
+          onLayout={handleHeaderLayout}>
+          <View style={styles.handleContainer}>
+            <View
+              style={[
+                styles.handle,
+                {
+                  backgroundColor: Color(theme.colors.text)
+                    .alpha(0.2)
+                    .toString(),
+                },
+              ]}
+            />
+          </View>
+          <Header onOptionsPress={onOptionsPress} />
+        </Animated.View>
+      </GestureDetector>
 
       {/* Controls overlay — absolute positioned at bottom */}
-      <Animated.View
-        style={[
-          styles.controlsOverlay,
-          overlayAnimatedStyle,
-          {
-            backgroundColor: theme.colors.background,
-            paddingBottom: insets.bottom || moderateScale(20),
-          },
-        ]}
-        pointerEvents={isImmersive ? 'none' : 'auto'}
-        onLayout={handleControlsLayout}>
-        <TrackInfo />
-        <PlaybackControls />
-        <ControlButtons
-          onSpeedPress={onSpeedPress}
-          onSleepTimerPress={onSleepTimerPress}
-          onQueuePress={handleQueuePress}
-          showQueue={showQueue}
-          onMushafLayoutPress={onMushafLayoutPress}
-          onAmbientPress={onAmbientPress}
-        />
-      </Animated.View>
+      <GestureDetector gesture={sheetDragGesture}>
+        <Animated.View
+          style={[
+            styles.controlsOverlay,
+            overlayAnimatedStyle,
+            {
+              backgroundColor: theme.colors.background,
+              paddingBottom: insets.bottom || moderateScale(20),
+            },
+          ]}
+          pointerEvents={isImmersive ? 'none' : 'auto'}
+          onLayout={handleControlsLayout}>
+          <TrackInfo />
+          <PlaybackControls />
+          <ControlButtons
+            onSpeedPress={onSpeedPress}
+            onSleepTimerPress={onSleepTimerPress}
+            onQueuePress={handleQueuePress}
+            showQueue={showQueue}
+            onMushafLayoutPress={onMushafLayoutPress}
+            onAmbientPress={onAmbientPress}
+          />
+        </Animated.View>
+      </GestureDetector>
 
       {/* Rounded TV frame between header and controls */}
       <Animated.View


### PR DESCRIPTION
## Summary
- PR #112's auto-scroll updates `contentOffsetY` in `@gorhom/bottom-sheet`, which gates all content pan gestures — even on non-scrollable header/controls overlays
- Wraps header and controls overlays in `GestureDetector`s using the **handle** pan gesture handler, bypassing scroll-offset gating
- QuranView (FlashList) keeps its scroll-then-close behavior unchanged

## Test plan
- [ ] Play audio so auto-scroll positions the FlashList away from the top
- [ ] Pan down on header area → sheet closes immediately
- [ ] Pan down on controls area → sheet closes immediately
- [ ] Pan down on QuranView → list scrolls up first, then sheet closes
- [ ] Tap buttons in header/controls → still work (taps not captured by pan gesture)
- [ ] Enter immersive mode → overlay gestures pass through (pointerEvents="none")

🤖 Generated with [Claude Code](https://claude.com/claude-code)