### PR TITLE
Fix verse search and bookmarks to navigate to exact verse page

### DIFF
--- a/app/(tabs)/(c.collection)/collection/bookmarks.tsx
+++ b/app/(tabs)/(c.collection)/collection/bookmarks.tsx
@@ -17,6 +17,7 @@ import {ListRenderItem} from 'react-native';
 import {getSurahById} from '@/services/dataService';
 import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
 import {BookmarkItem} from '@/components/collection/BookmarkItem';
 import {CollectionStickyHeader} from '@/components/collection/CollectionStickyHeader';
 import {SheetManager} from 'react-native-actions-sheet';
@@ -129,7 +130,20 @@ const BookmarksScreen = () => {
       ayahNumber={item.bookmark.ayahNumber}
       surahNumber={item.bookmark.surahNumber}
       verseKey={item.bookmark.verseKey}
-      onPress={() => {}}
+      onPress={() => {
+        const verseKey = `${item.bookmark.surahNumber}:${item.bookmark.ayahNumber}`;
+        const page = digitalKhattDataService.getPageForVerse(verseKey);
+        const surahStartPages = digitalKhattDataService.getSurahStartPages();
+        const fallbackPage = surahStartPages[item.bookmark.surahNumber] || 1;
+        router.push({
+          pathname: '/mushaf',
+          params: {
+            surah: String(item.bookmark.surahNumber),
+            ayah: String(item.bookmark.ayahNumber),
+            page: String(page || fallbackPage),
+          },
+        });
+      }}
       onOptionsPress={() => handleOptionsPress(item)}
     />
   );

--- a/app/mushaf.tsx
+++ b/app/mushaf.tsx
@@ -56,12 +56,19 @@ export default function MushafScreen() {
     };
   }, []);
 
