### PR TITLE
Prevent screen timeout on Mushaf screen 

### DIFF
--- a/components/mushaf/main.tsx
+++ b/components/mushaf/main.tsx
@@ -1,4 +1,5 @@
 import React, {useState, useMemo, useRef, useCallback, useEffect} from 'react';
+import {useKeepAwake} from 'expo-keep-awake';
 import {
   View,
   StyleSheet,
@@ -232,6 +233,7 @@ interface MushafViewerProps {
 export default function MushafViewer({
   pageNumber: initialPage,
 }: MushafViewerProps) {
+  useKeepAwake();
   const [currentPage, setCurrentPage] = useState(initialPage);
   const [isImmersive, setIsImmersive] = useState(false);
   const [isSearchMode, setIsSearchMode] = useState(false);


### PR DESCRIPTION
## Summary
- Adds `useKeepAwake()` from `expo-keep-awake` to the Mushaf viewer component so the screen stays on while reading
- Works on both iOS and Android — no platform-specific code needed
- `expo-keep-awake` was already a project dependency; this just activates it on the Mushaf screen
- Wake lock automatically deactivates when navigating away from the Mushaf

## Test plan
- [ ] Open the Mushaf screen on iOS and verify the screen does not dim or lock after the device timeout period
- [ ] Open the Mushaf screen on Android and verify the same
- [ ] Navigate away from the Mushaf screen and verify normal screen timeout behavior resumes
