### PR TITLE
feat: show What's New modal on first install

### DIFF
--- a/utils/versionUtils.ts
+++ b/utils/versionUtils.ts
@@ -4,7 +4,6 @@ import * as semver from 'semver';
 import {ChangelogEntry} from '@/types/changelog';
 
 const LAST_SEEN_VERSION_KEY = '@bayaan_last_seen_version';
-const FIRST_INSTALL_KEY = '@bayaan_first_install';
 
 /**
  * Normalize version string to valid semver format
@@ -39,23 +38,6 @@ export async function getLastSeenVersion(): Promise<string | null> {
   } catch (error) {
     console.error('[VersionUtils] Failed to get last seen version:', error);
     return null;
-  }
-}
-
-/**
- * Check if this is the first time the app is being installed
- */
-export async function isFirstInstall(): Promise<boolean> {
-  try {
-    const flag = await AsyncStorage.getItem(FIRST_INSTALL_KEY);
-    if (!flag) {
-      await AsyncStorage.setItem(FIRST_INSTALL_KEY, 'true');
-      return true;
-    }
-    return false;
-  } catch (error) {
-    console.error('[VersionUtils] Failed to check first install:', error);
-    return false;
   }
 }
 
@@ -96,19 +78,11 @@ export async function hasVersionChanged(): Promise<boolean> {
   try {
     const currentVersion = getCurrentVersion();
     const lastSeenVersion = await getLastSeenVersion();
-    const firstInstall = await isFirstInstall();
 
     console.log('[VersionUtils] Current version:', currentVersion);
     console.log('[VersionUtils] Last seen version:', lastSeenVersion);
-    console.log('[VersionUtils] First install:', firstInstall);
 
-    // Don't show on first install
-    if (firstInstall) {
-      await markVersionAsSeen();
-      return false;
-    }
-
-    // Show if no version seen (updating from pre-changelog version)
+    // Show if no version seen (first install or pre-changelog update)
     if (!lastSeenVersion) {
       return true;
     }


### PR DESCRIPTION
## Summary
- Removed the first-install early return that silently skipped the What's New modal for new users
- Removed the now-unused `isFirstInstall()` function and `FIRST_INSTALL_KEY` constant
- New installs now flow through the `!lastSeenVersion` check, showing all changelog entries up to the current version

## Test plan
- [ ] Reset version tracking (DevMenu → "Test What's New Modal" or clear AsyncStorage)
- [ ] Clear `@bayaan_first_install` key from AsyncStorage
- [ ] Relaunch app — What's New modal should appear
- [ ] Dismiss modal, relaunch — modal should NOT appear again
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)