### PR TITLE
revert: undo double-letter tab bar fixes

### DIFF
--- a/components/reciter-profile/components/RewayatTabBar.tsx
+++ b/components/reciter-profile/components/RewayatTabBar.tsx
@@ -1,7 +1,6 @@
 import React, {useCallback, useState, useRef, useEffect, useMemo} from 'react';
 import {
   View,
-  Text,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -94,6 +93,30 @@ export const RewayatTabBar: React.FC<RewayatTabBarProps> = ({
     return scrollX.interpolate({inputRange, outputRange, extrapolate: 'clamp'});
   }, [allLayoutsReady, tabs, tabLayouts, scrollX, screenWidth]);
 
+  // Per-tab opacity interpolations — native-driven, frame-perfect sync with swipe
+  const tabOpacities = useMemo(() => {
+    if (tabs.length < 2) {
+      const activeIdx = tabs.findIndex(t => t.id === activeTabId);
+      return tabs.map((_, tabIndex) => ({
+        active: new RNAnimated.Value(tabIndex === activeIdx ? 1 : 0),
+        inactive: new RNAnimated.Value(tabIndex === activeIdx ? 0 : 1),
+      }));
+    }
+    const inputRange = tabs.map((_, i) => i * screenWidth);
+    return tabs.map((_, tabIndex) => ({
+      active: scrollX.interpolate({
+        inputRange,
+        outputRange: tabs.map((_, i) => (i === tabIndex ? 1 : 0)),
+        extrapolate: 'clamp',
+      }),
+      inactive: scrollX.interpolate({
+        inputRange,
+        outputRange: tabs.map((_, i) => (i === tabIndex ? 0 : 1)),
+        extrapolate: 'clamp',
+      }),
+    }));
+  }, [tabs, scrollX, screenWidth]);
+
   const handleTabPress = useCallback(
     (tabId: string) => {
       const layout = tabLayouts.get(tabId);
@@ -126,17 +149,30 @@ export const RewayatTabBar: React.FC<RewayatTabBarProps> = ({
         horizontal
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.tabsRow}>
-        {tabs.map(tab => {
-          const isActive = tab.id === activeTabId;
+        {tabs.map((tab, tabIndex) => {
+          const {active: activeOpacity, inactive: inactiveOpacity} =
+            tabOpacities[tabIndex];
           return (
             <Pressable
               key={tab.id}
               style={styles.tab}
               onPress={() => handleTabPress(tab.id)}
               onLayout={e => handleTabLayout(tab.id, e)}>
-              <Text style={isActive ? styles.tabTextActive : styles.tabText}>
-                {tab.label}
-              </Text>
+              {/* Wrapper keeps both texts aligned — bold drives size */}
+              <View style={styles.tabTextWrapper}>
+                <RNAnimated.Text
+                  style={[styles.tabTextActive, {opacity: activeOpacity}]}>
+                  {tab.label}
+                </RNAnimated.Text>
+                <RNAnimated.Text
+                  style={[
+                    styles.tabText,
+                    styles.tabTextOverlay,
+                    {opacity: inactiveOpacity},
+                  ]}>
+                  {tab.label}
+                </RNAnimated.Text>
+              </View>
             </Pressable>
           );
         })}
@@ -175,6 +211,11 @@ const createStyles = (theme: Theme) =>
       paddingBottom: moderateScale(12),
       alignItems: 'center',
     },
+    tabTextWrapper: {
+      position: 'relative',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
     tabText: {
       fontSize: moderateScale(13),
       fontFamily: 'Manrope-Medium',
@@ -184,6 +225,9 @@ const createStyles = (theme: Theme) =>
       fontSize: moderateScale(13),
       fontFamily: 'Manrope-Bold',
       color: theme.colors.text,
+    },
+    tabTextOverlay: {
+      position: 'absolute',
     },
     indicator: {
       position: 'absolute',

--- a/components/reciter-profile/components/RewayatTabBar.tsx
+++ b/components/reciter-profile/components/RewayatTabBar.tsx
@@ -115,7 +115,7 @@ export const RewayatTabBar: React.FC<RewayatTabBarProps> = ({
         extrapolate: 'clamp',
       }),
     }));
-  }, [tabs, scrollX, screenWidth]);
+  }, [tabs, scrollX, screenWidth, activeTabId]);
 
   const handleTabPress = useCallback(
     (tabId: string) => {


### PR DESCRIPTION
## Summary

- Reverts f372d6c ("fix: prevent double-letter glitch when switching reciter tabs")
- Reverts 962f71b ("fix: remove dual-text overlay causing double-letter glitch in tab bar")

These two commits from PR #129 were incorrect and need to be backed out. The third commit from that PR (00f5a0e) is intentionally kept.

## Test plan

- [ ] Verify RewayatTabBar renders correctly after revert
- [ ] Verify reciter tab switching works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)