-  // Set verse highlight on mount, clear on unmount
+  // Set verse highlight on mount, auto-clear after 3s, clear on unmount
   useEffect(() => {
     if (initialVerseKey) {
       useMushafVerseSelectionStore
         .getState()
         .selectVerse(initialVerseKey, pageNumber);
+      const timer = setTimeout(() => {
+        useMushafVerseSelectionStore.getState().clearSelection();
+      }, 3000);
+      return () => {
+        clearTimeout(timer);
+        useMushafVerseSelectionStore.getState().clearSelection();
+      };
     }
     return () => {
       useMushafVerseSelectionStore.getState().clearSelection();

--- a/components/mushaf/BookmarkChips.tsx
+++ b/components/mushaf/BookmarkChips.tsx
@@ -17,7 +17,7 @@ export async function warmBookmarkCache(): Promise<void> {
 }
 
 interface BookmarkChipsProps {
-  onPress: (surahId: number) => void;
+  onPress: (surahId: number, ayahNumber: number) => void;
 }
 
 export const BookmarkChips: React.FC<BookmarkChipsProps> = React.memo(
@@ -69,7 +69,9 @@ export const BookmarkChips: React.FC<BookmarkChipsProps> = React.memo(
                       .toString(),
                   },
                 ]}
-                onPress={() => onPress(bookmark.surahNumber)}>
+                onPress={() =>
+                  onPress(bookmark.surahNumber, bookmark.ayahNumber)
+                }>
                 <Feather
                   name="bookmark"
                   size={moderateScale(12)}

--- a/components/mushaf/MushafSearchView.tsx
+++ b/components/mushaf/MushafSearchView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import React, {useState, useMemo, useCallback, useEffect, useRef} from 'react';
 import {
   View,
   Text,
@@ -11,21 +11,22 @@ import {
   Animated as RNAnimated,
   BackHandler,
 } from 'react-native';
-import { FlashList, type ListRenderItemInfo } from '@shopify/flash-list';
-import { moderateScale as ms } from 'react-native-size-matters';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useTheme } from '@/hooks/useTheme';
-import { Feather } from '@expo/vector-icons';
+import {FlashList, type ListRenderItemInfo} from '@shopify/flash-list';
+import {moderateScale as ms} from 'react-native-size-matters';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {useTheme} from '@/hooks/useTheme';
+import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { SearchInput } from '@/components/SearchInput';
-import { SurahItem } from '@/components/SurahItem';
-import { SURAHS, Surah } from '@/data/surahData';
-import { getJuzForSurah, getJuzName } from '@/data/juzData';
-import { useSettings } from '@/hooks/useSettings';
-import { BookmarkChips } from './BookmarkChips';
-import { JUZ_START_PAGES } from './constants';
-import { useMushafSettingsStore, RecentRead } from '@/store/mushafSettingsStore';
+import {SearchInput} from '@/components/SearchInput';
+import {SurahItem} from '@/components/SurahItem';
+import {SURAHS, Surah} from '@/data/surahData';
+import {getJuzForSurah, getJuzName} from '@/data/juzData';
+import {useSettings} from '@/hooks/useSettings';
+import {BookmarkChips} from './BookmarkChips';
+import {JUZ_START_PAGES} from './constants';
+import {useMushafSettingsStore, RecentRead} from '@/store/mushafSettingsStore';
+import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
 
 // ============================================================================
 // Types
@@ -34,6 +35,7 @@ import { useMushafSettingsStore, RecentRead } from '@/store/mushafSettingsStore'
 interface MushafSearchViewProps {
   onNavigateToPage: (page: number) => void;
   onNavigateToSurah: (surahId: number) => void;
+  onNavigateToVerse: (verseKey: string, page: number) => void;
   onClose: () => void;
   surahStartPages: Record<number, number>;
   pageToSurah: Record<number, number>;
@@ -42,26 +44,26 @@ interface MushafSearchViewProps {
 type SortOption = 'asc' | 'desc' | 'revelation';
 
 type BrowseItem =
-  | { type: 'juz-header'; juzName: string; key: string }
-  | { type: 'surah-row'; surah: Surah; key: string };
+  | {type: 'juz-header'; juzName: string; key: string}
+  | {type: 'surah-row'; surah: Surah; key: string};
 
 type SearchResultItem =
-  | { type: 'surah'; surah: Surah; primary: string; secondary: string }
+  | {type: 'surah'; surah: Surah; primary: string; secondary: string}
   | {
-    type: 'verse';
-    surahId: number;
-    verse: number;
-    primary: string;
-    secondary: string;
-  }
-  | { type: 'page'; page: number; primary: string; secondary: string }
+      type: 'verse';
+      surahId: number;
+      verse: number;
+      primary: string;
+      secondary: string;
+    }
+  | {type: 'page'; page: number; primary: string; secondary: string}
   | {
-    type: 'juz';
-    juz: number;
-    page: number;
-    primary: string;
-    secondary: string;
-  };
+      type: 'juz';
+      juz: number;
+      page: number;
+      primary: string;
+      secondary: string;
+    };
 
 interface SearchHistoryItem {
   type: string;
@@ -134,9 +136,9 @@ function parseSearchQuery(
   // 3. "juz N", "j N", "jz N" or common names like "Amma"
   const juzMatch = q.match(/^(?:juz|j|jz)\s*(\d+)$/i);
   const juzNames: Record<string, number> = {
-    'amma': 30,
+    amma: 30,
     'juz amma': 30,
-    'tabarak': 29,
+    tabarak: 29,
     'juz tabarak': 29,
   };
 
@@ -151,7 +153,8 @@ function parseSearchQuery(
         type: 'juz',
         juz,
         page,
-        primary: juz === 30 ? "Juz 'Amma" : juz === 29 ? 'Juz Tabarak' : `Juz ${juz}`,
+        primary:
+          juz === 30 ? "Juz 'Amma" : juz === 29 ? 'Juz Tabarak' : `Juz ${juz}`,
         secondary: `Page ${page} \u00B7 ${surahName}`,
       });
     }
@@ -248,9 +251,9 @@ const SearchResultRow: React.FC<{
   textColor: string;
   secondaryColor: string;
   onPress: () => void;
-}> = React.memo(({ item, textColor, secondaryColor, onPress }) => (
+}> = React.memo(({item, textColor, secondaryColor, onPress}) => (
   <Pressable
-    style={({ pressed }) => [styles.resultRow, { opacity: pressed ? 0.5 : 1 }]}
+    style={({pressed}) => [styles.resultRow, {opacity: pressed ? 0.5 : 1}]}
     onPress={onPress}>
     <Feather
       name="search"
@@ -259,14 +262,14 @@ const SearchResultRow: React.FC<{
     />
     <View style={styles.resultTextContainer}>
       <Text
-        style={[styles.resultPrimary, { color: textColor }]}
+        style={[styles.resultPrimary, {color: textColor}]}
         numberOfLines={1}>
         {item.primary}
       </Text>
       <Text
         style={[
           styles.resultSecondary,
-          { color: Color(secondaryColor).alpha(0.45).toString() },
+          {color: Color(secondaryColor).alpha(0.45).toString()},
         ]}
         numberOfLines={1}>
         {item.secondary}
@@ -282,9 +285,9 @@ const HistoryRow: React.FC<{
   textColor: string;
   secondaryColor: string;
   onPress: () => void;
-}> = React.memo(({ item, textColor, secondaryColor, onPress }) => (
+}> = React.memo(({item, textColor, secondaryColor, onPress}) => (
   <Pressable
-    style={({ pressed }) => [styles.historyRow, { opacity: pressed ? 0.5 : 1 }]}
+    style={({pressed}) => [styles.historyRow, {opacity: pressed ? 0.5 : 1}]}
     onPress={onPress}>
     <Feather
       name="clock"
@@ -294,7 +297,7 @@ const HistoryRow: React.FC<{
     <Text
       style={[
         styles.historyText,
-        { color: Color(textColor).alpha(0.85).toString() },
+        {color: Color(textColor).alpha(0.85).toString()},
       ]}
       numberOfLines={1}>
       {item.label}
@@ -309,7 +312,7 @@ const RecentReadChips: React.FC<{
   textColor: string;
   secondaryColor: string;
   onPress: (page: number) => void;
-}> = React.memo(({ recentPages, textColor, secondaryColor, onPress }) => {
+}> = React.memo(({recentPages, textColor, secondaryColor, onPress}) => {
   if (recentPages.length === 0) return null;
 
   return (
@@ -346,13 +349,13 @@ const RecentReadChips: React.FC<{
                 },
               ]}
               onPress={() => onPress(item.page)}>
-              <Text style={[styles.chipName, { color: textColor }]}>
+              <Text style={[styles.chipName, {color: textColor}]}>
                 {surah.name}
               </Text>
               <Text
                 style={[
                   styles.chipPage,
-                  { color: Color(secondaryColor).alpha(0.5).toString() },
+                  {color: Color(secondaryColor).alpha(0.5).toString()},
                 ]}>
                 Page {item.page}
               </Text>
@@ -373,11 +376,12 @@ RecentReadChips.displayName = 'RecentReadChips';
 const MushafSearchView: React.FC<MushafSearchViewProps> = ({
   onNavigateToPage,
   onNavigateToSurah,
+  onNavigateToVerse,
   onClose,
   surahStartPages,
   pageToSurah,
 }) => {
-  const { theme, isDarkMode } = useTheme();
+  const {theme, isDarkMode} = useTheme();
   const insets = useSafeAreaInsets();
   const [isSearchMode, setIsSearchMode] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -522,8 +526,13 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
           historyItem.surahId = item.surahId;
           historyItem.verse = item.verse;
           addToHistory(historyItem);
-          // Navigate to surah start page (verse-level nav would require page lookup)
-          onNavigateToSurah(item.surahId);
+          const verseKey = `${item.surahId}:${item.verse}`;
+          const versePage = digitalKhattDataService.getPageForVerse(verseKey);
+          if (versePage) {
+            onNavigateToVerse(verseKey, versePage);
+          } else {
+            onNavigateToSurah(item.surahId);
+          }
           break;
         }
         case 'page':
@@ -539,25 +548,33 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
           break;
       }
     },
-    [addToHistory, onNavigateToPage, onNavigateToSurah],
+    [addToHistory, onNavigateToPage, onNavigateToSurah, onNavigateToVerse],
   );
 
   const handleHistoryPress = useCallback(
     (item: SearchHistoryItem) => {
       Keyboard.dismiss();
+      if (item.surahId && item.verse) {
+        const verseKey = `${item.surahId}:${item.verse}`;
+        const versePage = digitalKhattDataService.getPageForVerse(verseKey);
+        if (versePage) {
+          onNavigateToVerse(verseKey, versePage);
+          return;
+        }
+      }
       if (item.page) {
         onNavigateToPage(item.page);
       } else if (item.surahId) {
         onNavigateToSurah(item.surahId);
       }
     },
-    [onNavigateToPage, onNavigateToSurah],
+    [onNavigateToPage, onNavigateToSurah, onNavigateToVerse],
   );
 
   // ──────────────────────────────────────────────────────────
   // Browse mode data
   // ──────────────────────────────────────────────────────────
-  const { browseData, stickyIndices } = useMemo(() => {
+  const {browseData, stickyIndices} = useMemo(() => {
     const sorted = [...SURAHS];
     switch (sortOption) {
       case 'asc':
@@ -588,15 +605,15 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
             key: `juz-${juz}`,
           });
         }
-        items.push({ type: 'surah-row', surah, key: `surah-${surah.id}` });
+        items.push({type: 'surah-row', surah, key: `surah-${surah.id}`});
       }
     } else {
       for (const surah of sorted) {
-        items.push({ type: 'surah-row', surah, key: `surah-${surah.id}` });
+        items.push({type: 'surah-row', surah, key: `surah-${surah.id}`});
       }
     }
 
-    return { browseData: items, stickyIndices: stickies };
+    return {browseData: items, stickyIndices: stickies};
   }, [sortOption]);
 
   const handleSurahPress = useCallback(
@@ -608,11 +625,17 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
   );
 
   const handleBookmarkPress = useCallback(
-    (surahId: number) => {
+    (surahId: number, ayahNumber: number) => {
       Keyboard.dismiss();
-      onNavigateToSurah(surahId);
+      const verseKey = `${surahId}:${ayahNumber}`;
+      const versePage = digitalKhattDataService.getPageForVerse(verseKey);
+      if (versePage) {
+        onNavigateToVerse(verseKey, versePage);
+      } else {
+        onNavigateToSurah(surahId);
+      }
     },
-    [onNavigateToSurah],
+    [onNavigateToSurah, onNavigateToVerse],
   );
 
   const handleChipPress = useCallback(
@@ -626,18 +649,18 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
   // Browse mode renderers
   // ──────────────────────────────────────────────────────────
   const renderBrowseItem = useCallback(
-    ({ item }: ListRenderItemInfo<BrowseItem>) => {
+    ({item}: ListRenderItemInfo<BrowseItem>) => {
       if (item.type === 'juz-header') {
         return (
           <View
             style={[
               styles.juzHeader,
-              { backgroundColor: theme.colors.background },
+              {backgroundColor: theme.colors.background},
             ]}>
             <Text
               style={[
                 styles.juzHeaderText,
-                { color: theme.colors.textSecondary },
+                {color: theme.colors.textSecondary},
               ]}>
               {item.juzName}
             </Text>
@@ -663,8 +686,8 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
               option === 'asc'
                 ? 'arrow-up'
                 : option === 'desc'
-                  ? 'arrow-down'
-                  : 'calendar';
+                ? 'arrow-down'
+                : 'calendar';
             const label =
               option === 'asc' ? 'Asc' : option === 'desc' ? 'Desc' : 'Rev';
             return (
@@ -726,7 +749,7 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
   // Search mode renderers
   // ──────────────────────────────────────────────────────────
   const renderSearchResult = useCallback(
-    ({ item }: { item: SearchResultItem }) => (
+    ({item}: {item: SearchResultItem}) => (
       <SearchResultRow
         item={item}
         textColor={theme.colors.text}
@@ -738,7 +761,7 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
   );
 
   const renderHistoryItem = useCallback(
-    ({ item }: { item: SearchHistoryItem }) => (
+    ({item}: {item: SearchHistoryItem}) => (
       <HistoryRow
         item={item}
         textColor={theme.colors.text}
@@ -767,14 +790,14 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
       {/* Browse Mode — always mounted, hidden via opacity              */}
       {/* ============================================================ */}
       <RNAnimated.View
-        style={[styles.modeContainer, { opacity: browseOpacity }]}
+        style={[styles.modeContainer, {opacity: browseOpacity}]}
         pointerEvents={isSearchMode ? 'none' : 'auto'}>
         {/* Header: back button + inactive search bar */}
         <View style={styles.browseHeader}>
           <Pressable
-            style={({ pressed }) => [
+            style={({pressed}) => [
               styles.backButton,
-              { opacity: pressed ? 0.3 : 0.6 },
+              {opacity: pressed ? 0.3 : 0.6},
             ]}
             onPress={onClose}
             hitSlop={8}>
@@ -787,7 +810,7 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
           <Pressable style={styles.searchBarTap} onPress={enterSearchMode}>
             <SearchInput
               value=""
-              onChangeText={() => { }}
+              onChangeText={() => {}}
               placeholder="Search surahs, pages, or juz..."
               showCancelButton={false}
               editable={false}
@@ -861,14 +884,14 @@ const MushafSearchView: React.FC<MushafSearchViewProps> = ({
               <View>
                 <View style={styles.historyHeader}>
                   <Text
-                    style={[styles.historyTitle, { color: theme.colors.text }]}>
+                    style={[styles.historyTitle, {color: theme.colors.text}]}>
                     Recent searches
                   </Text>
                   <Pressable onPress={clearHistory}>
                     <Text
                       style={[
                         styles.historyClear,
-                        { color: theme.colors.textSecondary },
+                        {color: theme.colors.textSecondary},
                       ]}>
                       Clear
                     </Text>

--- a/components/mushaf/main.tsx
+++ b/components/mushaf/main.tsx
@@ -357,6 +357,18 @@ export default function MushafViewer({
     return () => clearTimeout(timer);
   }, [navRequestId, navigateToPage]);
 
+  const navigateToVerse = useCallback(
+    (verseKey: string, page: number) => {
+      navigateToPage(page);
+      useMushafVerseSelectionStore.getState().selectVerse(verseKey, page);
+      const timer = setTimeout(() => {
+        useMushafVerseSelectionStore.getState().clearSelection();
+      }, 3000);
+      return () => clearTimeout(timer);
+    },
+    [navigateToPage],
+  );
+
   const openSearchMode = useCallback(() => setIsSearchMode(true), []);
 
   // Mushaf player state
@@ -537,6 +549,7 @@ export default function MushafViewer({
         <MushafSearchView
           onNavigateToPage={navigateToPage}
           onNavigateToSurah={navigateToSurah}
+          onNavigateToVerse={navigateToVerse}
           onClose={() => setIsSearchMode(false)}
           surahStartPages={surahStartPages}
           pageToSurah={pageToSurah}

--- a/docs/features/web-app.md
+++ b/docs/features/web-app.md
@@ -1,0 +1,517 @@
+# Feature: Bayaan Web Application
+
+**Status:** Proposal
+**Priority:** High
+**Complexity:** High
+**Created:** 2026-02-21
+
+## Overview
+
+Build a ground-up, web-native version of Bayaan at **thebayaan.com** — a full-featured Quran audio and Mushaf experience for the browser. Not a React Native Web port, but a proper web application built with Next.js, Tailwind CSS, and the Web Audio API, borrowing the design language and data layer from the mobile app.
+
+## User Story
+
+As a user, I want to visit thebayaan.com and immediately browse reciters, play Quran recitations, read the Mushaf, and manage my listening experience — all from my browser on desktop, tablet, or mobile, with no app download required.
+
+As a user, I want to share a direct link to a specific surah and reciter so that anyone I send it to can start listening instantly.
+
+## Why a Separate Web-Native App
+
+The mobile app is built with React Native/Expo. Rather than using Expo Web (which shoehorns native primitives into a browser), a ground-up web app allows:
+
+- **Proper HTML semantics** — accessibility, SEO, screen readers
+- **Native browser APIs** — HTML5 Audio, Service Workers, Cache API, Web Share API
+- **Web-native styling** — Tailwind CSS, CSS Grid/Flexbox, media queries, responsive design
+- **Server-side rendering** — SEO for every surah and reciter page
+- **URL-first architecture** — deep links, shareable URLs, browser history
+- **Desktop-class layouts** — sidebar navigation, persistent player bar, multi-panel views
+- **No React Native Web abstractions** — no `<View>`, no `StyleSheet.create()`, no RN compatibility shims
+
+## Tech Stack
+
+| Layer | Technology | Rationale |
+|-------|-----------|-----------|
+| **Framework** | Next.js (App Router) | SSR/SSG for SEO, file-based routing, React Server Components |
+| **Language** | TypeScript | Shared types with mobile app |
+| **Styling** | Tailwind CSS | Utility-first, responsive, dark mode built-in |
+| **State Management** | Zustand | Same library as mobile — store logic ports directly |
+| **Audio Engine** | HTML5 Audio API | Native browser audio, Media Session API for OS controls |
+| **Data** | Supabase (same backend) | Same database, same storage, same API |
+| **Static Data** | reciters.json, surahs.json | Copied/shared from mobile repo |
+| **Images** | Next.js `<Image>` | Optimized loading, lazy loading, responsive sizing |
+| **Animations** | Framer Motion | Web-native animation library (replaces Reanimated) |
+| **Fonts** | Manrope, Scheherazade New | Same typefaces as mobile app |
+| **i18n** | react-i18next or next-intl | Same i18n approach, shared translation keys |
+| **Hosting** | Cloudflare Pages | Global edge network, fast in MENA/Asia, generous free tier |
+| **Deployment** | `@opennextjs/cloudflare` | Next.js adapter for Cloudflare Pages |
+| **Domain** | thebayaan.com | Primary web domain |
+
+## What's Shared with Mobile
+
+| Asset | How It's Shared |
+|-------|----------------|
+| TypeScript types (`types/`) | Copy or npm package from shared repo |
+| Zustand store logic | Port store shapes and actions (same API, different persistence) |
+| Static data (reciters.json, surahs.json) | Copy to web repo or fetch from Supabase at build time |
+| Design tokens (colors, spacing, typography) | Extract into shared Tailwind config / CSS variables |
+| Supabase backend | Same project, same tables, same storage buckets |
+| Audio file URLs | Same CDN / Supabase storage URLs |
+| Translation strings | Shared i18n JSON files |
+| Reciter images | Same Supabase storage URLs |
+
+## What's Built From Scratch
+
+| Component | Web Implementation |
+|-----------|-------------------|
+| Navigation | Next.js App Router (sidebar + top nav) |
+| Audio engine | HTML5 `Audio` element + Media Session API |
+| Player UI | Custom React component with Tailwind (persistent bottom bar) |
+| Mushaf viewer | CSS/Canvas-based Uthmani page rendering |
+| Storage | `localStorage` for preferences, IndexedDB for offline cache |
+| Downloads/Offline | Service Worker + Cache API (PWA) |
+| Bottom sheets | Modal dialogs / slide-over panels (Headless UI or Radix) |
+| Lists/Grids | Native HTML + CSS Grid (no FlashList needed) |
+| Haptics | N/A (web has limited vibration API, not worth it) |
+| Notifications | Web Push API (optional, future) |
+| Dark mode | Tailwind `dark:` variant + `prefers-color-scheme` |
+
+## Architecture
+
+### Repository Structure
+
+```
+bayaan-web/                    # Separate repository
+├── app/                       # Next.js App Router
+│   ├── layout.tsx             # Root layout (sidebar + player bar)
+│   ├── page.tsx               # Home page
+│   ├── reciters/
+│   │   ├── page.tsx           # All reciters (grid, filterable)
+│   │   └── [slug]/
+│   │       └── page.tsx       # Reciter detail + surah list
+│   ├── surah/
+│   │   └── [id]/
+│   │       └── page.tsx       # Surah page (with reciter selector)
+│   ├── mushaf/
+│   │   ├── page.tsx           # Mushaf viewer (page 1)
+│   │   └── [page]/
+│   │       └── page.tsx       # Mushaf page N
+│   ├── queue/
+│   │   └── page.tsx           # Queue management
+│   ├── downloads/
+│   │   └── page.tsx           # Offline/downloaded content
+│   └── settings/
+│       └── page.tsx           # Preferences, theme, language
+├── components/
+│   ├── layout/
+│   │   ├── Sidebar.tsx        # Left navigation rail
+│   │   ├── PlayerBar.tsx      # Persistent bottom player
+│   │   ├── Header.tsx         # Top bar (search, settings)
+│   │   └── MobileNav.tsx      # Bottom nav for mobile viewports
+│   ├── player/
+│   │   ├── PlayerBar.tsx      # Compact bottom player bar
+│   │   ├── FullPlayer.tsx     # Expanded full-screen player
+│   │   ├── ProgressBar.tsx    # Seekable progress
+│   │   ├── VolumeControl.tsx  # Volume slider
+│   │   └── QueuePanel.tsx     # Side panel queue view
+│   ├── reciter/
+│   │   ├── ReciterCard.tsx    # Reciter grid card
+│   │   ├── ReciterGrid.tsx    # Responsive grid of reciters
+│   │   └── ReciterDetail.tsx  # Reciter profile + surah list
+│   ├── surah/
+│   │   ├── SurahList.tsx      # Surah listing table/list
+│   │   ├── SurahRow.tsx       # Individual surah row
+│   │   └── SurahHeader.tsx    # Surah metadata header
+│   ├── mushaf/
+│   │   ├── MushafViewer.tsx   # Page viewer with navigation
+│   │   ├── MushafPage.tsx     # Single Uthmani page render
+│   │   └── MushafControls.tsx # Page nav, zoom, settings
+│   ├── ambient/
+│   │   ├── AmbientPanel.tsx   # Ambient sound selector
+│   │   └── AmbientToggle.tsx  # Quick toggle button
+│   └── ui/                    # Shared primitives
+│       ├── Button.tsx
+│       ├── Modal.tsx
+│       ├── Slider.tsx
+│       ├── Tooltip.tsx
+│       └── SearchInput.tsx
+├── lib/
+│   ├── audio/
+│   │   ├── AudioService.ts    # HTML5 Audio wrapper (singleton)
+│   │   ├── AmbientService.ts  # Second Audio instance for ambient
+│   │   └── MediaSession.ts    # Media Session API (OS controls)
+│   ├── stores/
+│   │   ├── playerStore.ts     # Ported from mobile (Zustand)
+│   │   ├── queueStore.ts      # Queue state
+│   │   ├── ambientStore.ts    # Ambient preferences
+│   │   └── settingsStore.ts   # User preferences
+│   ├── api/
+│   │   ├── supabase.ts        # Supabase client
+│   │   └── reciters.ts        # Data fetching helpers
+│   └── utils/
+│       ├── formatTime.ts      # Duration formatting
+│       └── storage.ts         # localStorage helpers
+├── data/
+│   ├── reciters.json          # Static reciter data
+│   └── surahs.json            # Surah metadata
+├── styles/
+│   └── globals.css            # Tailwind imports, CSS variables, fonts
+├── public/
+│   ├── fonts/                 # Manrope, Scheherazade
+│   ├── audio/ambient/         # Bundled ambient sounds
+│   └── icons/                 # Favicons, PWA icons
+├── tailwind.config.ts         # Design tokens (colors, fonts, spacing)
+├── next.config.ts             # Next.js configuration
+└── wrangler.toml              # Cloudflare Pages config
+```
+
+### Audio Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Browser                                             │
+│                                                      │
+│  ┌────────────────┐      ┌──────────────────────┐    │
+│  │  AudioService   │      │  Media Session API   │    │
+│  │  (singleton)    │─────▶│  (OS-level controls) │    │
+│  │                 │      │  - lock screen        │    │
+│  │  new Audio()    │      │  - notification bar   │    │
+│  │  .src = url     │      │  - keyboard media keys│    │
+│  │  .play()        │      └──────────────────────┘    │
+│  │  .pause()       │                                  │
+│  │  .currentTime   │      ┌──────────────────────┐    │
+│  └────────────────┘      │  AmbientService       │    │
+│                           │  (second Audio())     │    │
+│  ┌────────────────┐      │  .loop = true          │    │
+│  │  Zustand Store  │      │  independent volume   │    │
+│  │  (playerStore)  │      └──────────────────────┘    │
+│  │  - currentTrack │                                  │
+│  │  - isPlaying    │      ┌──────────────────────┐    │
+│  │  - progress     │      │  Service Worker       │    │
+│  │  - queue        │      │  (PWA offline cache)  │    │
+│  └────────────────┘      │  - cached surahs       │    │
+│                           │  - app shell cache     │    │
+│                           └──────────────────────┘    │
+└──────────────────────────────────────────────────────┘
+```
+
+The Web Audio API is dramatically simpler than mobile audio:
+- `new Audio(url)` — that's it. No native modules, no bridges.
+- `.play()`, `.pause()`, `.currentTime` for seek
+- `timeupdate` event for progress
+- `ended` event for auto-next
+- Media Session API provides lock screen / notification / keyboard media key integration for free
+
+### Desktop Layout
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  ┌────┐  Bayaan                          🔍 Search         ⚙    │
+├──┤    ├──────────────────────────────────────────────────────────┤
+│  │    │                                                          │
+│  │ 🏠 │   Featured Reciters                                     │
+│  │Home│   ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐      │
+│  │    │   │         │ │         │ │         │ │         │      │
+│  │ 🎙 │   │Al-Husary│ │Minshawi │ │As-Sudais│ │Al-Ajmi  │      │
+│  │Rctrs│   │         │ │         │ │         │ │         │      │
+│  │    │   └─────────┘ └─────────┘ └─────────┘ └─────────┘      │
+│  │ 📖 │                                                          │
+│  │Surah│   Continue Listening                                    │
+│  │    │   ┌──────────────────────────────────────────────┐      │
+│  │ 📕 │   │  ▶  Al-Baqarah · Al-Husary · 02:34 / 45:12  │      │
+│  │Mshf│   └──────────────────────────────────────────────┘      │
+│  │    │                                                          │
+│  │ ⬇  │   All Surahs                                            │
+│  │DLs │   ┌──────────────────────────────────────────────┐      │
+│  │    │   │  1   Al-Fatiha        7 verses     Meccan    │      │
+│  │    │   │  2   Al-Baqarah     286 verses     Medinan   │      │
+│  │    │   │  3   Aal-Imran      200 verses     Medinan   │      │
+│  │    │   │  4   An-Nisa        176 verses     Medinan   │      │
+│  │    │   └──────────────────────────────────────────────┘      │
+│  │    │                                                          │
+├──┴────┴──────────────────────────────────────────────────────────┤
+│  ▶ Al-Baqarah · Sheikh Al-Husary    ━━━━━━●━━━━━━  02:34/45:12 │
+│  ⏮  ▶❚❚  ⏭    🔊━━━━━●━━━━    [Queue]  [Ambient]  [Speed]      │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- **Left sidebar**: Navigation (collapsible on smaller screens)
+- **Main content**: Scrollable, responsive grid/list
+- **Bottom player bar**: Persistent, always visible when something is playing
+- **On mobile viewports**: Sidebar collapses to bottom tab bar, player bar stacks above it
+
+### Mobile Web Layout
+
+```
+┌─────────────────────────┐
+│  Bayaan            🔍 ⚙ │
+├─────────────────────────┤
+│                         │
+│  Featured Reciters      │
+│  ┌──────┐ ┌──────┐     │
+│  │      │ │      │     │
+│  │Husary│ │Minsh.│ ... │
+│  └──────┘ └──────┘     │
+│                         │
+│  Continue Listening     │
+│  ┌─────────────────┐   │
+│  │ ▶ Al-Baqarah    │   │
+│  │   Al-Husary     │   │
+│  └─────────────────┘   │
+│                         │
+│  All Surahs             │
+│  1. Al-Fatiha      ▶   │
+│  2. Al-Baqarah     ▶   │
+│  3. Aal-Imran      ▶   │
+│  ...                    │
+│                         │
+├─────────────────────────┤
+│ ▶ Al-Baqarah  ━━●━━━━  │
+├─────────────────────────┤
+│ 🏠  🎙  📖  📕  ⬇      │
+└─────────────────────────┘
+```
+
+### URL Structure & SEO
+
+Every page is server-rendered and indexable:
+
+| URL | Page | SEO Title |
+|-----|------|-----------|
+| `/` | Home | Bayaan — Listen to the Holy Quran |
+| `/reciters` | All reciters | Quran Reciters — Bayaan |
+| `/reciters/al-husary` | Reciter detail | Sheikh Al-Husary — Bayaan |
+| `/surah/2` | Surah page | Surah Al-Baqarah — Listen Online — Bayaan |
+| `/surah/2?reciter=al-husary` | Surah + reciter | Al-Baqarah by Al-Husary — Bayaan |
+| `/mushaf` | Mushaf viewer | Read the Holy Quran — Bayaan |
+| `/mushaf/604` | Mushaf page N | Quran Page 604 — Bayaan |
+| `/queue` | Queue | Queue — Bayaan |
+| `/settings` | Settings | Settings — Bayaan |
+
+### Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Space` | Play / Pause |
+| `→` | Seek forward 10s |
+| `←` | Seek backward 10s |
+| `Shift + →` | Next track |
+| `Shift + ←` | Previous track |
+| `↑` / `↓` | Volume up / down |
+| `M` | Mute / unmute |
+| `Q` | Toggle queue panel |
+| `F` | Toggle full-screen player |
+| `/` | Focus search |
+
+## Requirements
+
+### Functional Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| WEB-01 | Browse all reciters with images, names, and metadata | Must |
+| WEB-02 | Browse all 114 surahs with metadata | Must |
+| WEB-03 | Play any surah by any reciter | Must |
+| WEB-04 | Persistent player bar with play/pause/seek/next/prev | Must |
+| WEB-05 | Queue management (add, remove, reorder) | Must |
+| WEB-06 | Volume control | Must |
+| WEB-07 | Playback speed control (0.5x–2.0x) | Must |
+| WEB-08 | Dark mode / light mode toggle + system preference | Must |
+| WEB-09 | Responsive layout (desktop, tablet, mobile) | Must |
+| WEB-10 | Shareable URLs for every surah and reciter | Must |
+| WEB-11 | Server-side rendering for SEO | Must |
+| WEB-12 | Ambient nature sounds | Should |
+| WEB-13 | Digital Mushaf viewer (Uthmani pages) | Should |
+| WEB-14 | Keyboard shortcuts for playback | Should |
+| WEB-15 | Media Session API (OS-level play/pause, lock screen) | Should |
+| WEB-16 | Search (surahs, reciters) | Should |
+| WEB-17 | PWA support (installable, offline cached surahs) | Should |
+| WEB-18 | Arabic / English language toggle | Should |
+| WEB-19 | RTL layout support for Arabic UI | Should |
+| WEB-20 | Continue listening (persist last played across sessions) | Should |
+| WEB-21 | Download indicator for cached/offline surahs | Could |
+| WEB-22 | Embeddable player widget for external sites | Could |
+| WEB-23 | Social sharing meta tags (Open Graph, Twitter cards) | Should |
+| WEB-24 | Mushaf page synced with audio playback position | Could |
+
+### Non-Functional Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| WEB-NF-01 | First Contentful Paint < 1.5s | Must |
+| WEB-NF-02 | Largest Contentful Paint < 2.5s | Must |
+| WEB-NF-03 | Cumulative Layout Shift < 0.1 | Must |
+| WEB-NF-04 | Lighthouse Performance score > 90 | Should |
+| WEB-NF-05 | Lighthouse Accessibility score > 95 | Must |
+| WEB-NF-06 | Works in all modern browsers (Chrome, Firefox, Safari, Edge) | Must |
+| WEB-NF-07 | Fully responsive from 320px to 2560px+ | Must |
+| WEB-NF-08 | Audio starts playing in < 1s after user presses play | Must |
+| WEB-NF-09 | PWA passes Chrome installability criteria | Should |
+| WEB-NF-10 | Page weight < 500KB initial load (excluding audio) | Should |
+
+## Design System
+
+### Borrowed from Mobile App
+
+The web app should feel like the same product, not a different app:
+
+| Token | Mobile Value | Web Implementation |
+|-------|-------------|-------------------|
+| Primary font | Manrope | `font-family: 'Manrope', sans-serif` |
+| Arabic font | Scheherazade New | `font-family: 'Scheherazade New', serif` |
+| Surah name font | surah_names.ttf | Custom `@font-face` |
+| Dark background | `theme.colors.background` | CSS variable `--color-bg` |
+| Text primary | `theme.colors.text` | CSS variable `--color-text` |
+| Text secondary | `theme.colors.textSecondary` | CSS variable `--color-text-secondary` |
+| No accent/primary colors on UI | Convention from CLAUDE.md | Stick to text/textSecondary + alpha variants |
+| Border radius | Consistent rounded corners | Tailwind `rounded-xl` / `rounded-2xl` |
+| Spacing scale | 4/8/12/16/24/32 | Tailwind default scale |
+
+### Web-Specific Design
+
+| Element | Approach |
+|---------|----------|
+| Sidebar navigation | 240px width, collapsible, icon-only on collapse |
+| Player bar | Fixed bottom, 80px height, full-width |
+| Cards | CSS Grid, responsive columns (1-col mobile, 2-3 tablet, 4-5 desktop) |
+| Modals / panels | Slide-over panels from right (queue, ambient, settings) |
+| Hover states | Subtle background highlight, cursor pointer |
+| Focus states | Visible focus rings for keyboard navigation |
+| Transitions | 150-200ms ease, no jarring jumps |
+
+## Implementation Phases
+
+### Phase 1: Foundation & Core Playback
+
+1. Next.js project setup with App Router, Tailwind CSS, TypeScript
+2. Cloudflare Pages deployment pipeline (wrangler, `@opennextjs/cloudflare`)
+3. Root layout: sidebar navigation + persistent player bar
+4. Responsive breakpoints (mobile, tablet, desktop)
+5. Dark mode / light mode with system preference detection
+6. AudioService: HTML5 Audio wrapper with play/pause/seek/volume
+7. Zustand stores: playerStore, queueStore (ported from mobile)
+8. Home page: featured reciters, continue listening
+9. Reciter grid page with Supabase data
+10. Reciter detail page with surah list
+11. Basic surah playback: click surah → audio plays in player bar
+12. Media Session API integration (OS-level controls)
+
+**Exit criteria:** User can browse reciters, select a surah, and play it with full controls.
+
+### Phase 2: Full Player & Queue
+
+1. Full-screen expanded player view (click player bar to expand)
+2. Queue panel (slide-over from right)
+3. Add to queue / play next / play last
+4. Queue reordering (drag and drop)
+5. Playback speed control
+6. Next/previous track with queue integration
+7. Auto-advance to next surah
+8. Keyboard shortcuts for playback
+9. Progress persistence (localStorage — resume where you left off)
+
+### Phase 3: Surah Pages & SEO
+
+1. Individual surah pages (`/surah/[id]`) with server-rendered metadata
+2. Reciter selector on surah page (choose which reciter to listen to)
+3. Open Graph meta tags and Twitter cards for social sharing
+4. Structured data (JSON-LD) for Google rich results
+5. Sitemap generation (all surahs, all reciters)
+6. Search functionality (client-side fuzzy search with Fuse.js)
+7. Arabic/English language toggle with RTL support
+
+### Phase 4: Ambient Sounds
+
+1. AmbientService: second `Audio()` instance for nature sounds
+2. Bundle ambient MP3s (same 8 sounds from mobile app)
+3. Ambient sound selector panel
+4. Independent volume control
+5. Ambient syncs with main playback (pause/resume together)
+6. Ambient preference persisted in localStorage
+
+### Phase 5: Digital Mushaf
+
+1. Mushaf page viewer (`/mushaf/[page]`)
+2. Uthmani page rendering (CSS-based or Canvas-based)
+3. Page navigation (swipe on mobile, arrow keys on desktop, buttons)
+4. Page thumbnails or page number input for quick navigation
+5. Surah/Juz index for jumping to specific content
+6. Integration with audio: tap to play from a specific page
+7. (Stretch) Highlight current ayah during playback using timestamp data
+
+### Phase 6: PWA & Offline
+
+1. Service Worker registration
+2. App shell caching (HTML, CSS, JS, fonts)
+3. Runtime caching strategy for audio files (Cache First for downloaded, Network First for streaming)
+4. "Save offline" button for surahs (caches audio in Cache API)
+5. Offline indicator UI
+6. PWA manifest (installable on desktop and mobile browsers)
+7. Splash screen and app icons for PWA
+
+### Phase 7: Polish & Launch
+
+1. Performance optimization (bundle splitting, image optimization, lazy loading)
+2. Lighthouse audit pass (performance > 90, accessibility > 95)
+3. Cross-browser testing (Chrome, Firefox, Safari, Edge)
+4. Mobile Safari audio quirks (autoplay restrictions, audio session handling)
+5. Analytics integration
+6. Error tracking (Sentry or similar)
+7. DNS + SSL setup for thebayaan.com on Cloudflare
+8. Launch
+
+## Hosting & Deployment
+
+### Cloudflare Pages
+
+```
+bayaan-web/
+├── wrangler.toml              # Cloudflare Pages config
+├── next.config.ts             # Next.js config
+└── ...
+```
+
+**Deployment flow:**
+1. Push to `main` branch → Cloudflare Pages auto-deploys to thebayaan.com
+2. Push to `develop` / feature branches → Preview deployments at `*.bayaan-web.pages.dev`
+3. `@opennextjs/cloudflare` adapter converts Next.js output to Cloudflare Workers
+
+**Cloudflare benefits:**
+- Global edge CDN (300+ cities, strong MENA/Asia presence)
+- Free SSL
+- Free tier: 500 builds/month, unlimited bandwidth
+- Web Analytics (privacy-focused, no cookie banner needed)
+- R2 storage available if needed for audio caching at edge
+
+### Domain Setup
+
+| Domain | Purpose |
+|--------|---------|
+| `thebayaan.com` | Primary web app |
+| `www.thebayaan.com` | Redirect to `thebayaan.com` |
+| `api.thebayaan.com` | (Future) API if needed beyond Supabase |
+
+## Open Questions
+
+1. **Shared package for types/data** — Should a shared npm package or Git submodule hold types, surahs.json, reciters.json, and i18n strings between mobile and web repos? Or just copy and sync manually?
+2. **User accounts** — The mobile app doesn't have user auth. Should the web version? Could enable cross-device sync (bookmarks, listening history, queue).
+3. **Mushaf rendering approach** — Port the Digital Khatt rendering from mobile (Skia-based) to web (Canvas/SVG/CSS)? Or use a different rendering approach optimized for web?
+4. **Audio CDN** — Should audio files be proxied through Cloudflare R2/CDN for faster delivery, or continue serving directly from Supabase Storage?
+5. **Analytics** — Cloudflare Web Analytics (privacy-first) vs. Plausible vs. PostHog?
+6. **Component library** — Build from scratch with Tailwind, or use a headless library (Radix UI, Headless UI) for modals, dropdowns, sliders?
+
+## References
+
+- [Next.js App Router Documentation](https://nextjs.org/docs/app)
+- [Tailwind CSS Documentation](https://tailwindcss.com/docs)
+- [Media Session API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API)
+- [HTML5 Audio API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement)
+- [Cloudflare Pages Documentation](https://developers.cloudflare.com/pages/)
+- [@opennextjs/cloudflare](https://github.com/opennextjs/opennextjs-cloudflare)
+- [Service Workers (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)
+- [Web App Manifest (MDN)](https://developer.mozilla.org/en-US/docs/Web/Manifest)
+- [Bayaan Mobile App — TV Feature Doc](./tv-app.md)
+- [Bayaan Mobile App — Smartwatch Feature Doc](./smartwatch.md)
+
+---
+
+*Created: 2026-02-21*

--- a/docs/features/widgets.md
+++ b/docs/features/widgets.md
@@ -1,0 +1,189 @@
+# Feature: Home Screen Widgets (iOS & Android)
+
+**Status:** Planned
+**Priority:** Medium
+**Complexity:** High
+**Created:** 2026-02-21
+**GitHub Issue:** [#126](https://github.com/thebayaan/Bayaan/issues/126)
+**Related:** [Shareable Deep Links (#117)](https://github.com/thebayaan/Bayaan/issues/117), [Cloud Sync (#120)](https://github.com/thebayaan/Bayaan/issues/120)
+
+## Overview
+
+Build native home screen widgets for iOS (WidgetKit + SwiftUI) and Android (App Widgets / Jetpack Glance) that give users quick access to Quran playback, reading progress, adhkar, and listening stats without opening the app.
+
+## Widget Catalog
+
+### Tier 1 — High Value, Low Complexity
+
+#### 1. Now Playing / Continue Listening
+- Shows currently playing or last played surah, reciter name, and progress
+- Play/pause button directly on widget (iOS 17+ interactive widgets, Android natively)
+- Tap to open app and resume playback
+- Sizes: small, medium, large
+
+#### 2. Quick Play (Surah Shortcuts)
+- Grid of 4–6 surah buttons (configurable or auto-populated from most played / recents)
+- One tap opens app and starts playing immediately
+- Good defaults: Al-Fatiha, Ya-Sin, Al-Mulk, Al-Kahf, Ar-Rahman, Al-Waqi'ah
+
+#### 3. Daily Verse / Ayah of the Day
+- Displays a Quran verse in Arabic + translation, refreshes daily
+- Tap opens the mushaf at that verse's page
+- Calligraphic presentation using existing Uthmani fonts
+
+#### 4. Last Read (Mushaf Bookmark)
+- Shows last mushaf page and surah name from `mushafSettingsStore.lastReadPage`
+- "Continue reading" — one tap opens mushaf where the user left off
+- Uses `recentPages` for additional context
+
+### Tier 2 — Medium Complexity
+
+#### 5. Adhkar (Morning/Evening)
+- Auto-switches between morning and evening adhkar based on time of day
+- Shows current dhikr with repeat count
+- Progress indicator if the user has started the sequence
+- Tap opens adhkar flow in-app
+
+#### 6. Listening Stats
+- Total listening time today/this week, most played surah, streak count
+- Data from `playCountStore`
+- Motivational: "You've listened to 3 surahs today"
+
+#### 7. Playlist Widget
+- User picks a playlist during widget configuration
+- Shows first few tracks with reciter names
+- Tap any track to start playing
+
+#### 8. Favorites / Loved Tracks
+- Quick-access grid of loved recitations
+- Tap to play directly
+
+### Tier 3 — High Complexity / High Delight
+
+#### 9. Juz Tracker / Khatma Progress
+- Circular progress ring: "12/30 Juz completed"
+- Based on mushaf pages read or surahs listened to
+- Requires new tracking logic (does not exist yet)
+
+#### 10. Live Tasbeeh Counter
+- Interactive widget — tap to increment counter on home screen without opening app
+- Shows current dhikr text, count, and target
+- iOS 17+ interactive widgets support this; Android has always supported it
+
+#### 11. Prayer Time + Suggested Adhkar
+- Shows next prayer time (requires prayer time calculation or API)
+- Suggests relevant adhkar for the time of day
+- Larger scope — may warrant its own feature
+
+#### 12. Random Reciter Discovery
+- "Listen to someone new" — random reciter with photo and name
+- Tap to browse their surahs
+- Refreshes daily or on tap
+
+## Technical Architecture
+
+### iOS (WidgetKit + SwiftUI)
+
+Widgets are a **separate Xcode target** written in Swift/SwiftUI, not part of the React Native bundle.
+
+**Data sharing:**
+- App Group container (`group.com.bayaan.app`) shared between RN app and widget extension
+- RN app writes to `UserDefaults(suiteName: "group.com.bayaan.app")` or a shared SQLite file
+- Widget reads from the same App Group on timeline refresh
+
+**Update model:**
+- Timeline-based — widget provides a `TimelineProvider` with scheduled entries
+- RN app triggers timeline reload via `WidgetCenter.shared.reloadAllTimelines()` when state changes
+
+**Interactivity (iOS 17+):**
+- Buttons and toggles trigger `AppIntent` without opening the app
+- Enables play/pause and tasbeeh counter directly on widget
+
+**Sizes:** Small (2x2), Medium (4x2), Large (4x4), Lock Screen, StandBy
+
+### Android (App Widgets / Jetpack Glance)
+
+Widgets use `AppWidgetProvider` with `RemoteViews` or Jetpack Glance (Compose-style).
+
+**Data sharing:**
+- `SharedPreferences` or shared SQLite accessible by both RN and the widget
+- RN app writes via a native module bridge
+
+**Update model:**
+- Widgets update via broadcasts or `AppWidgetManager.updateAppWidget()`
+- RN app triggers updates when player state or data changes
+
+**Interactivity:**
+- Buttons work natively via `PendingIntent`
+- Play/pause, counter increment, etc.
+
+**Sizes:** Flexible grid-based (1x1 through 4x4+)
+
+### Data Flow (Both Platforms)
+
+```
+React Native app
+  ├── state changes (player, mushaf, adhkar, play counts)
+  ├── writes to shared storage (App Group / SharedPreferences)
+  └── triggers widget refresh
+
+Widget (native)
+  ├── reads from shared storage
+  ├── renders native UI (SwiftUI / Glance)
+  └── user taps → deep link (bayaan://) → opens app at correct screen
+```
+
+### Expo Integration
+
+Since widgets are native code, integration with the Expo/RN project requires:
+
+1. **Expo Config Plugin** to add widget extension target (iOS) and widget provider (Android) during `expo prebuild`
+2. **Native module** to write data from RN → shared storage (App Group / SharedPreferences)
+3. **Deep links** via existing `bayaan://` scheme bring users back into the RN app
+
+**Community packages:**
+- `@bittingz/expo-widgets` — Expo config plugin that scaffolds iOS and Android widget targets
+- `expo-apple-targets` — Adds arbitrary Apple extension targets to an Expo project
+- `react-native-android-widget` — Write Android widget UI in JS via Jetpack Glance
+- `react-native-shared-group-preferences` — Read/write to App Group UserDefaults from RN
+
+### Existing Data Sources
+
+| Widget | Data Source | Already Exists? |
+|--------|------------|-----------------|
+| Now Playing | `playerStore` (current track, progress) | Yes |
+| Quick Play | `playCountStore.getMostPlayed()`, `recentSurahStore` | Yes |
+| Daily Verse | `surahData`, verse text from SQLite | Yes |
+| Last Read | `mushafSettingsStore.lastReadPage`, `recentPages` | Yes |
+| Adhkar | `adhkarStore`, `adhkarSettingsStore` | Yes |
+| Listening Stats | `playCountStore` | Yes (counts only, no duration) |
+| Playlist | `PlaylistService` (SQLite) | Yes |
+| Favorites | `favoriteRecitersStore`, loved tracks | Yes |
+| Juz Tracker | — | No (needs new tracking) |
+| Tasbeeh Counter | `adhkarStore.dhikrCounts` | Partial |
+| Prayer Times | — | No (needs calculation/API) |
+
+## Implementation Phases
+
+1. **Phase 1:** Shared data bridge — native module to write player/mushaf state to App Group (iOS) and SharedPreferences (Android)
+2. **Phase 2:** Now Playing widget (both platforms) — exercises the full pattern
+3. **Phase 3:** Last Read + Quick Play widgets — reuse the same bridge
+4. **Phase 4:** Daily Verse + Adhkar widgets
+5. **Phase 5:** Interactive widgets (play/pause, tasbeeh counter) — iOS 17+ and Android
+
+## Files Likely Affected
+
+- `app.config.js` — Config plugin for widget targets, App Group entitlement
+- New: `plugins/withWidgets.js` — Expo config plugin for widget setup
+- New: `ios/BayaanWidgets/` — Swift/SwiftUI widget extension
+- New: `android/app/src/main/java/.../widgets/` — Kotlin widget provider
+- New: `services/widget/WidgetBridge.ts` — RN → native shared storage bridge
+- Existing stores (`playerStore`, `mushafSettingsStore`, `playCountStore`) — add write-to-widget-storage side effects
+
+## Open Questions
+
+- Which widgets to build first? (Recommended: Now Playing, then Last Read)
+- Should widget UI match the app theme (dark/light)?
+- Minimum iOS version for interactive widgets? (iOS 17 for AppIntent-based interactivity)
+- Use `@bittingz/expo-widgets` or build custom config plugin?
+- Should listening stats track duration (not just play counts) to power the stats widget?


### PR DESCRIPTION
## Summary
- Verse search (e.g. "2:255") and bookmark taps now navigate to the exact mushaf page instead of the surah start page
- Target ayah is briefly highlighted for 3 seconds then auto-clears
- Bookmarks collection screen (`onPress`) now opens mushaf at the correct verse page
- Search history re-taps for verse results also navigate to the exact page

## Test plan
- [ ] Search "2:255" in mushaf → navigates to page 42, highlights Ayat al-Kursi briefly
- [ ] Search "112:1" → navigates to page 604, highlights verse 1 of Al-Ikhlas
- [ ] Tap a bookmark chip in mushaf search → navigates to exact verse page with highlight
- [ ] Open Bookmarks collection screen, tap a bookmark → opens mushaf at exact verse page
- [ ] Re-tap a verse search from history → navigates to exact page
- [ ] Verify highlight auto-clears after ~3 seconds in all cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)