### PR TITLE
refactor: redesign settings screens to match unified design system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,81 @@ export const MyComponent: React.FC<MyComponentProps> = ({ title, onPress }) => {
 
 ---
 
+## Design System
+
+**Always use the `frontend-design` skill when making UI decisions.**
+
+The app uses a unified alpha-based color system derived from `theme.colors.text` and `theme.colors.textSecondary`. Never use `theme.colors.primary` or accent colors for UI chrome. Reference implementations: `MushafSettingsContent.tsx`, `VerseActionsSheet.tsx`.
+
+### Color Tokens
+
+| Token | Value | Usage |
+|---|---|---|
+| Card bg | `Color(theme.colors.text).alpha(0.04)` | Surface backgrounds |
+| Card border | `Color(theme.colors.text).alpha(0.06)` | 1px borders on cards |
+| Divider | `Color(theme.colors.text).alpha(0.06)` | Hairline separators inside cards |
+| Pressed bg | `Color(theme.colors.text).alpha(0.06)` | Pressable feedback |
+| Secondary bg | `Color(theme.colors.text).alpha(0.08)` | Selected/active cards |
+| Switch track off | `Color(theme.colors.text).alpha(0.1)` | Switch inactive |
+| Segmented active | `Color(theme.colors.text).alpha(0.12)` | Active segment bg |
+| Chevron | `Color(theme.colors.text).alpha(0.2)` | Nav arrows |
+| Icon | `Color(theme.colors.text).alpha(0.7)` | Secondary icons |
+| Option label | `Color(theme.colors.text).alpha(0.85)` | Row labels |
+| Switch track on | `Color(theme.colors.text).alpha(0.65)` | Switch active |
+| Section header | `Color(theme.colors.textSecondary).alpha(0.5)` | ALL CAPS labels |
+| Hint/description | `Color(theme.colors.textSecondary).alpha(0.45)` | Sub-text, descriptions |
+| Switch thumb | `#FFFFFF` | Always white |
+| Primary btn bg | `theme.colors.text` | Action buttons |
+| Primary btn text | `theme.colors.background` | Button text |
+
+### Typography
+
+| Role | Font | Size | Extra |
+|---|---|---|---|
+| Section header | `Manrope-SemiBold` | `ms(10.5)` | `uppercase`, `letterSpacing: 1.2` |
+| Option label | `Manrope-Medium` | `ms(13.5)` | |
+| Description | `Manrope-Regular` | `ms(11-11.5)` | |
+| Hint text | `Manrope-Regular` | `ms(11.5)` | |
+| Primary btn | `Manrope-SemiBold` | `ms(15)` | |
+
+### Card Pattern
+
+```tsx
+backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+borderWidth: 1,
+borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+borderRadius: moderateScale(14),
+overflow: 'hidden',
+```
+
+### Grouped Card with Dividers
+
+Use a single wrapping card with hairline dividers between rows:
+
+```tsx
+<View style={styles.card}>
+  {items.map((item, idx) => (
+    <React.Fragment key={item.key}>
+      {idx > 0 && <View style={styles.divider} />}
+      <Pressable style={({pressed}) => [styles.row, pressed && styles.pressed]}>
+        {/* row content */}
+      </Pressable>
+    </React.Fragment>
+  ))}
+</View>
+```
+
+### Switch Pattern
+
+```tsx
+trackColor={{ false: Color(theme.colors.text).alpha(0.1).toString(), true: Color(theme.colors.text).alpha(0.65).toString() }}
+thumbColor="#FFFFFF"
+ios_backgroundColor={trackColor.false}
+style={{ transform: [{ scaleX: 0.8 }, { scaleY: 0.8 }] }}
+```
+
+---
+
 ## Performance Optimization
 
 ### React Native Best Practices

--- a/app/(tabs)/(a.home)/settings/about.tsx
+++ b/app/(tabs)/(a.home)/settings/about.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {View, Text, ScrollView, Image} from 'react-native';
 import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
@@ -12,19 +12,13 @@ import {VersionDisplay} from '@/components/VersionDisplay';
 interface FeatureProps {
   title: string;
   description: string;
-  theme: Theme;
   styles: ReturnType<typeof createStyles>;
 }
 
-const Feature = ({title, description, theme, styles}: FeatureProps) => (
+const Feature = ({title, description, styles}: FeatureProps) => (
   <View style={styles.featureItem}>
-    <Text style={[styles.featureTitle, {color: theme.colors.text}]}>
-      {title}
-    </Text>
-    <Text
-      style={[styles.featureDescription, {color: theme.colors.textSecondary}]}>
-      {description}
-    </Text>
+    <Text style={styles.featureTitle}>{title}</Text>
+    <Text style={styles.featureDescription}>{description}</Text>
   </View>
 );
 
@@ -32,7 +26,7 @@ export default function AboutScreen() {
   const {theme} = useTheme();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const styles = createStyles(theme);
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   return (
     <View style={styles.container}>
@@ -52,16 +46,13 @@ export default function AboutScreen() {
 
           <VersionDisplay style={styles.version} />
 
-          <Text style={[styles.tagline, {color: theme.colors.text}]}>
+          <Text style={styles.tagline}>
             Your Companion for Quranic Recitation
           </Text>
 
           <View style={styles.section}>
-            <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-              Alhamdulillah
-            </Text>
-            <Text
-              style={[styles.sectionText, {color: theme.colors.textSecondary}]}>
+            <Text style={styles.contentHeading}>Alhamdulillah</Text>
+            <Text style={styles.bodyText}>
               All praise is due to Allah for blessing us with the opportunity to
               serve His Book and the Ummah. We are deeply grateful for being
               chosen to develop this platform that connects people with the
@@ -70,11 +61,8 @@ export default function AboutScreen() {
           </View>
 
           <View style={styles.section}>
-            <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-              Our Mission
-            </Text>
-            <Text
-              style={[styles.sectionText, {color: theme.colors.textSecondary}]}>
+            <Text style={styles.contentHeading}>Our Mission</Text>
+            <Text style={styles.bodyText}>
               Bayaan is dedicated to making the beautiful recitation of the Holy
               Quran accessible to everyone. We strive to provide a serene and
               intuitive experience for listening to the Quran, featuring the
@@ -83,61 +71,49 @@ export default function AboutScreen() {
           </View>
 
           <View style={styles.section}>
-            <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-              Features
-            </Text>
+            <Text style={styles.sectionHeader}>FEATURES</Text>
             <View style={styles.featureList}>
               <Feature
                 title="Offline Downloads"
                 description="Download surahs for offline listening anytime, anywhere without internet connection"
-                theme={theme}
                 styles={styles}
               />
               <Feature
                 title="Custom Playlists"
                 description="Create and manage your own personalized playlists of your favorite recitations"
-                theme={theme}
                 styles={styles}
               />
               <Feature
                 title="Browse by Juz"
                 description="Easily navigate through the Quran with Juz-based organization and grouping"
-                theme={theme}
                 styles={styles}
               />
               <Feature
                 title="Advanced Audio Controls"
                 description="Precise playback control with continuous play and adjustable recitation speed"
-                theme={theme}
                 styles={styles}
               />
               <Feature
                 title="High-Quality Audio"
                 description="Crystal clear recitations from the world's best Qaris with optimized streaming"
-                theme={theme}
                 styles={styles}
               />
               <Feature
                 title="Curated Collections"
                 description="Thoughtfully organized surahs for different occasions and themes"
-                theme={theme}
                 styles={styles}
               />
               <Feature
                 title="Personalization"
                 description="Customize themes, accent colors, and audio settings to your liking"
-                theme={theme}
                 styles={styles}
               />
             </View>
           </View>
 
           <View style={styles.section}>
-            <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-              Coming Soon, InshaAllah
-            </Text>
-            <Text
-              style={[styles.sectionText, {color: theme.colors.textSecondary}]}>
+            <Text style={styles.sectionHeader}>COMING SOON</Text>
+            <Text style={styles.bodyText}>
               We&apos;re working hard to bring you even more features to enhance
               your Quranic journey, including:
             </Text>
@@ -145,42 +121,34 @@ export default function AboutScreen() {
               <Feature
                 title="Multiple Translations"
                 description="Access Quran translations in various languages to better understand the meanings"
-                theme={theme}
                 styles={styles}
               />
               <Feature
                 title="Word-by-Word Follow Along"
                 description="Real-time word highlighting synchronized with recitations to help you follow and learn"
-                theme={theme}
                 styles={styles}
               />
               <Feature
                 title="Smart Bookmarking"
                 description="Save your favorite verses and track your progress across surahs"
-                theme={theme}
                 styles={styles}
               />
               <Feature
                 title="Learning Tools"
                 description="Interactive features to help you memorize and understand the Quran better"
-                theme={theme}
                 styles={styles}
               />
               <Feature
                 title="Community Features"
                 description="Connect with others, share your journey, and grow together in your Quranic experience"
-                theme={theme}
                 styles={styles}
               />
             </View>
           </View>
 
           <View style={styles.section}>
-            <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-              Our Commitment
-            </Text>
-            <Text
-              style={[styles.sectionText, {color: theme.colors.textSecondary}]}>
+            <Text style={styles.contentHeading}>Our Commitment</Text>
+            <Text style={styles.bodyText}>
               We are committed to continuous improvement and maintaining the
               highest standards of quality. Our team works diligently to ensure
               that Bayaan remains a reliable and respectful platform for Quranic
@@ -205,9 +173,6 @@ const createStyles = (theme: Theme) =>
     content: {
       flex: 1,
     },
-    scrollView: {
-      flex: 1,
-    },
     scrollContent: {
       paddingHorizontal: moderateScale(24),
       paddingVertical: moderateScale(20),
@@ -224,45 +189,61 @@ const createStyles = (theme: Theme) =>
     },
     version: {
       textAlign: 'center',
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.regular,
+      fontSize: moderateScale(13),
+      fontFamily: 'Manrope-Regular',
       marginBottom: moderateScale(8),
     },
     tagline: {
       textAlign: 'center',
-      fontSize: moderateScale(20),
-      fontFamily: theme.fonts.semiBold,
+      fontSize: moderateScale(17),
+      fontFamily: 'Manrope-SemiBold',
+      color: theme.colors.text,
       marginBottom: moderateScale(32),
     },
     section: {
-      marginBottom: moderateScale(32),
+      marginBottom: moderateScale(28),
     },
-    sectionTitle: {
-      fontSize: moderateScale(18),
-      fontFamily: theme.fonts.semiBold,
-      marginBottom: moderateScale(12),
+    sectionHeader: {
+      fontSize: moderateScale(10.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+      letterSpacing: 1.2,
+      textTransform: 'uppercase',
+      marginBottom: moderateScale(10),
+      marginLeft: moderateScale(2),
     },
-    sectionText: {
-      fontSize: moderateScale(16),
-      fontFamily: theme.fonts.regular,
-      lineHeight: moderateScale(24),
+    contentHeading: {
+      fontSize: moderateScale(14),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
+      marginBottom: moderateScale(10),
+    },
+    bodyText: {
+      fontSize: moderateScale(13),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
+      lineHeight: moderateScale(20),
     },
     featureList: {
-      gap: moderateScale(16),
+      gap: moderateScale(10),
     },
     featureItem: {
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
-      padding: moderateScale(16),
-      borderRadius: moderateScale(12),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      padding: moderateScale(14),
+      borderRadius: moderateScale(14),
     },
     featureTitle: {
-      fontSize: moderateScale(16),
-      fontFamily: theme.fonts.semiBold,
-      marginBottom: moderateScale(4),
+      fontSize: moderateScale(13.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
+      marginBottom: moderateScale(3),
     },
     featureDescription: {
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.regular,
-      lineHeight: moderateScale(20),
+      fontSize: moderateScale(11.5),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
+      lineHeight: moderateScale(17),
     },
   });

--- a/app/(tabs)/(a.home)/settings/credits.tsx
+++ b/app/(tabs)/(a.home)/settings/credits.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import {View, Text, ScrollView, TouchableOpacity, Linking} from 'react-native';
+import React, {useMemo} from 'react';
+import {View, Text, ScrollView, Pressable, Linking} from 'react-native';
 import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
@@ -123,7 +123,10 @@ export default function CreditsScreen() {
   const {theme} = useTheme();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const styles = createStyles(theme);
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const linkIconColor = Color(theme.colors.text).alpha(0.35).toString();
+  const pressedBg = Color(theme.colors.text).alpha(0.06).toString();
 
   const handleLinkPress = async (url?: string) => {
     if (url) {
@@ -139,65 +142,52 @@ export default function CreditsScreen() {
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}>
         <View>
-          <Text style={[styles.introText, {color: theme.colors.textSecondary}]}>
+          <Text style={styles.introText}>
             Bayaan wouldn&apos;t be possible without the incredible work of
             these projects, organizations, and individuals. We&apos;re deeply
             grateful for their contributions to the Muslim community and the
             tech world.
           </Text>
 
-          {CREDITS.map((section, sectionIndex) => (
+          {CREDITS.map(section => (
             <View key={section.section} style={styles.section}>
-              <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-                {section.section}
+              <Text style={styles.sectionHeader}>
+                {section.section.toUpperCase()}
               </Text>
-              <View style={styles.creditsList}>
+              <View style={styles.card}>
                 {section.items.map((item, index) => (
-                  <TouchableOpacity
-                    key={index}
-                    activeOpacity={item.link ? 0.7 : 1}
-                    onPress={() => handleLinkPress(item.link)}
-                    style={[
-                      styles.creditItem,
-                      {
-                        backgroundColor: Color(theme.colors.card)
-                          .alpha(0.5)
-                          .toString(),
-                      },
-                    ]}>
-                    <View style={styles.creditContent}>
-                      <Text
-                        style={[
-                          styles.creditTitle,
-                          {color: theme.colors.text},
-                        ]}>
-                        {item.title}
-                      </Text>
-                      <Text
-                        style={[
-                          styles.creditDescription,
-                          {color: theme.colors.textSecondary},
-                        ]}>
-                        {item.description}
-                      </Text>
-                    </View>
-                    {item.link && (
-                      <Feather
-                        name="external-link"
-                        size={moderateScale(16)}
-                        color={theme.colors.textSecondary}
-                      />
-                    )}
-                  </TouchableOpacity>
+                  <React.Fragment key={index}>
+                    {index > 0 && <View style={styles.divider} />}
+                    <Pressable
+                      style={({pressed}) => [
+                        styles.creditRow,
+                        pressed && item.link
+                          ? {backgroundColor: pressedBg}
+                          : null,
+                      ]}
+                      onPress={() => handleLinkPress(item.link)}
+                      disabled={!item.link}>
+                      <View style={styles.creditContent}>
+                        <Text style={styles.creditTitle}>{item.title}</Text>
+                        <Text style={styles.creditDescription}>
+                          {item.description}
+                        </Text>
+                      </View>
+                      {item.link && (
+                        <Feather
+                          name="external-link"
+                          size={moderateScale(14)}
+                          color={linkIconColor}
+                        />
+                      )}
+                    </Pressable>
+                  </React.Fragment>
                 ))}
               </View>
             </View>
           ))}
 
-          <Text
-            style={[styles.footerText, {color: theme.colors.textSecondary}]}>
-            Made with ❤️ by the Bayaan team
-          </Text>
+          <Text style={styles.footerText}>Made with ❤️ by the Bayaan team</Text>
         </View>
       </ScrollView>
     </View>
@@ -214,52 +204,68 @@ const createStyles = (theme: Theme) =>
       flex: 1,
     },
     scrollContent: {
-      paddingHorizontal: moderateScale(24),
+      paddingHorizontal: moderateScale(20),
       paddingVertical: moderateScale(20),
       paddingBottom: moderateScale(160),
     },
     introText: {
-      fontSize: moderateScale(16),
-      fontFamily: theme.fonts.regular,
-      lineHeight: moderateScale(24),
-      marginBottom: moderateScale(32),
+      fontSize: moderateScale(13),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
+      lineHeight: moderateScale(20),
+      marginBottom: moderateScale(28),
       textAlign: 'center',
     },
     section: {
-      marginBottom: moderateScale(24),
+      marginBottom: moderateScale(20),
     },
-    sectionTitle: {
-      fontSize: moderateScale(18),
-      fontFamily: theme.fonts.semiBold,
-      marginBottom: moderateScale(12),
-      marginLeft: moderateScale(4),
+    sectionHeader: {
+      fontSize: moderateScale(10.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+      letterSpacing: 1.2,
+      textTransform: 'uppercase',
+      marginBottom: moderateScale(6),
+      marginLeft: moderateScale(2),
     },
-    creditsList: {
-      gap: moderateScale(8),
+    card: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderRadius: moderateScale(14),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      overflow: 'hidden',
     },
-    creditItem: {
+    divider: {
+      height: 1,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      marginHorizontal: moderateScale(16),
+    },
+    creditRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      padding: moderateScale(16),
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(12),
+      paddingHorizontal: moderateScale(16),
     },
     creditContent: {
       flex: 1,
       marginRight: moderateScale(12),
     },
     creditTitle: {
-      fontSize: moderateScale(16),
-      fontFamily: theme.fonts.semiBold,
+      fontSize: moderateScale(13.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
       marginBottom: moderateScale(2),
     },
     creditDescription: {
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.regular,
+      fontSize: moderateScale(11.5),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
     },
     footerText: {
       textAlign: 'center',
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.medium,
-      marginTop: moderateScale(32),
+      fontSize: moderateScale(13),
+      fontFamily: 'Manrope-Medium',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
+      marginTop: moderateScale(24),
     },
   });

--- a/app/(tabs)/(a.home)/settings/default-reciter.tsx
+++ b/app/(tabs)/(a.home)/settings/default-reciter.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback} from 'react';
+import React, {useState, useCallback, useMemo} from 'react';
 import {View, Text, FlatList} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {
@@ -7,6 +7,7 @@ import {
   verticalScale,
 } from 'react-native-size-matters';
 import {Theme} from '@/utils/themeUtils';
+import Color from 'color';
 import SearchBar from '@/components/SearchBar';
 import {RECITERS, Reciter} from '@/data/reciterData';
 import {ReciterItem} from '@/components/ReciterItem';
@@ -20,13 +21,12 @@ export default function DefaultReciterScreen() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<Reciter[]>([]);
   const {theme} = useTheme();
-  const styles = createStyles(theme);
+  const styles = useMemo(() => createStyles(theme), [theme]);
   const defaultReciter = useReciterStore(state => state.defaultReciter);
   const setDefaultReciter = useReciterStore(state => state.setDefaultReciter);
   const router = useRouter();
   const insets = useSafeAreaInsets();
 
-  // Helper function to check if a reciter has complete Quran
   const hasCompleteQuran = useCallback((reciter: Reciter) => {
     return reciter.rewayat.some(
       r => r.surah_list?.filter(id => id !== null).length === 114,
@@ -90,18 +90,10 @@ export default function DefaultReciterScreen() {
                 style={styles.currentReciterImage}
               />
               <View style={styles.currentReciterInfo}>
-                <Text
-                  style={[
-                    styles.currentReciterName,
-                    {color: theme.colors.text},
-                  ]}>
+                <Text style={styles.currentReciterName}>
                   {defaultReciter.name}
                 </Text>
-                <Text
-                  style={[
-                    styles.currentReciterMoshaf,
-                    {color: theme.colors.textSecondary},
-                  ]}>
+                <Text style={styles.currentReciterMoshaf}>
                   {defaultReciter.rewayat[0].name}
                 </Text>
               </View>
@@ -110,9 +102,7 @@ export default function DefaultReciterScreen() {
         )}
 
         <View style={styles.searchSection}>
-          <Text style={[styles.searchLabel, {color: theme.colors.text}]}>
-            Change Default Reciter
-          </Text>
+          <Text style={styles.searchLabel}>CHANGE DEFAULT RECITER</Text>
           <View style={styles.searchContainer}>
             <SearchBar
               placeholder="Search reciters..."
@@ -128,8 +118,7 @@ export default function DefaultReciterScreen() {
           keyExtractor={item => item.id}
           style={styles.reciterList}
           ListEmptyComponent={
-            <Text
-              style={[styles.emptyText, {color: theme.colors.textSecondary}]}>
+            <Text style={styles.emptyText}>
               {searchQuery.trim() === ''
                 ? 'Only reciters with complete Quran are shown'
                 : 'No reciters found'}
@@ -152,19 +141,22 @@ const createStyles = (theme: Theme) =>
       paddingHorizontal: moderateScale(16),
     },
     currentReciterContainer: {
-      padding: moderateScale(20),
-      marginBottom: verticalScale(20),
-      borderRadius: moderateScale(12),
+      padding: moderateScale(16),
+      marginBottom: verticalScale(16),
+      borderRadius: moderateScale(14),
       marginHorizontal: moderateScale(15),
       marginTop: moderateScale(15),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     currentReciterContent: {
       flexDirection: 'row',
       alignItems: 'center',
     },
     currentReciterImage: {
-      width: moderateScale(80),
-      height: moderateScale(80),
+      width: moderateScale(72),
+      height: moderateScale(72),
       borderRadius: moderateScale(10),
       marginRight: moderateScale(15),
     },
@@ -172,20 +164,27 @@ const createStyles = (theme: Theme) =>
       flex: 1,
     },
     currentReciterName: {
-      fontSize: moderateScale(20),
-      fontWeight: 'bold',
+      fontSize: moderateScale(16),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
       marginBottom: verticalScale(4),
     },
     currentReciterMoshaf: {
-      fontSize: moderateScale(14),
+      fontSize: moderateScale(12),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
     },
     searchSection: {
       paddingHorizontal: moderateScale(15),
     },
     searchLabel: {
-      fontSize: moderateScale(16),
-      fontWeight: 'bold',
-      marginBottom: verticalScale(10),
+      fontSize: moderateScale(10.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+      letterSpacing: 1.2,
+      textTransform: 'uppercase',
+      marginBottom: verticalScale(8),
+      marginLeft: moderateScale(2),
     },
     searchContainer: {
       marginBottom: verticalScale(15),
@@ -195,7 +194,9 @@ const createStyles = (theme: Theme) =>
       paddingHorizontal: moderateScale(15),
     },
     emptyText: {
-      fontSize: moderateScale(16),
+      fontSize: moderateScale(13),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
       textAlign: 'center',
       paddingVertical: moderateScale(15),
     },

--- a/app/(tabs)/(a.home)/settings/index.tsx
+++ b/app/(tabs)/(a.home)/settings/index.tsx
@@ -1,12 +1,5 @@
-import React from 'react';
-import {
-  Text,
-  TouchableOpacity,
-  ScrollView,
-  View,
-  Linking,
-  Switch,
-} from 'react-native';
+import React, {useMemo} from 'react';
+import {Text, Pressable, ScrollView, View, Linking, Switch} from 'react-native';
 import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
@@ -21,8 +14,6 @@ import {openAppStoreForReview, markAsRated} from '@/utils/reviewUtils';
 import {QuranIcon} from '@/components/Icons';
 import {useDevSettingsStore} from '@/store/devSettingsStore';
 
-// App Store IDs - Replace with your actual IDs
-
 const formatColorName = (colorName: string): string => {
   return colorName
     .replace(/([A-Z])/g, ' $1')
@@ -32,7 +23,6 @@ const formatColorName = (colorName: string): string => {
     .join(' ');
 };
 
-// Helper function to determine if a setting is an external link
 const isExternalLink = (type: string): boolean => {
   return ['support', 'featureRequest', 'terms', 'privacy', 'rateApp'].includes(
     type,
@@ -82,7 +72,6 @@ const settingsItems = [
         icon: 'users',
         iconType: 'feather',
       },
-      // Add more audio settings here as needed
     ],
   },
   {
@@ -95,8 +84,6 @@ const settingsItems = [
         icon: 'hard-drive',
         iconType: 'feather',
       },
-
-      // Add more app settings here as needed
     ],
   },
   {
@@ -167,14 +154,49 @@ const settingsItems = [
   },
 ];
 
+const renderIcon = (
+  item: {icon: string; iconType: string},
+  iconColor: string,
+) => {
+  if (item.iconType === 'custom' && item.icon === 'quran') {
+    return <QuranIcon size={moderateScale(20)} color={iconColor} />;
+  }
+  if (item.iconType === 'material') {
+    return (
+      <MaterialIcons
+        name={item.icon as any}
+        size={moderateScale(20)}
+        color={iconColor}
+      />
+    );
+  }
+  return (
+    <Feather
+      name={item.icon as any}
+      size={moderateScale(20)}
+      color={iconColor}
+    />
+  );
+};
+
 export default function SettingsScreen() {
   const router = useRouter();
   const {theme, themeMode, setThemeMode, primaryColor, setPrimaryColor} =
     useTheme();
   const insets = useSafeAreaInsets();
-  const styles = createStyles(theme);
-  const [pressedOption, setPressedOption] = React.useState<string | null>(null);
+  const styles = useMemo(() => createStyles(theme), [theme]);
   const {showFloatingDevMenu, toggleFloatingDevMenu} = useDevSettingsStore();
+
+  const iconColor = Color(theme.colors.text).alpha(0.7).toString();
+  const chevronColor = Color(theme.colors.text).alpha(0.2).toString();
+
+  const trackColor = useMemo(
+    () => ({
+      false: Color(theme.colors.text).alpha(0.1).toString(),
+      true: Color(theme.colors.text).alpha(0.65).toString(),
+    }),
+    [theme.colors.text],
+  );
 
   const handleSettingPress = async (type: string) => {
     switch (type) {
@@ -194,9 +216,7 @@ export default function SettingsScreen() {
         await clearPlayerCache();
         break;
       case 'rateApp':
-        // Mark that the user has manually chosen to rate the app
         await markAsRated();
-        // Open the app store for review
         await openAppStoreForReview();
         break;
       case 'whatsNew':
@@ -235,103 +255,88 @@ export default function SettingsScreen() {
           {paddingTop: insets.top + moderateScale(56)},
         ]}
         showsVerticalScrollIndicator={false}>
+        {/* Theme Selector */}
         <View style={styles.section}>
-          <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-            Theme
-          </Text>
-          <View style={styles.themeContainer}>
-            {themeOptions.map((option, index) => (
-              <TouchableOpacity
-                activeOpacity={1}
-                key={option.value}
-                style={[
-                  styles.themeOption,
-                  {
-                    backgroundColor:
-                      themeMode === option.value
-                        ? Color(theme.colors.text).alpha(0.1).toString()
-                        : Color(theme.colors.card).alpha(0.5).toString(),
-                    borderWidth: themeMode === option.value ? 1.5 : 0,
-                    borderColor: theme.colors.text,
-                  },
-                  index === 0 && styles.firstThemeOption,
-                  index === themeOptions.length - 1 && styles.lastThemeOption,
-                  pressedOption === `theme-${option.value}` &&
-                    styles.optionPressed,
-                ]}
-                onPress={() => setThemeMode(option.value)}
-                onPressIn={() => setPressedOption(`theme-${option.value}`)}
-                onPressOut={() => setPressedOption(null)}>
-                <View style={styles.themeContent}>
-                  <View style={[styles.iconContainer]}>
+          <Text style={styles.sectionHeader}>THEME</Text>
+          <View style={styles.segmentedTrack}>
+            {themeOptions.map(option => {
+              const isActive = themeMode === option.value;
+              return (
+                <Pressable
+                  key={option.value}
+                  style={[styles.segment, isActive && styles.segmentActive]}
+                  onPress={() => setThemeMode(option.value)}>
+                  <View style={styles.segmentIconWrap}>
                     {option.iconType === 'ionicon' ? (
                       <Ionicons
                         name={option.icon as any}
-                        size={moderateScale(20)}
-                        color={theme.colors.text}
+                        size={moderateScale(16)}
+                        color={
+                          isActive
+                            ? theme.colors.text
+                            : Color(theme.colors.textSecondary)
+                                .alpha(0.6)
+                                .toString()
+                        }
                       />
                     ) : (
                       <Feather
                         name={option.icon as any}
-                        size={moderateScale(20)}
-                        color={theme.colors.text}
+                        size={moderateScale(16)}
+                        color={
+                          isActive
+                            ? theme.colors.text
+                            : Color(theme.colors.textSecondary)
+                                .alpha(0.6)
+                                .toString()
+                        }
                       />
                     )}
                   </View>
                   <Text
                     style={[
-                      styles.themeText,
+                      styles.segmentText,
                       {
-                        color: theme.colors.text,
-                        fontFamily:
-                          themeMode === option.value
-                            ? theme.fonts.semiBold
-                            : theme.fonts.regular,
+                        color: isActive
+                          ? theme.colors.text
+                          : Color(theme.colors.textSecondary)
+                              .alpha(0.6)
+                              .toString(),
+                        fontFamily: isActive
+                          ? 'Manrope-SemiBold'
+                          : 'Manrope-Medium',
                       },
                     ]}>
                     {option.label}
                   </Text>
-                </View>
-              </TouchableOpacity>
-            ))}
+                </Pressable>
+              );
+            })}
           </View>
         </View>
 
-        <View style={[styles.section, styles.colorSection]}>
-          <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-            Accent Color
-          </Text>
+        {/* Accent Color */}
+        <View style={styles.section}>
+          <Text style={styles.sectionHeader}>ACCENT COLOR</Text>
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.colorScrollContent}>
             {Object.entries(primaryColors).map(([color, value]) => {
+              const isSelected = primaryColor === color;
               return (
-                <TouchableOpacity
-                  activeOpacity={1}
+                <Pressable
                   key={color}
-                  style={[
-                    styles.colorOptionContainer,
-                    pressedOption === `color-${color}` &&
-                      styles.colorOptionPressed,
-                  ]}
-                  onPress={() => setPrimaryColor(color as PrimaryColor)}
-                  onPressIn={() => setPressedOption(`color-${color}`)}
-                  onPressOut={() => setPressedOption(null)}>
+                  style={styles.colorOptionContainer}
+                  onPress={() => setPrimaryColor(color as PrimaryColor)}>
                   <View
                     style={[
                       styles.colorOption,
                       {
                         backgroundColor: value,
-                        borderColor:
-                          primaryColor === color
-                            ? theme.colors.text
-                            : 'transparent',
-                        shadowColor: value,
-                        shadowOffset: {width: 0, height: 2},
-                        shadowOpacity: 0.25,
-                        shadowRadius: 3.84,
-                        elevation: 5,
+                        borderColor: isSelected
+                          ? Color(theme.colors.text).alpha(0.4).toString()
+                          : Color(theme.colors.text).alpha(0.08).toString(),
                       },
                     ]}
                   />
@@ -339,134 +344,91 @@ export default function SettingsScreen() {
                     style={[
                       styles.colorLabel,
                       {
-                        color:
-                          primaryColor === color
-                            ? theme.colors.text
-                            : theme.colors.textSecondary,
-                        fontFamily:
-                          primaryColor === color
-                            ? theme.fonts.medium
-                            : theme.fonts.regular,
+                        color: isSelected
+                          ? Color(theme.colors.text).alpha(0.85).toString()
+                          : Color(theme.colors.textSecondary)
+                              .alpha(0.45)
+                              .toString(),
+                        fontFamily: isSelected
+                          ? 'Manrope-Medium'
+                          : 'Manrope-Regular',
                       },
                     ]}>
                     {formatColorName(color)}
                   </Text>
-                </TouchableOpacity>
+                </Pressable>
               );
             })}
           </ScrollView>
         </View>
 
+        {/* Settings Sections */}
         {settingsItems.map(section => (
           <View key={section.section} style={styles.section}>
-            <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-              {section.section}
+            <Text style={styles.sectionHeader}>
+              {section.section.toUpperCase()}
             </Text>
-            <View style={styles.settingsGroup}>
+            <View style={styles.card}>
               {section.items.map((item, itemIndex) => (
-                <TouchableOpacity
-                  key={item.type}
-                  style={[
-                    styles.settingsItem,
-                    styles.settingsItemCard,
-                    itemIndex > 0 && styles.settingsItemMarginTop,
-                    pressedOption === `setting-${item.type}` &&
-                      styles.optionPressed,
-                  ]}
-                  onPress={() => handleSettingPress(item.type)}
-                  onPressIn={() => setPressedOption(`setting-${item.type}`)}
-                  onPressOut={() => setPressedOption(null)}
-                  activeOpacity={1}>
-                  <View style={styles.settingsItemContent}>
+                <React.Fragment key={item.type}>
+                  {itemIndex > 0 && <View style={styles.divider} />}
+                  <Pressable
+                    style={({pressed}) => [
+                      styles.settingsRow,
+                      pressed && styles.pressed,
+                    ]}
+                    onPress={() => handleSettingPress(item.type)}>
                     <View style={styles.settingsItemIcon}>
-                      {item.iconType === 'custom' && item.icon === 'quran' ? (
-                        <QuranIcon
-                          size={moderateScale(24)}
-                          color={theme.colors.textSecondary}
-                        />
-                      ) : item.iconType === 'material' ? (
-                        <MaterialIcons
-                          name={item.icon as any}
-                          size={moderateScale(20)}
-                          color={theme.colors.textSecondary}
-                        />
-                      ) : (
-                        <Feather
-                          name={item.icon as any}
-                          size={moderateScale(20)}
-                          color={theme.colors.textSecondary}
-                        />
-                      )}
+                      {renderIcon(item, iconColor)}
                     </View>
                     <View style={styles.settingsTextContainer}>
-                      <Text
-                        style={[
-                          styles.settingsTitle,
-                          {color: theme.colors.text},
-                        ]}>
-                        {item.title}
-                      </Text>
-                      <Text
-                        style={[
-                          styles.settingsDescription,
-                          {color: theme.colors.textSecondary},
-                        ]}>
+                      <Text style={styles.settingsTitle}>{item.title}</Text>
+                      <Text style={styles.settingsDescription}>
                         {item.description}
                       </Text>
                     </View>
-                    <View style={{opacity: 0.6}}>
-                      <Feather
-                        name={
-                          isExternalLink(item.type)
-                            ? 'external-link'
-                            : 'arrow-right'
-                        }
-                        size={moderateScale(20)}
-                        color={theme.colors.textSecondary}
-                      />
-                    </View>
-                  </View>
-                </TouchableOpacity>
+                    <Feather
+                      name={
+                        isExternalLink(item.type)
+                          ? 'external-link'
+                          : 'chevron-right'
+                      }
+                      size={moderateScale(16)}
+                      color={chevronColor}
+                    />
+                  </Pressable>
+                </React.Fragment>
               ))}
             </View>
           </View>
         ))}
 
+        {/* Developer Section */}
         {__DEV__ && (
           <View style={styles.section}>
-            <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-              Developer
-            </Text>
-            <View style={[styles.settingsItemCard, styles.settingsItem]}>
-              <View style={styles.settingsItemContent}>
+            <Text style={styles.sectionHeader}>DEVELOPER</Text>
+            <View style={styles.card}>
+              <View style={styles.settingsRow}>
                 <View style={styles.settingsItemIcon}>
                   <Feather
                     name="tool"
                     size={moderateScale(20)}
-                    color={theme.colors.textSecondary}
+                    color={iconColor}
                   />
                 </View>
                 <View style={styles.settingsTextContainer}>
-                  <Text
-                    style={[styles.settingsTitle, {color: theme.colors.text}]}>
-                    Floating Dev Menu
-                  </Text>
-                  <Text
-                    style={[
-                      styles.settingsDescription,
-                      {color: theme.colors.textSecondary},
-                    ]}>
+                  <Text style={styles.settingsTitle}>Floating Dev Menu</Text>
+                  <Text style={styles.settingsDescription}>
                     Show the floating developer tools button
                   </Text>
                 </View>
                 <Switch
                   value={showFloatingDevMenu}
                   onValueChange={toggleFloatingDevMenu}
-                  trackColor={{
-                    false: Color(theme.colors.text).alpha(0.15).toString(),
-                    true: Color(theme.colors.text).alpha(0.3).toString(),
-                  }}
-                  thumbColor={theme.colors.text}
+                  trackColor={trackColor}
+                  thumbColor="#FFFFFF"
+                  ios_backgroundColor={trackColor.false}
+                  style={styles.switchStyle}
                 />
               </View>
             </View>
@@ -488,47 +450,50 @@ const createStyles = (theme: Theme) =>
       paddingBottom: moderateScale(40),
     },
     section: {
-      marginBottom: moderateScale(24),
+      marginBottom: moderateScale(20),
     },
-    sectionTitle: {
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.medium,
-      marginBottom: moderateScale(8),
-      marginLeft: moderateScale(4),
+    sectionHeader: {
+      fontSize: moderateScale(10.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+      letterSpacing: 1.2,
+      textTransform: 'uppercase',
+      marginBottom: moderateScale(6),
+      marginLeft: moderateScale(2),
     },
-    themeContainer: {
+
+    // --- Theme Segmented Control ---
+    segmentedTrack: {
       flexDirection: 'row',
-      borderRadius: moderateScale(12),
-      overflow: 'hidden',
-      gap: moderateScale(8),
+      borderRadius: moderateScale(10),
+      padding: moderateScale(3),
+      backgroundColor: Color(theme.colors.text).alpha(0.05).toString(),
     },
-    themeOption: {
+    segment: {
       flex: 1,
-      paddingVertical: moderateScale(14),
+      paddingVertical: moderateScale(7),
+      borderRadius: moderateScale(8),
       alignItems: 'center',
       justifyContent: 'center',
-      borderRadius: moderateScale(12),
+      gap: moderateScale(3),
     },
-    themeContent: {
-      flexDirection: 'column',
-      alignItems: 'center',
-      gap: moderateScale(4),
+    segmentActive: {
+      backgroundColor: Color(theme.colors.text).alpha(0.12).toString(),
+      shadowColor: '#000',
+      shadowOffset: {width: 0, height: 1},
+      shadowOpacity: 0.06,
+      shadowRadius: 3,
+      elevation: 1,
     },
-    iconContainer: {
-      width: moderateScale(42),
-      height: moderateScale(42),
-      borderRadius: moderateScale(21),
-      alignItems: 'center',
+    segmentIconWrap: {
+      height: moderateScale(18),
       justifyContent: 'center',
-      borderColor: 'transparent',
     },
-    themeText: {
+    segmentText: {
       fontSize: moderateScale(11),
-      fontWeight: '500',
     },
-    colorSection: {
-      marginBottom: moderateScale(14),
-    },
+
+    // --- Accent Color ---
     colorScrollContent: {
       paddingHorizontal: moderateScale(4),
       gap: moderateScale(16),
@@ -549,31 +514,33 @@ const createStyles = (theme: Theme) =>
       fontSize: moderateScale(10),
       textAlign: 'center',
     },
-    settingsGroup: {
-      borderRadius: moderateScale(12),
+
+    // --- Cards ---
+    card: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderRadius: moderateScale(14),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
       overflow: 'hidden',
-      gap: moderateScale(1),
     },
-    settingsItem: {
+    divider: {
+      height: 1,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      marginHorizontal: moderateScale(16),
+    },
+
+    // --- Settings Rows ---
+    settingsRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      width: '100%',
+      paddingVertical: moderateScale(12),
+      paddingHorizontal: moderateScale(14),
     },
-    settingsItemCard: {
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
-      borderRadius: moderateScale(12),
-      padding: moderateScale(12),
-    },
-    settingsItemMarginTop: {
-      marginTop: moderateScale(8),
-    },
-    settingsItemContent: {
-      flex: 1,
-      flexDirection: 'row',
-      alignItems: 'center',
+    pressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     settingsItemIcon: {
-      marginRight: moderateScale(15),
+      marginRight: moderateScale(12),
       width: moderateScale(24),
       alignItems: 'center',
     },
@@ -582,28 +549,19 @@ const createStyles = (theme: Theme) =>
       marginRight: moderateScale(10),
     },
     settingsTitle: {
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.medium,
-      color: theme.colors.text,
+      fontSize: moderateScale(13.5),
+      fontFamily: 'Manrope-Medium',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
     },
     settingsDescription: {
       fontSize: moderateScale(11),
-      fontFamily: theme.fonts.regular,
-      color: theme.colors.textSecondary,
-      marginTop: moderateScale(2),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
+      marginTop: moderateScale(1),
     },
-    firstThemeOption: {
-      borderTopLeftRadius: moderateScale(12),
-      borderBottomLeftRadius: moderateScale(12),
-    },
-    lastThemeOption: {
-      borderTopRightRadius: moderateScale(12),
-      borderBottomRightRadius: moderateScale(12),
-    },
-    optionPressed: {
-      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
-    },
-    colorOptionPressed: {
-      opacity: 0.6,
+
+    // --- Switch ---
+    switchStyle: {
+      transform: [{scaleX: 0.8}, {scaleY: 0.8}],
     },
   });

--- a/app/(tabs)/(a.home)/settings/reciter-choice.tsx
+++ b/app/(tabs)/(a.home)/settings/reciter-choice.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import {View, Text, TouchableOpacity, Switch, ScrollView} from 'react-native';
+import React, {useMemo} from 'react';
+import {View, Text, Pressable, Switch, ScrollView} from 'react-native';
 import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
@@ -12,7 +12,7 @@ import {useSettings} from '@/hooks/useSettings';
 
 export default function ReciterChoiceScreen() {
   const {theme} = useTheme();
-  const styles = createStyles(theme);
+  const styles = useMemo(() => createStyles(theme), [theme]);
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const {
@@ -21,6 +21,14 @@ export default function ReciterChoiceScreen() {
     defaultReciterSelection,
     setDefaultReciterSelection,
   } = useSettings();
+
+  const trackColor = useMemo(
+    () => ({
+      false: Color(theme.colors.text).alpha(0.1).toString(),
+      true: Color(theme.colors.text).alpha(0.65).toString(),
+    }),
+    [theme.colors.text],
+  );
 
   const options = [
     {
@@ -49,70 +57,45 @@ export default function ReciterChoiceScreen() {
           {paddingTop: insets.top + moderateScale(56)},
         ]}
         showsVerticalScrollIndicator={false}>
-        <View>
-          <Text style={[styles.subtitle, {color: theme.colors.textSecondary}]}>
-            Choose how you want to select reciters when playing Surahs
-          </Text>
+        <Text style={styles.subtitle}>
+          Choose how you want to select reciters when playing Surahs
+        </Text>
 
-          <View style={styles.section}>
-            <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-              Selection Preference
-            </Text>
-            <View style={[styles.card, {backgroundColor: theme.colors.card}]}>
-              <View style={styles.settingRow}>
-                <View style={styles.settingInfo}>
-                  <Text
-                    style={[styles.settingTitle, {color: theme.colors.text}]}>
-                    Ask Every Time
-                  </Text>
-                  <Text
-                    style={[
-                      styles.settingDescription,
-                      {color: theme.colors.textSecondary},
-                    ]}>
-                    Choose a reciter each time you play
-                  </Text>
-                </View>
-                <Switch
-                  value={askEveryTime}
-                  onValueChange={() => setAskEveryTime(!askEveryTime)}
-                  trackColor={{
-                    false: Color(theme.colors.border).alpha(0.3).toString(),
-                    true: Color(theme.colors.text).alpha(0.6).toString(),
-                  }}
-                  thumbColor={theme.colors.background}
-                  ios_backgroundColor={Color(theme.colors.border)
-                    .alpha(0.3)
-                    .toString()}
-                />
+        <View style={styles.section}>
+          <Text style={styles.sectionHeader}>SELECTION PREFERENCE</Text>
+          <View style={styles.card}>
+            <View style={styles.settingRow}>
+              <View style={styles.settingInfo}>
+                <Text style={styles.settingTitle}>Ask Every Time</Text>
+                <Text style={styles.settingDescription}>
+                  Choose a reciter each time you play
+                </Text>
               </View>
+              <Switch
+                value={askEveryTime}
+                onValueChange={() => setAskEveryTime(!askEveryTime)}
+                trackColor={trackColor}
+                thumbColor="#FFFFFF"
+                ios_backgroundColor={trackColor.false}
+                style={styles.switchStyle}
+              />
             </View>
           </View>
+        </View>
 
-          {!askEveryTime && (
-            <View style={styles.section}>
-              <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
-                Default Selection Method
-              </Text>
-              <View style={styles.optionsContainer}>
-                {options.map(option => (
-                  <TouchableOpacity
-                    activeOpacity={0.7}
+        {!askEveryTime && (
+          <View style={styles.section}>
+            <Text style={styles.sectionHeader}>DEFAULT SELECTION METHOD</Text>
+            <View style={styles.optionsContainer}>
+              {options.map(option => {
+                const isSelected = defaultReciterSelection === option.action;
+                return (
+                  <Pressable
                     key={option.action}
-                    style={[
+                    style={({pressed}) => [
                       styles.card,
-                      {backgroundColor: theme.colors.card},
-                      defaultReciterSelection === option.action && [
-                        styles.selectedCard,
-                        {
-                          backgroundColor: Color(theme.colors.text)
-                            .alpha(0.05)
-                            .toString(),
-                          borderColor: Color(theme.colors.text)
-                            .alpha(0.2)
-                            .toString(),
-                        },
-                      ],
+                      isSelected && styles.selectedCard,
+                      pressed && styles.pressed,
                     ]}
                     onPress={() => setDefaultReciterSelection(option.action)}>
                     <View style={styles.optionContent}>
@@ -120,25 +103,26 @@ export default function ReciterChoiceScreen() {
                         style={[
                           styles.iconContainer,
                           {
-                            backgroundColor:
-                              defaultReciterSelection === option.action
-                                ? Color(theme.colors.text).alpha(0.1).toString()
-                                : Color(theme.colors.card)
-                                    .lighten(0.1)
-                                    .toString(),
+                            backgroundColor: isSelected
+                              ? Color(theme.colors.text).alpha(0.08).toString()
+                              : Color(theme.colors.text).alpha(0.04).toString(),
                           },
                         ]}>
                         {option.iconType === 'antdesign' ? (
                           <AntDesign
                             name={option.icon as any}
                             size={moderateScale(20)}
-                            color={theme.colors.text}
+                            color={Color(theme.colors.text)
+                              .alpha(0.7)
+                              .toString()}
                           />
                         ) : (
                           <Feather
                             name={option.icon as any}
                             size={moderateScale(20)}
-                            color={theme.colors.text}
+                            color={Color(theme.colors.text)
+                              .alpha(0.7)
+                              .toString()}
                           />
                         )}
                       </View>
@@ -147,37 +131,31 @@ export default function ReciterChoiceScreen() {
                           style={[
                             styles.optionTitle,
                             {
-                              color: theme.colors.text,
-                              fontFamily:
-                                defaultReciterSelection === option.action
-                                  ? theme.fonts.semiBold
-                                  : theme.fonts.medium,
+                              fontFamily: isSelected
+                                ? 'Manrope-SemiBold'
+                                : 'Manrope-Medium',
                             },
                           ]}>
                           {option.label}
                         </Text>
-                        <Text
-                          style={[
-                            styles.optionDescription,
-                            {color: theme.colors.textSecondary},
-                          ]}>
+                        <Text style={styles.optionDescription}>
                           {option.description}
                         </Text>
                       </View>
-                      {defaultReciterSelection === option.action && (
+                      {isSelected && (
                         <Feather
                           name="check-circle"
-                          size={24}
-                          color={Color(theme.colors.text).alpha(0.8).toString()}
+                          size={moderateScale(20)}
+                          color={Color(theme.colors.text).alpha(0.7).toString()}
                         />
                       )}
                     </View>
-                  </TouchableOpacity>
-                ))}
-              </View>
+                  </Pressable>
+                );
+              })}
             </View>
-          )}
-        </View>
+          </View>
+        )}
       </ScrollView>
     </View>
   );
@@ -194,25 +172,37 @@ const createStyles = (theme: Theme) =>
       paddingBottom: moderateScale(160),
     },
     subtitle: {
-      fontSize: moderateScale(14),
+      fontSize: moderateScale(11.5),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
       marginBottom: moderateScale(24),
-      fontFamily: theme.fonts.regular,
-      lineHeight: moderateScale(20),
+      lineHeight: moderateScale(18),
     },
     section: {
       marginBottom: moderateScale(24),
     },
-    sectionTitle: {
-      fontSize: moderateScale(18),
-      fontFamily: theme.fonts.semiBold,
-      marginBottom: moderateScale(12),
+    sectionHeader: {
+      fontSize: moderateScale(10.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+      letterSpacing: 1.2,
+      textTransform: 'uppercase',
+      marginBottom: moderateScale(6),
+      marginLeft: moderateScale(2),
     },
     card: {
-      borderRadius: moderateScale(12),
-      padding: moderateScale(16),
-      marginBottom: moderateScale(8),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderRadius: moderateScale(14),
       borderWidth: 1,
-      borderColor: 'transparent',
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      padding: moderateScale(14),
+      marginBottom: moderateScale(8),
+    },
+    selectedCard: {
+      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+    },
+    pressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     settingRow: {
       flexDirection: 'row',
@@ -221,22 +211,25 @@ const createStyles = (theme: Theme) =>
     },
     settingInfo: {
       flex: 1,
+      marginRight: moderateScale(12),
     },
     settingTitle: {
-      fontSize: moderateScale(16),
-      fontFamily: theme.fonts.medium,
-      marginBottom: moderateScale(4),
+      fontSize: moderateScale(13.5),
+      fontFamily: 'Manrope-Medium',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
+      marginBottom: moderateScale(2),
     },
     settingDescription: {
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.regular,
-      lineHeight: moderateScale(20),
+      fontSize: moderateScale(11.5),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
+      lineHeight: moderateScale(17),
+    },
+    switchStyle: {
+      transform: [{scaleX: 0.8}, {scaleY: 0.8}],
     },
     optionsContainer: {
       gap: moderateScale(8),
-    },
-    selectedCard: {
-      borderWidth: 1,
     },
     optionContent: {
       flexDirection: 'row',
@@ -254,12 +247,14 @@ const createStyles = (theme: Theme) =>
       flex: 1,
     },
     optionTitle: {
-      fontSize: moderateScale(16),
-      marginBottom: moderateScale(4),
+      fontSize: moderateScale(13.5),
+      color: Color(theme.colors.text).alpha(0.85).toString(),
+      marginBottom: moderateScale(2),
     },
     optionDescription: {
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.regular,
-      lineHeight: moderateScale(18),
+      fontSize: moderateScale(11.5),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
+      lineHeight: moderateScale(17),
     },
   });

--- a/app/(tabs)/(a.home)/settings/storage.tsx
+++ b/app/(tabs)/(a.home)/settings/storage.tsx
@@ -1,5 +1,5 @@
-import React, {useState} from 'react';
-import {View, Text, ScrollView, TouchableOpacity, Alert} from 'react-native';
+import React, {useState, useMemo} from 'react';
+import {View, Text, ScrollView, Pressable, Alert} from 'react-native';
 import {useRouter} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
@@ -16,7 +16,6 @@ interface StorageCategoryProps {
   color: string;
   label: string;
   size: string;
-  theme: Theme;
   styles: ReturnType<typeof createStyles>;
 }
 
@@ -24,19 +23,23 @@ const StorageCategory = ({
   color,
   label,
   size,
-  theme,
   styles,
 }: StorageCategoryProps) => (
   <View style={styles.categoryRow}>
     <View style={[styles.dot, {backgroundColor: color}]} />
-    <Text style={[styles.categoryLabel, {color: theme.colors.text}]}>
-      {label}
-    </Text>
-    <Text style={[styles.categorySize, {color: theme.colors.text}]}>
-      {size}
-    </Text>
+    <Text style={styles.categoryLabel}>{label}</Text>
+    <Text style={styles.categorySize}>{size}</Text>
   </View>
 );
+
+interface ActionSectionProps {
+  title: string;
+  description: string;
+  buttonLabel: string;
+  onPress: () => void;
+  theme: Theme;
+  styles: ReturnType<typeof createStyles>;
+}
 
 const ActionSection = ({
   title,
@@ -45,30 +48,21 @@ const ActionSection = ({
   onPress,
   theme,
   styles,
-}: {
-  title: string;
-  description: string;
-  buttonLabel: string;
-  onPress: () => void;
-  theme: Theme;
-  styles: ReturnType<typeof createStyles>;
-}) => (
+}: ActionSectionProps) => (
   <View style={styles.actionSection}>
     <View style={styles.actionContent}>
-      <Text style={[styles.actionTitle, {color: theme.colors.text}]}>
-        {title}
-      </Text>
-      <Text
-        style={[styles.actionDescription, {color: theme.colors.textSecondary}]}>
-        {description}
-      </Text>
+      <Text style={styles.actionTitle}>{title}</Text>
+      <Text style={styles.actionDescription}>{description}</Text>
     </View>
-    <TouchableOpacity
-      style={[styles.actionButton, {backgroundColor: theme.colors.text}]}
-      onPress={onPress}
-      activeOpacity={0.7}>
+    <Pressable
+      style={({pressed}) => [
+        styles.actionButton,
+        {backgroundColor: theme.colors.text},
+        pressed && {opacity: 0.8},
+      ]}
+      onPress={onPress}>
       <Text style={styles.actionButtonText}>{buttonLabel}</Text>
-    </TouchableOpacity>
+    </Pressable>
   </View>
 );
 
@@ -76,7 +70,7 @@ export default function StorageScreen() {
   const {theme} = useTheme();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const styles = createStyles(theme);
+  const styles = useMemo(() => createStyles(theme), [theme]);
   const [, setIsClearing] = useState(false);
 
   const {free, downloads, cache, otherApps, loading, error, rawData, refresh} =
@@ -95,7 +89,6 @@ export default function StorageScreen() {
             try {
               setIsClearing(true);
               await useDownloadStore.getState().clearAllDownloads();
-              // Refresh storage breakdown
               refresh();
               Alert.alert('Success', 'All downloads have been removed.');
             } catch (downloadError) {
@@ -121,10 +114,7 @@ export default function StorageScreen() {
           onPress: async () => {
             try {
               setIsClearing(true);
-              // Clear both AsyncStorage cache AND file system cache
               await clearPlayerCache();
-              //   await clearCacheDirectory();
-              // Refresh storage breakdown
               refresh();
               Alert.alert('Success', 'Cache has been cleared.');
             } catch (cacheError) {
@@ -138,21 +128,12 @@ export default function StorageScreen() {
     );
   };
 
-  // Calculate progress percentages for each category
   const totalRaw = rawData.total || 1;
   let otherAppsPercentage = (rawData.otherApps / totalRaw) * 100;
   let downloadsPercentage = (rawData.downloads / totalRaw) * 100;
   let cachePercentage = (rawData.cache / totalRaw) * 100;
   let freePercentage = (rawData.free / totalRaw) * 100;
 
-  console.log('[StorageScreen] Raw percentages:', {
-    otherApps: otherAppsPercentage.toFixed(2) + '%',
-    downloads: downloadsPercentage.toFixed(2) + '%',
-    cache: cachePercentage.toFixed(2) + '%',
-    free: freePercentage.toFixed(2) + '%',
-  });
-
-  // Ensure minimum 2% width for small segments so they're visible
   const MIN_PERCENTAGE = 2;
   if (downloadsPercentage > 0 && downloadsPercentage < MIN_PERCENTAGE) {
     downloadsPercentage = MIN_PERCENTAGE;
@@ -168,7 +149,6 @@ export default function StorageScreen() {
       100 - downloadsPercentage - cachePercentage - freePercentage,
     );
   }
-  // Recalculate to ensure total is 100%
   const totalPercentage =
     otherAppsPercentage +
     downloadsPercentage +
@@ -182,19 +162,11 @@ export default function StorageScreen() {
     freePercentage *= scale;
   }
 
-  console.log('[StorageScreen] Final percentages:', {
-    otherApps: otherAppsPercentage.toFixed(2) + '%',
-    downloads: downloadsPercentage.toFixed(2) + '%',
-    cache: cachePercentage.toFixed(2) + '%',
-    free: freePercentage.toFixed(2) + '%',
-  });
-
-  // Define colors for each category
   const colors = {
-    downloads: '#34C759', // Green
-    cache: '#8E8E93', // Grey
-    otherApps: '#007AFF', // Blue
-    free: '#E5E5EA', // Light grey
+    downloads: '#34C759',
+    cache: '#8E8E93',
+    otherApps: '#007AFF',
+    free: '#E5E5EA',
   };
 
   return (
@@ -207,8 +179,7 @@ export default function StorageScreen() {
         showsVerticalScrollIndicator={false}>
         {loading ? (
           <View style={styles.loadingContainer}>
-            <Text
-              style={[styles.loadingText, {color: theme.colors.textSecondary}]}>
+            <Text style={styles.loadingText}>
               Loading storage information...
             </Text>
           </View>
@@ -219,12 +190,13 @@ export default function StorageScreen() {
               size={moderateScale(48)}
               color={theme.colors.error}
             />
-            <Text style={[styles.errorText, {color: theme.colors.text}]}>
-              {error}
-            </Text>
+            <Text style={styles.errorText}>{error}</Text>
           </View>
         ) : (
           <>
+            {/* Storage Breakdown */}
+            <Text style={styles.sectionHeader}>STORAGE BREAKDOWN</Text>
+
             {/* Progress Bar */}
             <View style={styles.progressContainer}>
               <View style={styles.progressBarContainer}>
@@ -267,39 +239,35 @@ export default function StorageScreen() {
               </View>
             </View>
 
-            {/* Storage Breakdown */}
             <View style={styles.breakdownContainer}>
               <StorageCategory
                 color={colors.otherApps}
                 label="Other apps"
                 size={otherApps}
-                theme={theme}
                 styles={styles}
               />
               <StorageCategory
                 color={colors.downloads}
                 label="Downloads"
                 size={downloads}
-                theme={theme}
                 styles={styles}
               />
               <StorageCategory
                 color={colors.cache}
                 label="Cache"
                 size={cache}
-                theme={theme}
                 styles={styles}
               />
               <StorageCategory
                 color={colors.free}
                 label="Free"
                 size={free}
-                theme={theme}
                 styles={styles}
               />
             </View>
 
-            {/* Action Sections */}
+            {/* Manage Storage */}
+            <Text style={styles.sectionHeader}>MANAGE STORAGE</Text>
             <View>
               <ActionSection
                 title="Remove all downloads"
@@ -344,14 +312,24 @@ const createStyles = (theme: Theme) =>
       paddingVertical: moderateScale(20),
       paddingBottom: moderateScale(160),
     },
+    sectionHeader: {
+      fontSize: moderateScale(10.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+      letterSpacing: 1.2,
+      textTransform: 'uppercase',
+      marginBottom: moderateScale(10),
+      marginLeft: moderateScale(2),
+    },
     loadingContainer: {
       alignItems: 'center',
       justifyContent: 'center',
       paddingVertical: moderateScale(60),
     },
     loadingText: {
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.regular,
+      fontSize: moderateScale(13),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
     },
     errorContainer: {
       alignItems: 'center',
@@ -360,11 +338,12 @@ const createStyles = (theme: Theme) =>
       gap: moderateScale(16),
     },
     errorText: {
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.medium,
+      fontSize: moderateScale(13.5),
+      fontFamily: 'Manrope-Medium',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
     },
     progressContainer: {
-      marginBottom: moderateScale(32),
+      marginBottom: moderateScale(24),
     },
     progressBarContainer: {
       height: moderateScale(8),
@@ -378,7 +357,7 @@ const createStyles = (theme: Theme) =>
     },
     breakdownContainer: {
       gap: moderateScale(16),
-      marginBottom: moderateScale(40),
+      marginBottom: moderateScale(32),
     },
     categoryRow: {
       flexDirection: 'row',
@@ -392,34 +371,40 @@ const createStyles = (theme: Theme) =>
     },
     categoryLabel: {
       flex: 1,
-      fontSize: moderateScale(15),
-      fontFamily: theme.fonts.regular,
+      fontSize: moderateScale(13.5),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
     },
     categorySize: {
-      fontSize: moderateScale(15),
-      fontFamily: theme.fonts.medium,
+      fontSize: moderateScale(13.5),
+      fontFamily: 'Manrope-Medium',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
     },
     actionSection: {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
       padding: moderateScale(16),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
-      borderRadius: moderateScale(12),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderRadius: moderateScale(14),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
       gap: moderateScale(16),
     },
     actionContent: {
       flex: 1,
     },
     actionTitle: {
-      fontSize: moderateScale(16),
-      fontFamily: theme.fonts.semiBold,
+      fontSize: moderateScale(13.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
       marginBottom: moderateScale(4),
     },
     actionDescription: {
-      fontSize: moderateScale(13),
-      fontFamily: theme.fonts.regular,
-      lineHeight: moderateScale(18),
+      fontSize: moderateScale(11.5),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
+      lineHeight: moderateScale(17),
     },
     actionButton: {
       paddingHorizontal: moderateScale(20),
@@ -427,9 +412,9 @@ const createStyles = (theme: Theme) =>
       borderRadius: moderateScale(8),
     },
     actionButtonText: {
-      color: '#FFFFFF',
+      color: theme.colors.background,
       fontSize: moderateScale(14),
-      fontFamily: theme.fonts.semiBold,
+      fontFamily: 'Manrope-SemiBold',
     },
     actionSpacer: {
       height: moderateScale(12),


### PR DESCRIPTION
## Summary
- Aligned all 6 settings screens (index, reciter-choice, storage, credits, about, default-reciter) with the alpha-based color system used in MushafSettingsContent and VerseActionsSheet
- Replaced `TouchableOpacity` with `Pressable`, adopted grouped cards with dividers, ALL CAPS section headers, and standardized typography/switch tokens
- Added Design System reference section to CLAUDE.md documenting color tokens, typography, card patterns, and switch patterns

## Test plan
- [ ] Verify all 6 settings screens render correctly in light mode
- [ ] Verify all 6 settings screens render correctly in dark mode
- [ ] Confirm theme segmented control works on main settings
- [ ] Confirm accent color picker works on main settings
- [ ] Confirm switches toggle correctly (Ask Every Time, Floating Dev Menu)
- [ ] Confirm external links open correctly (Support, Privacy, Terms, Rate App)
- [ ] Confirm navigation to sub-screens works (Credits, About, Storage, Default Reciter, Reciter Choice, Mushaf Settings, What's New)

🤖 Generated with [Claude Code](https://claude.com/claude-code)