### PR TITLE
feat: add Skia-rendered verse preview component

### DIFF
--- a/components/collection/BookmarkItem.tsx
+++ b/components/collection/BookmarkItem.tsx
@@ -6,18 +6,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
 import {surahGlyphMap} from '@/utils/surahGlyphMap';
 import Color from 'color';
-
-// Build verse_key -> text lookup once at module scope
-interface QuranEntry {
-  verse_key: string;
-  text: string;
-}
-const quranRaw = require('@/data/quran.json') as Record<string, QuranEntry>;
-const qpcTextByKey: Record<string, string> = {};
-for (const key of Object.keys(quranRaw)) {
-  const entry = quranRaw[key];
-  if (entry?.verse_key) qpcTextByKey[entry.verse_key] = entry.text;
-}
+import SkiaVersePreview from '@/components/share/SkiaVersePreview';
 
 interface BookmarkItemProps {
   surahName: string;
@@ -34,7 +23,6 @@ export const BookmarkItem = memo<BookmarkItemProps>(
     const styles = useMemo(() => createStyles(theme), [theme]);
 
     const surahGlyph = surahGlyphMap[surahNumber] ?? '';
-    const arabicText = qpcTextByKey[verseKey] ?? '';
 
     return (
       <Pressable
@@ -67,9 +55,7 @@ export const BookmarkItem = memo<BookmarkItemProps>(
 
         {/* Arabic text */}
         <View style={styles.arabicContainer}>
-          <Text style={[styles.arabicText, {fontFamily: 'Uthmani'}]}>
-            {arabicText}
-          </Text>
+          <SkiaVersePreview verseKey={verseKey} />
         </View>
       </Pressable>
     );
@@ -135,13 +121,6 @@ const createStyles = (theme: Theme) => {
     arabicContainer: {
       padding: moderateScale(16),
       paddingBottom: moderateScale(18),
-    },
-    arabicText: {
-      fontSize: moderateScale(20),
-      color: theme.colors.text,
-      textAlign: 'center',
-      writingDirection: 'rtl',
-      lineHeight: moderateScale(38),
     },
   });
 };

--- a/components/collection/NoteItem.tsx
+++ b/components/collection/NoteItem.tsx
@@ -6,18 +6,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
 import {surahGlyphMap} from '@/utils/surahGlyphMap';
 import Color from 'color';
-
-// Build verse_key -> text lookup once at module scope
-interface QuranEntry {
-  verse_key: string;
-  text: string;
-}
-const quranRaw = require('@/data/quran.json') as Record<string, QuranEntry>;
-const qpcTextByKey: Record<string, string> = {};
-for (const key of Object.keys(quranRaw)) {
-  const entry = quranRaw[key];
-  if (entry?.verse_key) qpcTextByKey[entry.verse_key] = entry.text;
-}
+import SkiaVersePreview from '@/components/share/SkiaVersePreview';
 
 interface NoteItemProps {
   surahName: string;
@@ -47,16 +36,6 @@ export const NoteItem = memo<NoteItemProps>(
     const surahGlyph = surahGlyphMap[surahNumber] ?? '';
 
     const isRange = verseKeys && verseKeys.length > 1;
-
-    const arabicText = useMemo(() => {
-      if (isRange) {
-        return verseKeys
-          .map(vk => qpcTextByKey[vk] ?? '')
-          .filter(Boolean)
-          .join(' ');
-      }
-      return qpcTextByKey[verseKey] ?? '';
-    }, [verseKey, verseKeys, isRange]);
 
     const verseRefText = useMemo(() => {
       if (!isRange) return `${surahNumber}:${ayahNumber}`;
@@ -99,11 +78,11 @@ export const NoteItem = memo<NoteItemProps>(
 
         {/* Arabic text */}
         <View style={styles.arabicContainer}>
-          <Text
-            style={[styles.arabicText, {fontFamily: 'Uthmani'}]}
-            numberOfLines={isRange ? 3 : undefined}>
-            {arabicText}
-          </Text>
+          <SkiaVersePreview
+            verseKey={verseKey}
+            verseKeys={verseKeys}
+            numberOfLines={isRange ? 3 : undefined}
+          />
         </View>
 
         {/* Note preview */}
@@ -177,13 +156,6 @@ const createStyles = (theme: Theme) => {
     arabicContainer: {
       padding: moderateScale(16),
       paddingBottom: moderateScale(14),
-    },
-    arabicText: {
-      fontSize: moderateScale(20),
-      color: theme.colors.text,
-      textAlign: 'center',
-      writingDirection: 'rtl',
-      lineHeight: moderateScale(38),
     },
     annotationContainer: {
       paddingHorizontal: moderateScale(16),

--- a/components/share/SkiaVersePreview.tsx
+++ b/components/share/SkiaVersePreview.tsx
@@ -1,0 +1,78 @@
+import React, {useMemo, useState} from 'react';
+import {View, Text} from 'react-native';
+import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
+import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
+import {useTheme} from '@/hooks/useTheme';
+import SkiaVerseText from '@/components/player/v2/PlayerContent/QuranView/SkiaVerseText';
+
+interface SkiaVersePreviewProps {
+  verseKey: string;
+  verseKeys?: string[];
+  numberOfLines?: number;
+}
+
+const SkiaVersePreview: React.FC<SkiaVersePreviewProps> = ({
+  verseKey,
+  verseKeys,
+  numberOfLines = 2,
+}) => {
+  const {theme} = useTheme();
+  const [width, setWidth] = useState(0);
+
+  const mushafRenderer = useMushafSettingsStore(s => s.mushafRenderer);
+  const fontFamily =
+    mushafRenderer === 'dk_indopak'
+      ? 'DigitalKhattIndoPak'
+      : mushafRenderer === 'dk_v1'
+      ? 'DigitalKhattV1'
+      : 'DigitalKhattV2';
+
+  const fontMgr = mushafPreloadService.fontMgr;
+
+  const text = useMemo(() => {
+    const keys = verseKeys && verseKeys.length > 1 ? verseKeys : [verseKey];
+    return keys
+      .map(vk => digitalKhattDataService.getVerseText(vk))
+      .filter(Boolean)
+      .join(' ');
+  }, [verseKey, verseKeys]);
+
+  if (!fontMgr || !text) {
+    return (
+      <Text
+        style={{
+          fontFamily: 'Uthmani',
+          fontSize: 18,
+          color: theme.colors.text,
+          textAlign: 'right',
+          writingDirection: 'rtl',
+          lineHeight: 34,
+        }}
+        numberOfLines={numberOfLines}>
+        {text}
+      </Text>
+    );
+  }
+
+  return (
+    <View
+      style={{width: '100%', direction: 'rtl'}}
+      onLayout={e => setWidth(e.nativeEvent.layout.width)}>
+      {width > 0 ? (
+        <SkiaVerseText
+          text={text}
+          fontMgr={fontMgr}
+          fontFamily={fontFamily}
+          fontSize={22}
+          textColor={theme.colors.text}
+          showTajweed={false}
+          width={width}
+          indexedTajweedData={null}
+        />
+      ) : null}
+    </View>
+  );
+};
+
+export default React.memo(SkiaVersePreview);

--- a/components/sheets/VerseCopySheet.tsx
+++ b/components/sheets/VerseCopySheet.tsx
@@ -14,18 +14,7 @@ import ActionSheet, {
 import Color from 'color';
 import {Feather} from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
-
-// Build verse_key -> text lookup once at module scope
-interface QuranEntry {
-  verse_key: string;
-  text: string;
-}
-const quranRaw = require('@/data/quran.json') as Record<string, QuranEntry>;
-const qpcTextByKey: Record<string, string> = {};
-for (const key of Object.keys(quranRaw)) {
-  const entry = quranRaw[key];
-  if (entry?.verse_key) qpcTextByKey[entry.verse_key] = entry.text;
-}
+import SkiaVersePreview from '@/components/share/SkiaVersePreview';
 
 interface CheckboxRowProps {
   label: string;
@@ -85,17 +74,6 @@ export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
   const isRange = verseKeys && verseKeys.length > 1;
   const arabicText = props.payload?.arabicText;
   const translation = props.payload?.translation;
-
-  // Get Arabic text for display — multi-verse when range
-  const displayArabicText = useMemo(() => {
-    if (isRange) {
-      return verseKeys
-        .map(vk => qpcTextByKey[vk] ?? '')
-        .filter(Boolean)
-        .join(' ');
-    }
-    return qpcTextByKey[verseKey] ?? arabicText ?? '';
-  }, [verseKey, verseKeys, isRange, arabicText]);
 
   // Compute range-aware reference text
   const verseRefText = useMemo(() => {
@@ -165,15 +143,13 @@ export const VerseCopySheet = (props: SheetProps<'verse-copy'>) => {
         <Text style={styles.title}>Copy Options</Text>
         <Text style={styles.subtitle}>Select what to copy</Text>
 
-        {displayArabicText ? (
-          <View style={styles.ayahContainer}>
-            <Text
-              style={[styles.ayahText, {fontFamily: 'Uthmani'}]}
-              numberOfLines={isRange ? 3 : 2}>
-              {displayArabicText}
-            </Text>
-          </View>
-        ) : null}
+        <View style={styles.ayahContainer}>
+          <SkiaVersePreview
+            verseKey={verseKey}
+            verseKeys={verseKeys}
+            numberOfLines={isRange ? 3 : 2}
+          />
+        </View>
 
         <View style={styles.optionsContainer}>
           <CheckboxRow
@@ -266,13 +242,6 @@ const createStyles = (theme: Theme) =>
       borderRadius: moderateScale(12),
       padding: moderateScale(16),
       marginBottom: verticalScale(16),
-    },
-    ayahText: {
-      fontSize: moderateScale(18),
-      color: theme.colors.text,
-      textAlign: 'right',
-      writingDirection: 'rtl',
-      lineHeight: moderateScale(36),
     },
     optionsContainer: {
       backgroundColor: theme.colors.card,

--- a/components/sheets/VerseHighlightSheet.tsx
+++ b/components/sheets/VerseHighlightSheet.tsx
@@ -16,18 +16,7 @@ import {Feather} from '@expo/vector-icons';
 import {HIGHLIGHT_COLORS, HighlightColor} from '@/types/verse-annotations';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
 import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
-
-// Build verse_key -> text lookup once at module scope
-interface QuranEntry {
-  verse_key: string;
-  text: string;
-}
-const quranRaw = require('@/data/quran.json') as Record<string, QuranEntry>;
-const qpcTextByKey: Record<string, string> = {};
-for (const key of Object.keys(quranRaw)) {
-  const entry = quranRaw[key];
-  if (entry?.verse_key) qpcTextByKey[entry.verse_key] = entry.text;
-}
+import SkiaVersePreview from '@/components/share/SkiaVersePreview';
 
 const COLORS = Object.entries(HIGHLIGHT_COLORS) as [HighlightColor, string][];
 
@@ -42,8 +31,6 @@ export const VerseHighlightSheet = (props: SheetProps<'verse-highlight'>) => {
   const allKeys = verseKeys && verseKeys.length > 1 ? verseKeys : [verseKey];
 
   const currentColor = useVerseAnnotationsStore(s => s.highlights[verseKey]);
-
-  const arabicText = qpcTextByKey[verseKey] ?? '';
 
   const handleSelectColor = useCallback(
     async (color: HighlightColor) => {
@@ -81,15 +68,9 @@ export const VerseHighlightSheet = (props: SheetProps<'verse-highlight'>) => {
       <View style={styles.container}>
         <Text style={styles.title}>Highlight Color</Text>
 
-        {arabicText ? (
-          <View style={styles.ayahContainer}>
-            <Text
-              style={[styles.ayahText, {fontFamily: 'Uthmani'}]}
-              numberOfLines={2}>
-              {arabicText}
-            </Text>
-          </View>
-        ) : null}
+        <View style={styles.ayahContainer}>
+          <SkiaVersePreview verseKey={verseKey} verseKeys={verseKeys} />
+        </View>
 
         <View style={styles.colorsGrid}>
           {COLORS.map(([name, hex]) => {
@@ -150,13 +131,6 @@ const createStyles = (theme: Theme) =>
       borderRadius: moderateScale(12),
       padding: moderateScale(16),
       marginBottom: verticalScale(20),
-    },
-    ayahText: {
-      fontSize: moderateScale(18),
-      color: theme.colors.text,
-      textAlign: 'right',
-      writingDirection: 'rtl',
-      lineHeight: moderateScale(36),
     },
     colorsGrid: {
       flexDirection: 'row',

--- a/components/sheets/VerseNoteSheet.tsx
+++ b/components/sheets/VerseNoteSheet.tsx
@@ -10,23 +10,13 @@ import {Theme} from '@/utils/themeUtils';
 import ActionSheet, {
   SheetProps,
   SheetManager,
+  ScrollView,
 } from 'react-native-actions-sheet';
 import Color from 'color';
 import {Feather} from '@expo/vector-icons';
 import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
-
-// Build verse_key -> text lookup once at module scope
-interface QuranEntry {
-  verse_key: string;
-  text: string;
-}
-const quranRaw = require('@/data/quran.json') as Record<string, QuranEntry>;
-const qpcTextByKey: Record<string, string> = {};
-for (const key of Object.keys(quranRaw)) {
-  const entry = quranRaw[key];
-  if (entry?.verse_key) qpcTextByKey[entry.verse_key] = entry.text;
-}
+import SkiaVersePreview from '@/components/share/SkiaVersePreview';
 
 export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
   const {theme} = useTheme();
@@ -41,17 +31,6 @@ export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
 
   const [noteText, setNoteText] = useState('');
   const [isEditMode, setIsEditMode] = useState(false);
-
-  // For range: concatenate Arabic text from all verses; for single: just the one
-  const arabicText = useMemo(() => {
-    if (isRange) {
-      return verseKeys
-        .map(vk => qpcTextByKey[vk] ?? '')
-        .filter(Boolean)
-        .join(' ');
-    }
-    return qpcTextByKey[verseKey] ?? '';
-  }, [verseKey, verseKeys, isRange]);
 
   // Compute range-aware reference text
   const verseRefText = useMemo(() => {
@@ -130,20 +109,22 @@ export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
       containerStyle={styles.sheetContainer}
       indicatorStyle={styles.indicator}
       gestureEnabled={true}>
-      <View style={styles.container}>
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}>
         <Text style={styles.title}>
           {isEditMode ? 'Edit Note' : 'Note'} for {verseRefText}
         </Text>
 
-        {arabicText ? (
-          <View style={styles.ayahContainer}>
-            <Text
-              style={[styles.ayahText, {fontFamily: 'Uthmani'}]}
-              numberOfLines={isRange ? 3 : 2}>
-              {arabicText}
-            </Text>
-          </View>
-        ) : null}
+        <View style={styles.ayahContainer}>
+          <SkiaVersePreview
+            verseKey={verseKey}
+            verseKeys={verseKeys}
+            numberOfLines={isRange ? 3 : 2}
+          />
+        </View>
 
         <TextInput
           style={styles.textInput}
@@ -176,11 +157,15 @@ export const VerseNoteSheet = (props: SheetProps<'verse-note'>) => {
 
         {isEditMode && noteId ? (
           <Pressable style={styles.deleteButton} onPress={handleDelete}>
-            <Feather name="trash-2" size={moderateScale(18)} color="#ff4444" />
+            <Feather
+              name="minus-circle"
+              size={moderateScale(18)}
+              color="#ff4444"
+            />
             <Text style={styles.deleteButtonText}>Delete Note</Text>
           </Pressable>
         ) : null}
-      </View>
+      </ScrollView>
     </ActionSheet>
   );
 };
@@ -199,6 +184,8 @@ const createStyles = (theme: Theme) =>
     },
     container: {
       padding: moderateScale(16),
+    },
+    scrollContent: {
       paddingBottom: moderateScale(40),
     },
     title: {
@@ -213,13 +200,6 @@ const createStyles = (theme: Theme) =>
       borderRadius: moderateScale(12),
       padding: moderateScale(16),
       marginBottom: verticalScale(16),
-    },
-    ayahText: {
-      fontSize: moderateScale(18),
-      color: theme.colors.text,
-      textAlign: 'right',
-      writingDirection: 'rtl',
-      lineHeight: moderateScale(36),
     },
     textInput: {
       backgroundColor: theme.colors.card,


### PR DESCRIPTION
## Summary
- Adds `SkiaVersePreview` component using mushaf font engine for verse rendering
- Integrates into BookmarkItem and NoteItem for collection screens
- Updates VerseCopySheet, VerseHighlightSheet, and VerseNoteSheet

## Test plan
- [ ] Bookmarks show verse preview with Arabic text
- [ ] Notes show verse preview correctly
- [ ] Verse copy/highlight/note sheets display verse text
- [ ] Both Uthmani and IndoPak scripts render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)