### PR TITLE
refactor: unify sheet UI to alpha-based design system

### DIFF
--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -71,10 +71,10 @@ export const Input: React.FC<InputProps> = ({
         style={[
           styles.inputContainer,
           {
-            backgroundColor: theme.colors.card,
+            backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
             borderColor: error
               ? '#EF4444'
-              : Color(theme.colors.border).alpha(0.3).toString(),
+              : Color(theme.colors.text).alpha(0.06).toString(),
           },
           inputContainerStyle,
         ]}>
@@ -132,31 +132,31 @@ export const Input: React.FC<InputProps> = ({
 
 const styles = StyleSheet.create({
   container: {
-    marginBottom: moderateScale(24),
+    marginBottom: moderateScale(16),
   },
   labelRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: moderateScale(12),
+    marginBottom: moderateScale(8),
   },
   label: {
-    fontSize: moderateScale(15),
+    fontSize: moderateScale(13.5),
     fontFamily: 'Manrope-SemiBold',
     letterSpacing: 0.2,
   },
   inputContainer: {
-    borderWidth: 1.5,
-    borderRadius: moderateScale(16),
+    borderWidth: 1,
+    borderRadius: moderateScale(12),
     overflow: 'hidden',
   },
   input: {
-    paddingHorizontal: moderateScale(20),
-    paddingVertical: moderateScale(16),
-    fontSize: moderateScale(16),
+    paddingHorizontal: moderateScale(16),
+    paddingVertical: moderateScale(10),
+    fontSize: moderateScale(14),
     fontFamily: 'Manrope-Medium',
   },
   footer: {
-    marginTop: moderateScale(8),
+    marginTop: moderateScale(6),
     paddingHorizontal: moderateScale(4),
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/components/sheets/AddToCollectionSheet.tsx
+++ b/components/sheets/AddToCollectionSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
-import {View, Text, Pressable} from 'react-native';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -82,7 +82,7 @@ export const AddToCollectionSheet = (
           <Text style={styles.title}>Add to Collection</Text>
         </View>
 
-        <View style={styles.optionsGrid}>
+        <View style={styles.card}>
           <Pressable
             style={({pressed}) => [
               styles.option,
@@ -91,11 +91,13 @@ export const AddToCollectionSheet = (
             onPress={handleNewUpload}>
             <Feather
               name="mic"
-              size={moderateScale(20)}
+              size={moderateScale(18)}
               color={theme.colors.text}
             />
             <Text style={styles.optionText}>Upload Recitation</Text>
           </Pressable>
+
+          <View style={styles.divider} />
 
           <Pressable
             style={({pressed}) => [
@@ -103,9 +105,11 @@ export const AddToCollectionSheet = (
               pressed && styles.optionPressed,
             ]}
             onPress={handleNewPlaylist}>
-            <PlaylistIcon color={theme.colors.text} size={moderateScale(20)} />
+            <PlaylistIcon color={theme.colors.text} size={moderateScale(18)} />
             <Text style={styles.optionText}>Create New Playlist</Text>
           </Pressable>
+
+          <View style={styles.divider} />
 
           <Pressable
             style={({pressed}) => [
@@ -115,7 +119,7 @@ export const AddToCollectionSheet = (
             onPress={handleAddFavoriteReciter}>
             <Feather
               name="star"
-              size={moderateScale(20)}
+              size={moderateScale(18)}
               color={theme.colors.text}
             />
             <Text style={styles.optionText}>Add Favorite Reciter</Text>
@@ -132,11 +136,16 @@ const createStyles = (theme: Theme) =>
       backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
       paddingTop: moderateScale(8),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       paddingHorizontal: moderateScale(20),
@@ -144,34 +153,41 @@ const createStyles = (theme: Theme) =>
     },
     header: {
       alignItems: 'center',
-      marginTop: moderateScale(8),
-      marginBottom: moderateScale(20),
+      marginTop: moderateScale(4),
+      marginBottom: moderateScale(14),
     },
     title: {
-      fontSize: moderateScale(20),
+      fontSize: moderateScale(18),
       fontFamily: 'Manrope-Bold',
       color: theme.colors.text,
       textAlign: 'center',
     },
-    optionsGrid: {
-      gap: moderateScale(8),
+    card: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+    },
+    divider: {
+      height: 1,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      marginHorizontal: moderateScale(14),
     },
     option: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
     },
     optionPressed: {
-      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     optionText: {
       flex: 1,
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: theme.colors.text,
-      marginLeft: moderateScale(12),
+      marginLeft: moderateScale(10),
     },
   });

--- a/components/sheets/AdhkarCopyOptionsSheet.tsx
+++ b/components/sheets/AdhkarCopyOptionsSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useMemo, useCallback} from 'react';
-import {View, Text, TouchableOpacity} from 'react-native';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {
   ScaledSheet,
   moderateScale,
@@ -34,10 +34,13 @@ const CheckboxRow: React.FC<CheckboxRowProps> = ({
   styles,
 }) => {
   return (
-    <TouchableOpacity
-      style={[styles.checkboxRow, disabled && styles.checkboxRowDisabled]}
+    <Pressable
+      style={({pressed}) => [
+        styles.checkboxRow,
+        disabled && styles.checkboxRowDisabled,
+        pressed && !disabled && styles.checkboxRowPressed,
+      ]}
       onPress={onToggle}
-      activeOpacity={1}
       disabled={disabled}>
       <View
         style={[
@@ -60,7 +63,7 @@ const CheckboxRow: React.FC<CheckboxRowProps> = ({
         ]}>
         {label}
       </Text>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 
@@ -122,6 +125,7 @@ export const AdhkarCopyOptionsSheet = (
             theme={theme}
             styles={styles}
           />
+          <View style={styles.divider} />
           <CheckboxRow
             label="Translation"
             checked={copyTranslation}
@@ -130,6 +134,7 @@ export const AdhkarCopyOptionsSheet = (
             theme={theme}
             styles={styles}
           />
+          <View style={styles.divider} />
           <CheckboxRow
             label="Transliteration"
             checked={copyTransliteration}
@@ -140,10 +145,13 @@ export const AdhkarCopyOptionsSheet = (
           />
         </View>
 
-        <TouchableOpacity
-          style={[styles.copyButton, !canCopy && styles.copyButtonDisabled]}
+        <Pressable
+          style={({pressed}) => [
+            styles.copyButton,
+            !canCopy && styles.copyButtonDisabled,
+            pressed && canCopy && styles.copyButtonPressed,
+          ]}
           onPress={handleCopy}
-          activeOpacity={1}
           disabled={!canCopy}>
           <Feather
             name="copy"
@@ -159,7 +167,7 @@ export const AdhkarCopyOptionsSheet = (
             ]}>
             Copy to Clipboard
           </Text>
-        </TouchableOpacity>
+        </Pressable>
       </View>
     </ActionSheet>
   );
@@ -168,14 +176,19 @@ export const AdhkarCopyOptionsSheet = (
 const createStyles = (theme: Theme) =>
   ScaledSheet.create({
     sheetContainer: {
-      backgroundColor: theme.colors.backgroundSecondary,
+      backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       padding: moderateScale(16),
@@ -196,11 +209,17 @@ const createStyles = (theme: Theme) =>
       marginBottom: verticalScale(16),
     },
     optionsContainer: {
-      backgroundColor: theme.colors.card,
-      borderRadius: moderateScale(12),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderRadius: moderateScale(14),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
       paddingHorizontal: moderateScale(14),
-      paddingVertical: verticalScale(8),
+      overflow: 'hidden',
       marginBottom: verticalScale(16),
+    },
+    divider: {
+      height: StyleSheet.hairlineWidth,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     checkboxRow: {
       flexDirection: 'row',
@@ -210,12 +229,15 @@ const createStyles = (theme: Theme) =>
     checkboxRowDisabled: {
       opacity: 0.4,
     },
+    checkboxRowPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+    },
     checkbox: {
       width: moderateScale(24),
       height: moderateScale(24),
       borderRadius: moderateScale(6),
       borderWidth: 2,
-      borderColor: theme.colors.border,
+      borderColor: Color(theme.colors.text).alpha(0.2).toString(),
       justifyContent: 'center',
       alignItems: 'center',
       marginRight: moderateScale(12),
@@ -225,12 +247,12 @@ const createStyles = (theme: Theme) =>
       borderColor: theme.colors.text,
     },
     checkboxDisabled: {
-      borderColor: Color(theme.colors.border).alpha(0.5).toString(),
+      borderColor: Color(theme.colors.text).alpha(0.1).toString(),
     },
     checkboxLabel: {
-      fontSize: moderateScale(15),
-      fontFamily: theme.fonts.medium,
-      color: theme.colors.text,
+      fontSize: moderateScale(13.5),
+      fontFamily: 'Manrope-Medium',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
     },
     checkboxLabelDisabled: {
       color: theme.colors.textSecondary,
@@ -247,9 +269,12 @@ const createStyles = (theme: Theme) =>
     copyButtonDisabled: {
       backgroundColor: Color(theme.colors.textSecondary).alpha(0.2).toString(),
     },
+    copyButtonPressed: {
+      opacity: 0.9,
+    },
     copyButtonText: {
-      fontSize: moderateScale(16),
-      fontFamily: theme.fonts.semiBold,
+      fontSize: moderateScale(15),
+      fontFamily: 'Manrope-SemiBold',
       color: theme.colors.background,
     },
     copyButtonTextDisabled: {

--- a/components/sheets/AdhkarLayoutSheet.tsx
+++ b/components/sheets/AdhkarLayoutSheet.tsx
@@ -1,5 +1,12 @@
 import React, {useMemo} from 'react';
-import {View, Text, Dimensions, Switch, TouchableOpacity} from 'react-native';
+import {
+  View,
+  Text,
+  Dimensions,
+  Switch,
+  Pressable,
+  StyleSheet,
+} from 'react-native';
 import {
   ScaledSheet,
   moderateScale,
@@ -67,9 +74,8 @@ const FontSizeControl: React.FC<FontSizeControlProps> = ({
       <View style={styles.fontSizeControlRow}>
         <Text style={styles.optionLabel}>{label}</Text>
         <View style={styles.fontSizeAdjuster}>
-          <TouchableOpacity
+          <Pressable
             onPress={handleDecrement}
-            activeOpacity={1}
             hitSlop={10}
             disabled={currentDisplayValue <= DISPLAY_MIN}>
             <Feather
@@ -81,11 +87,10 @@ const FontSizeControl: React.FC<FontSizeControlProps> = ({
                   : theme.colors.text
               }
             />
-          </TouchableOpacity>
+          </Pressable>
           <Text style={styles.fontSizeValue}>{currentDisplayValue}</Text>
-          <TouchableOpacity
+          <Pressable
             onPress={handleIncrement}
-            activeOpacity={1}
             hitSlop={10}
             disabled={currentDisplayValue >= DISPLAY_MAX}>
             <Feather
@@ -97,7 +102,7 @@ const FontSizeControl: React.FC<FontSizeControlProps> = ({
                   : theme.colors.text
               }
             />
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </View>
       <View
@@ -136,8 +141,8 @@ export const AdhkarLayoutSheet = (props: SheetProps<'adhkar-layout'>) => {
   } = useAdhkarSettingsStore();
 
   const trackColor = {
-    false: Color(theme.colors.textSecondary).alpha(0.3).toString(),
-    true: theme.colors.text,
+    false: Color(theme.colors.text).alpha(0.1).toString(),
+    true: Color(theme.colors.text).alpha(0.65).toString(),
   };
 
   return (
@@ -234,15 +239,20 @@ export const AdhkarLayoutSheet = (props: SheetProps<'adhkar-layout'>) => {
 const createStyles = (theme: Theme) =>
   ScaledSheet.create({
     sheetContainer: {
-      backgroundColor: theme.colors.backgroundSecondary,
+      backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
       height: SCREEN_HEIGHT * 0.6,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     scrollView: {
       flex: 1,
@@ -261,18 +271,23 @@ const createStyles = (theme: Theme) =>
       textAlign: 'center',
     },
     sectionHeader: {
-      fontSize: moderateScale(14),
-      fontFamily: theme.fonts.semiBold,
-      color: theme.colors.textSecondary,
+      fontSize: moderateScale(10.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
       marginBottom: verticalScale(8),
       marginLeft: moderateScale(4),
+      letterSpacing: 1.2,
+      textTransform: 'uppercase',
     },
     card: {
-      backgroundColor: theme.colors.card,
-      borderRadius: moderateScale(12),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderRadius: moderateScale(14),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
       paddingHorizontal: moderateScale(14),
       paddingVertical: verticalScale(5),
       marginBottom: verticalScale(16),
+      overflow: 'hidden',
     },
     optionRow: {
       flexDirection: 'row',
@@ -281,14 +296,14 @@ const createStyles = (theme: Theme) =>
       paddingVertical: verticalScale(8),
     },
     optionLabel: {
-      fontSize: moderateScale(13),
-      fontFamily: theme.fonts.medium,
-      color: theme.colors.text,
+      fontSize: moderateScale(13.5),
+      fontFamily: 'Manrope-Medium',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
       marginRight: moderateScale(10),
     },
     divider: {
-      height: 1,
-      backgroundColor: theme.colors.border,
+      height: StyleSheet.hairlineWidth,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
       marginVertical: verticalScale(8),
     },
     switchStyle: {

--- a/components/sheets/AmbientSoundsSheet.tsx
+++ b/components/sheets/AmbientSoundsSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {View, Text, Pressable} from 'react-native';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import Slider from '@react-native-community/slider';
 import {useTheme} from '@/hooks/useTheme';
@@ -177,16 +177,21 @@ const createStyles = (theme: Theme) =>
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     headerContainer: {
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerTitle: {
       fontSize: moderateScale(18),
@@ -209,12 +214,12 @@ const createStyles = (theme: Theme) =>
       paddingVertical: moderateScale(16),
       paddingHorizontal: moderateScale(12),
       borderRadius: moderateScale(16),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
       alignItems: 'center',
       justifyContent: 'center',
       gap: moderateScale(6),
-      borderWidth: 1.5,
-      borderColor: 'transparent',
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     soundCardSelected: {
       backgroundColor: Color(theme.colors.text).alpha(0.12).toString(),

--- a/components/sheets/CollectionOptionsSheet.tsx
+++ b/components/sheets/CollectionOptionsSheet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, Pressable} from 'react-native';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -21,6 +21,10 @@ export const CollectionOptionsSheet = (
   const subtitle = payload?.subtitle;
   const options = payload?.options ?? [];
 
+  // Separate destructive from non-destructive options
+  const normalOptions = options.filter(opt => !opt.destructive);
+  const destructiveOptions = options.filter(opt => opt.destructive);
+
   return (
     <ActionSheet
       id={props.sheetId}
@@ -32,16 +36,43 @@ export const CollectionOptionsSheet = (
           <Text style={styles.title}>{title}</Text>
           {subtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
         </View>
-        <View style={styles.optionsGrid}>
-          {options.map((opt, i) => (
+
+        {normalOptions.length > 0 && (
+          <View style={styles.card}>
+            {normalOptions.map((opt, i) => (
+              <React.Fragment key={i}>
+                {i > 0 && <View style={styles.divider} />}
+                <Pressable
+                  style={({pressed}) => [
+                    styles.option,
+                    pressed && styles.optionPressed,
+                    opt.disabled && styles.optionDisabled,
+                  ]}
+                  onPress={() => {
+                    SheetManager.hide('collection-options');
+                    opt.onPress();
+                  }}
+                  disabled={opt.disabled}>
+                  {opt.customIcon || (
+                    <Feather
+                      name={opt.icon as any}
+                      size={moderateScale(18)}
+                      color={theme.colors.text}
+                    />
+                  )}
+                  <Text style={styles.optionText}>{opt.label}</Text>
+                </Pressable>
+              </React.Fragment>
+            ))}
+          </View>
+        )}
+
+        {destructiveOptions.map((opt, i) => (
+          <View key={`destructive-${i}`} style={styles.destructiveCard}>
             <Pressable
-              key={i}
               style={({pressed}) => [
-                opt.destructive ? styles.optionDestructive : styles.option,
-                pressed &&
-                  (opt.destructive
-                    ? styles.optionDestructivePressed
-                    : styles.optionPressed),
+                styles.optionDestructive,
+                pressed && styles.optionDestructivePressed,
                 opt.disabled && styles.optionDisabled,
               ]}
               onPress={() => {
@@ -52,21 +83,14 @@ export const CollectionOptionsSheet = (
               {opt.customIcon || (
                 <Feather
                   name={opt.icon as any}
-                  size={moderateScale(20)}
-                  color={opt.destructive ? '#ff4444' : theme.colors.text}
+                  size={moderateScale(18)}
+                  color="#ff4444"
                 />
               )}
-              <Text
-                style={
-                  opt.destructive
-                    ? styles.optionTextDestructive
-                    : styles.optionText
-                }>
-                {opt.label}
-              </Text>
+              <Text style={styles.optionTextDestructive}>{opt.label}</Text>
             </Pressable>
-          ))}
-        </View>
+          </View>
+        ))}
       </View>
     </ActionSheet>
   );
@@ -78,11 +102,16 @@ const createStyles = (theme: Theme) =>
       backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
       paddingTop: moderateScale(8),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       paddingHorizontal: moderateScale(20),
@@ -90,62 +119,74 @@ const createStyles = (theme: Theme) =>
     },
     header: {
       alignItems: 'center',
-      marginTop: moderateScale(8),
-      marginBottom: moderateScale(20),
-      gap: moderateScale(4),
+      marginTop: moderateScale(4),
+      marginBottom: moderateScale(14),
+      gap: moderateScale(2),
     },
     title: {
-      fontSize: moderateScale(20),
+      fontSize: moderateScale(18),
       fontFamily: 'Manrope-Bold',
       color: theme.colors.text,
       textAlign: 'center',
     },
     subtitle: {
-      fontSize: moderateScale(14),
+      fontSize: moderateScale(13),
       fontFamily: 'Manrope-Medium',
-      color: theme.colors.textSecondary,
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
       textAlign: 'center',
     },
-    optionsGrid: {
-      gap: moderateScale(8),
+    card: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+      marginBottom: moderateScale(8),
+    },
+    divider: {
+      height: 1,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      marginHorizontal: moderateScale(14),
     },
     option: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
     },
     optionDisabled: {
       opacity: 0.5,
     },
     optionPressed: {
-      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+    },
+    optionText: {
+      flex: 1,
+      fontSize: moderateScale(14),
+      fontFamily: 'Manrope-SemiBold',
+      color: theme.colors.text,
+      marginLeft: moderateScale(10),
+    },
+    destructiveCard: {
+      backgroundColor: 'rgba(255, 68, 68, 0.1)',
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+      marginBottom: moderateScale(8),
     },
     optionDestructive: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
-      backgroundColor: 'rgba(255, 68, 68, 0.1)',
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
     },
     optionDestructivePressed: {
       backgroundColor: 'rgba(255, 68, 68, 0.18)',
     },
-    optionText: {
-      flex: 1,
-      fontSize: moderateScale(15),
-      fontFamily: 'Manrope-SemiBold',
-      color: theme.colors.text,
-      marginLeft: moderateScale(12),
-    },
     optionTextDestructive: {
       flex: 1,
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: '#ff4444',
-      marginLeft: moderateScale(12),
+      marginLeft: moderateScale(10),
     },
   });

--- a/components/sheets/CreatePlaylistSheet.tsx
+++ b/components/sheets/CreatePlaylistSheet.tsx
@@ -2,7 +2,8 @@ import React, {useState, useCallback} from 'react';
 import {
   View,
   Text,
-  TouchableOpacity,
+  Pressable,
+  StyleSheet,
   Platform,
   Dimensions,
   Keyboard,
@@ -90,13 +91,13 @@ export const CreatePlaylistSheet = (props: SheetProps<'create-playlist'>) => {
       keyboardHandlerEnabled={true}>
       {/* Header */}
       <View style={styles.headerContainer}>
-        <TouchableOpacity onPress={handleClose} style={styles.headerButton}>
+        <Pressable onPress={handleClose} style={styles.headerButton}>
           <Text style={styles.cancelText}>Cancel</Text>
-        </TouchableOpacity>
+        </Pressable>
         <Text style={styles.headerTitle}>
           {isEditMode ? 'Edit Playlist' : 'New Playlist'}
         </Text>
-        <TouchableOpacity
+        <Pressable
           onPress={handleCreate}
           style={[
             styles.headerButton,
@@ -104,7 +105,7 @@ export const CreatePlaylistSheet = (props: SheetProps<'create-playlist'>) => {
           ]}
           disabled={!playlistName.trim()}>
           <Text style={styles.saveText}>Save</Text>
-        </TouchableOpacity>
+        </Pressable>
       </View>
 
       <ScrollView
@@ -175,10 +176,15 @@ const createStyles = (theme: Theme) =>
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
       height: SCREEN_HEIGHT * 0.6,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     headerContainer: {
       flexDirection: 'row',
@@ -187,7 +193,7 @@ const createStyles = (theme: Theme) =>
       paddingHorizontal: moderateScale(20),
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerButton: {
       minWidth: moderateScale(60),

--- a/components/sheets/DownloadOptionsSheet.tsx
+++ b/components/sheets/DownloadOptionsSheet.tsx
@@ -3,6 +3,7 @@ import {
   View,
   Text,
   Pressable,
+  StyleSheet,
   useWindowDimensions,
   Dimensions,
   Alert,
@@ -52,7 +53,6 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
   const {theme} = useTheme();
   const styles = createStyles(theme);
   const {width} = useWindowDimensions();
-  const [pressedOption, setPressedOption] = useState<string | null>(null);
   const [showSurahInfo, setShowSurahInfo] = useState(false);
 
   const payload = props.payload;
@@ -213,16 +213,18 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
             </Text>
           </View>
 
-          <View style={styles.optionsGrid}>
+          <View style={styles.card}>
             <Pressable
               style={({pressed}) => [
                 styles.option,
                 pressed && styles.optionPressed,
               ]}
               onPress={handlePlay}>
-              <PlayIcon color={theme.colors.text} size={moderateScale(20)} />
+              <PlayIcon color={theme.colors.text} size={moderateScale(18)} />
               <Text style={styles.optionText}>Play Now</Text>
             </Pressable>
+
+            <View style={styles.divider} />
 
             <Pressable
               style={({pressed}) => [
@@ -233,7 +235,7 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
               onPress={handleToggleLove}>
               <HeartIcon
                 color={theme.colors.text}
-                size={moderateScale(20)}
+                size={moderateScale(18)}
                 filled={isLovedState}
               />
               <Text
@@ -245,6 +247,8 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
               </Text>
             </Pressable>
 
+            <View style={styles.divider} />
+
             <Pressable
               style={({pressed}) => [
                 styles.option,
@@ -254,12 +258,14 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
               <View style={styles.rotatedIcon}>
                 <QueueIcon
                   color={theme.colors.text}
-                  size={moderateScale(20)}
+                  size={moderateScale(18)}
                   filled={true}
                 />
               </View>
               <Text style={styles.optionText}>Add to Queue</Text>
             </Pressable>
+
+            <View style={styles.divider} />
 
             <Pressable
               style={({pressed}) => [
@@ -270,7 +276,7 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
               onPress={handleAddToPlaylist}>
               <Feather
                 name="plus-circle"
-                size={moderateScale(20)}
+                size={moderateScale(18)}
                 color={theme.colors.text}
               />
               <Text
@@ -282,6 +288,8 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
               </Text>
             </Pressable>
 
+            <View style={styles.divider} />
+
             <Pressable
               style={({pressed}) => [
                 styles.option,
@@ -290,12 +298,14 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
               onPress={handleViewInfo}>
               <Feather
                 name="info"
-                size={moderateScale(20)}
+                size={moderateScale(18)}
                 color={theme.colors.text}
               />
               <Text style={styles.optionText}>Learn About Surah</Text>
             </Pressable>
+          </View>
 
+          <View style={styles.destructiveCard}>
             <Pressable
               style={({pressed}) => [
                 styles.optionDestructive,
@@ -304,7 +314,7 @@ export const DownloadOptionsSheet = (props: SheetProps<'download-options'>) => {
               onPress={handleRemoveDownload}>
               <Feather
                 name="trash-2"
-                size={moderateScale(20)}
+                size={moderateScale(18)}
                 color="#ff4444"
               />
               <Text style={styles.optionTextDestructive}>Remove Download</Text>
@@ -322,6 +332,10 @@ const createStyles = (theme: Theme) =>
       backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
       paddingTop: moderateScale(8),
     },
     sheetContainerExpanded: {
@@ -330,6 +344,7 @@ const createStyles = (theme: Theme) =>
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       paddingHorizontal: moderateScale(20),
@@ -337,45 +352,58 @@ const createStyles = (theme: Theme) =>
     },
     header: {
       alignItems: 'center',
-      marginTop: moderateScale(8),
-      marginBottom: moderateScale(20),
-      gap: moderateScale(4),
+      marginTop: moderateScale(4),
+      marginBottom: moderateScale(14),
+      gap: moderateScale(2),
     },
     surahName: {
-      fontSize: moderateScale(20),
+      fontSize: moderateScale(18),
       fontFamily: 'Manrope-Bold',
       color: theme.colors.text,
       textAlign: 'center',
     },
     surahTranslation: {
-      fontSize: moderateScale(14),
+      fontSize: moderateScale(13),
       fontFamily: 'Manrope-Medium',
-      color: theme.colors.textSecondary,
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
       textAlign: 'center',
     },
-    optionsGrid: {
-      gap: moderateScale(8),
+    card: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+      marginBottom: moderateScale(8),
+    },
+    destructiveCard: {
+      backgroundColor: 'rgba(255, 68, 68, 0.1)',
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+    },
+    divider: {
+      height: 1,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      marginHorizontal: moderateScale(14),
     },
     option: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
     },
     optionDisabled: {
       opacity: 0.5,
     },
     optionPressed: {
-      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     optionText: {
       flex: 1,
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: theme.colors.text,
-      marginLeft: moderateScale(12),
+      marginLeft: moderateScale(10),
     },
     optionTextDisabled: {
       color: theme.colors.textSecondary,
@@ -383,20 +411,18 @@ const createStyles = (theme: Theme) =>
     optionDestructive: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
-      backgroundColor: 'rgba(255, 68, 68, 0.1)',
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
     },
     optionDestructivePressed: {
       backgroundColor: 'rgba(255, 68, 68, 0.18)',
     },
     optionTextDestructive: {
       flex: 1,
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: '#ff4444',
-      marginLeft: moderateScale(12),
+      marginLeft: moderateScale(10),
     },
     rotatedIcon: {
       transform: [{rotate: '180deg'}],
@@ -406,7 +432,7 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerTitle: {
       fontSize: moderateScale(18),

--- a/components/sheets/FavoriteRecitersSheet.tsx
+++ b/components/sheets/FavoriteRecitersSheet.tsx
@@ -133,8 +133,8 @@ export const FavoriteRecitersSheet = (
             placeholder="Search reciters..."
             value={searchQuery}
             onChangeText={setSearchQuery}
-            backgroundColor={Color(theme.colors.card).alpha(0.5).toString()}
-            borderColor={Color(theme.colors.border).alpha(0.1).toString()}
+            backgroundColor={Color(theme.colors.text).alpha(0.04).toString()}
+            borderColor={Color(theme.colors.text).alpha(0.06).toString()}
             iconColor={theme.colors.textSecondary}
             textColor={theme.colors.text}
             showCancelButton={false}
@@ -176,10 +176,15 @@ const createStyles = (theme: Theme) =>
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
       height: SCREEN_HEIGHT * 0.85,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     header: {
       flexDirection: 'row',

--- a/components/sheets/FollowAlongSheet.tsx
+++ b/components/sheets/FollowAlongSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo} from 'react';
-import {View, Text, FlatList} from 'react-native';
+import {View, Text, FlatList, StyleSheet} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -66,16 +66,21 @@ const createStyles = (theme: Theme) =>
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
       maxHeight: '80%',
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     headerContainer: {
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerTitle: {
       fontSize: moderateScale(18),

--- a/components/sheets/MushafPlayerOptionsSheet.tsx
+++ b/components/sheets/MushafPlayerOptionsSheet.tsx
@@ -606,10 +606,15 @@ const createStyles = (theme: Theme) =>
       borderTopRightRadius: ms(20),
       paddingTop: ms(8),
       maxHeight: '85%',
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: ms(40),
+      height: 2.5,
     },
     scrollView: {
       flexGrow: 0,

--- a/components/sheets/MushafRepeatOptionsSheet.tsx
+++ b/components/sheets/MushafRepeatOptionsSheet.tsx
@@ -293,10 +293,15 @@ const createStyles = (theme: Theme) =>
       borderTopLeftRadius: ms(20),
       borderTopRightRadius: ms(20),
       paddingTop: ms(8),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: ms(40),
+      height: 2.5,
     },
     container: {
       paddingHorizontal: ms(20),

--- a/components/sheets/OrganizeRecitationSheet.tsx
+++ b/components/sheets/OrganizeRecitationSheet.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   TextInput,
   Pressable,
+  StyleSheet,
   Keyboard,
   Platform,
   Dimensions,
@@ -926,10 +927,15 @@ const createStyles = (theme: Theme) =>
       paddingTop: moderateScale(8),
       paddingBottom: 0,
       height: SCREEN_HEIGHT,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     headerContainer: {
       flexDirection: 'row',
@@ -938,7 +944,7 @@ const createStyles = (theme: Theme) =>
       paddingHorizontal: moderateScale(20),
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerButton: {
       minWidth: moderateScale(60),
@@ -971,7 +977,7 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.08).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
       marginBottom: moderateScale(20),
     },
     fileIconContainer: {
@@ -1063,7 +1069,7 @@ const createStyles = (theme: Theme) =>
       paddingHorizontal: moderateScale(14),
       paddingVertical: moderateScale(10),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.06).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     resultNumber: {
       fontSize: moderateScale(13),

--- a/components/sheets/PlaybackSpeedSheet.tsx
+++ b/components/sheets/PlaybackSpeedSheet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {TouchableOpacity, Text, View} from 'react-native';
+import {Pressable, StyleSheet, Text, View} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -38,14 +38,14 @@ export const PlaybackSpeedSheet = (props: SheetProps<'playback-speed'>) => {
       <View style={styles.container}>
         <View style={styles.speedContainer}>
           {SPEEDS.map(speed => (
-            <TouchableOpacity
+            <Pressable
               key={speed}
-              style={[
+              style={({pressed}) => [
                 styles.speedButton,
                 currentSpeed === speed && styles.selectedSpeed,
+                pressed && !currentSpeed && styles.speedButtonPressed,
               ]}
-              onPress={() => handleSpeedSelect(speed)}
-              activeOpacity={0.7}>
+              onPress={() => handleSpeedSelect(speed)}>
               <Text
                 style={[
                   styles.speedText,
@@ -53,7 +53,7 @@ export const PlaybackSpeedSheet = (props: SheetProps<'playback-speed'>) => {
                 ]}>
                 {speed}x
               </Text>
-            </TouchableOpacity>
+            </Pressable>
           ))}
         </View>
       </View>
@@ -68,16 +68,21 @@ const createStyles = (theme: Theme) =>
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     headerContainer: {
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerTitle: {
       fontSize: moderateScale(18),
@@ -99,7 +104,10 @@ const createStyles = (theme: Theme) =>
       paddingVertical: moderateScale(10),
       paddingHorizontal: moderateScale(20),
       borderRadius: moderateScale(20),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+    },
+    speedButtonPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.1).toString(),
     },
     selectedSpeed: {
       backgroundColor: theme.colors.text,

--- a/components/sheets/PlayerOptionsSheet.tsx
+++ b/components/sheets/PlayerOptionsSheet.tsx
@@ -3,6 +3,7 @@ import {
   View,
   Text,
   Pressable,
+  StyleSheet,
   useWindowDimensions,
   Dimensions,
 } from 'react-native';
@@ -63,7 +64,6 @@ export const PlayerOptionsSheet = (props: SheetProps<'player-options'>) => {
   const {theme} = useTheme();
   const styles = createStyles(theme);
   const {width} = useWindowDimensions();
-  const [pressedOption, setPressedOption] = useState<string | null>(null);
   const [showSurahInfo, setShowSurahInfo] = useState(false);
 
   // Extract payload
@@ -275,6 +275,154 @@ export const PlayerOptionsSheet = (props: SheetProps<'player-options'>) => {
   const showGoToReciter = !!onGoToReciter;
   const showLearnAboutSurah = !!surah;
 
+  // Build option entries for the card
+  const optionEntries: {key: string; render: () => React.ReactNode}[] = [];
+
+  if (showEditDetails) {
+    optionEntries.push({
+      key: 'edit',
+      render: () => (
+        <Pressable
+          style={({pressed}) => [
+            styles.option,
+            pressed && styles.optionPressed,
+          ]}
+          onPress={handleEditDetails}>
+          <FontAwesome5
+            name="sliders-h"
+            size={moderateScale(16)}
+            color={theme.colors.text}
+          />
+          <Text style={styles.optionText}>Edit Details</Text>
+        </Pressable>
+      ),
+    });
+  }
+
+  if (showDownload) {
+    optionEntries.push({
+      key: 'download',
+      render: () => (
+        <Pressable
+          style={({pressed}) => [
+            styles.option,
+            pressed && styles.optionPressed,
+          ]}
+          onPress={handleDownload}>
+          {isCurrentlyDownloading ? (
+            <CircularProgress
+              progress={downloadProgress}
+              size={moderateScale(18)}
+              strokeWidth={moderateScale(2.5)}
+              color={theme.colors.text}
+            />
+          ) : isTrackDownloaded ? (
+            <CheckIcon color={theme.colors.text} size={moderateScale(18)} />
+          ) : (
+            <Ionicons
+              name="arrow-down"
+              size={moderateScale(18)}
+              color={theme.colors.text}
+            />
+          )}
+          <Text style={styles.optionText}>
+            {isCurrentlyDownloading
+              ? `Downloading ${Math.round(downloadProgress * 100)}%`
+              : isTrackDownloaded
+              ? 'Downloaded'
+              : 'Download'}
+          </Text>
+        </Pressable>
+      ),
+    });
+  }
+
+  if (showAddToCollection) {
+    optionEntries.push({
+      key: 'collection',
+      render: () => (
+        <Pressable
+          style={({pressed}) => [
+            styles.option,
+            pressed && styles.optionPressed,
+          ]}
+          onPress={handleAddToPlaylist}>
+          <Feather
+            name="plus-circle"
+            size={moderateScale(18)}
+            color={theme.colors.text}
+          />
+          <Text style={styles.optionText}>Add to Collection</Text>
+        </Pressable>
+      ),
+    });
+  }
+
+  if (showLove) {
+    optionEntries.push({
+      key: 'love',
+      render: () => (
+        <Pressable
+          style={({pressed}) => [
+            styles.option,
+            pressed && styles.optionPressed,
+          ]}
+          onPress={handleToggleLove}>
+          <HeartIcon
+            color={theme.colors.text}
+            size={moderateScale(18)}
+            filled={isLovedState}
+          />
+          <Text style={styles.optionText}>
+            {isLovedState ? 'Remove from Loved' : 'Add to Loved'}
+          </Text>
+        </Pressable>
+      ),
+    });
+  }
+
+  if (showGoToReciter) {
+    optionEntries.push({
+      key: 'reciter',
+      render: () => (
+        <Pressable
+          style={({pressed}) => [
+            styles.option,
+            pressed && styles.optionPressed,
+          ]}
+          onPress={handleGoToReciter}>
+          <ProfileIcon
+            color={theme.colors.text}
+            size={moderateScale(18)}
+            filled={false}
+          />
+          <Text style={styles.optionText}>Go to Reciter</Text>
+        </Pressable>
+      ),
+    });
+  }
+
+  if (showLearnAboutSurah) {
+    optionEntries.push({
+      key: 'info',
+      render: () => (
+        <Pressable
+          style={({pressed}) => [
+            styles.option,
+            pressed && styles.optionPressed,
+          ]}
+          onPress={handleViewInfo}>
+          <Feather
+            name="info"
+            size={moderateScale(18)}
+            color={theme.colors.text}
+          />
+          <Text style={styles.optionText}>Learn About Surah</Text>
+        </Pressable>
+      ),
+    });
+  }
+
   return (
     <ActionSheet
       id={props.sheetId}
@@ -326,124 +474,13 @@ export const PlayerOptionsSheet = (props: SheetProps<'player-options'>) => {
             </Text>
           </View>
 
-          <View style={styles.optionsGrid}>
-            {showEditDetails && (
-              <Pressable
-                style={({pressed}) => [
-                  styles.option,
-                  pressed && styles.optionPressed,
-                ]}
-                onPress={handleEditDetails}>
-                <FontAwesome5
-                  name="sliders-h"
-                  size={moderateScale(18)}
-                  color={theme.colors.text}
-                />
-                <Text style={styles.optionText}>Edit Details</Text>
-              </Pressable>
-            )}
-
-            {showDownload && (
-              <Pressable
-                style={({pressed}) => [
-                  styles.option,
-                  pressed && styles.optionPressed,
-                ]}
-                onPress={handleDownload}>
-                {isCurrentlyDownloading ? (
-                  <CircularProgress
-                    progress={downloadProgress}
-                    size={moderateScale(20)}
-                    strokeWidth={moderateScale(2.5)}
-                    color={theme.colors.text}
-                  />
-                ) : isTrackDownloaded ? (
-                  <CheckIcon
-                    color={theme.colors.text}
-                    size={moderateScale(20)}
-                  />
-                ) : (
-                  <Ionicons
-                    name="arrow-down"
-                    size={moderateScale(20)}
-                    color={theme.colors.text}
-                  />
-                )}
-                <Text style={styles.optionText}>
-                  {isCurrentlyDownloading
-                    ? `Downloading ${Math.round(downloadProgress * 100)}%`
-                    : isTrackDownloaded
-                    ? 'Downloaded'
-                    : 'Download'}
-                </Text>
-              </Pressable>
-            )}
-
-            {showAddToCollection && (
-              <Pressable
-                style={({pressed}) => [
-                  styles.option,
-                  pressed && styles.optionPressed,
-                ]}
-                onPress={handleAddToPlaylist}>
-                <Feather
-                  name="plus-circle"
-                  size={moderateScale(20)}
-                  color={theme.colors.text}
-                />
-                <Text style={styles.optionText}>Add to Collection</Text>
-              </Pressable>
-            )}
-
-            {showLove && (
-              <Pressable
-                style={({pressed}) => [
-                  styles.option,
-                  pressed && styles.optionPressed,
-                ]}
-                onPress={handleToggleLove}>
-                <HeartIcon
-                  color={theme.colors.text}
-                  size={moderateScale(20)}
-                  filled={isLovedState}
-                />
-                <Text style={styles.optionText}>
-                  {isLovedState ? 'Remove from Loved' : 'Add to Loved'}
-                </Text>
-              </Pressable>
-            )}
-
-            {showGoToReciter && (
-              <Pressable
-                style={({pressed}) => [
-                  styles.option,
-                  pressed && styles.optionPressed,
-                ]}
-                onPress={handleGoToReciter}>
-                <ProfileIcon
-                  color={theme.colors.text}
-                  size={moderateScale(20)}
-                  filled={false}
-                />
-                <Text style={styles.optionText}>Go to Reciter</Text>
-              </Pressable>
-            )}
-
-            {showLearnAboutSurah && (
-              <Pressable
-                style={({pressed}) => [
-                  styles.option,
-                  pressed && styles.optionPressed,
-                ]}
-                onPress={handleViewInfo}>
-                <Feather
-                  name="info"
-                  size={moderateScale(20)}
-                  color={theme.colors.text}
-                />
-                <Text style={styles.optionText}>Learn About Surah</Text>
-              </Pressable>
-            )}
+          <View style={styles.card}>
+            {optionEntries.map((entry, idx) => (
+              <React.Fragment key={entry.key}>
+                {idx > 0 && <View style={styles.divider} />}
+                {entry.render()}
+              </React.Fragment>
+            ))}
           </View>
         </View>
       )}
@@ -457,6 +494,10 @@ const createStyles = (theme: Theme) =>
       backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
       paddingTop: moderateScale(8),
     },
     sheetContainerExpanded: {
@@ -465,6 +506,7 @@ const createStyles = (theme: Theme) =>
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       paddingHorizontal: moderateScale(20),
@@ -472,49 +514,57 @@ const createStyles = (theme: Theme) =>
     },
     header: {
       alignItems: 'center',
-      marginTop: moderateScale(8),
-      marginBottom: moderateScale(20),
-      gap: moderateScale(4),
+      marginTop: moderateScale(4),
+      marginBottom: moderateScale(14),
+      gap: moderateScale(2),
     },
     surahName: {
-      fontSize: moderateScale(20),
+      fontSize: moderateScale(18),
       fontFamily: 'Manrope-Bold',
       color: theme.colors.text,
       textAlign: 'center',
     },
     surahTranslation: {
-      fontSize: moderateScale(14),
+      fontSize: moderateScale(13),
       fontFamily: 'Manrope-Medium',
-      color: theme.colors.textSecondary,
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
       textAlign: 'center',
     },
-    optionsGrid: {
-      gap: moderateScale(8),
+    card: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+      marginBottom: moderateScale(8),
+    },
+    divider: {
+      height: 1,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      marginHorizontal: moderateScale(14),
     },
     option: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
     },
     optionPressed: {
-      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     optionText: {
       flex: 1,
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: theme.colors.text,
-      marginLeft: moderateScale(12),
+      marginLeft: moderateScale(10),
     },
     // Surah Info styles
     headerContainer: {
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerTitle: {
       fontSize: moderateScale(18),

--- a/components/sheets/PlaylistContextSheet.tsx
+++ b/components/sheets/PlaylistContextSheet.tsx
@@ -1,5 +1,12 @@
 import React, {useState, useCallback, useRef, useEffect} from 'react';
-import {View, Text, TouchableOpacity, StyleSheet, Alert} from 'react-native';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  Alert,
+  ActivityIndicator,
+} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {Feather} from '@expo/vector-icons';
 import ActionSheet, {
@@ -10,7 +17,6 @@ import {useTheme} from '@/hooks/useTheme';
 import {usePlaylistsStore} from '@/store/playlistsStore';
 import {downloadSurah} from '@/services/downloadService';
 import {useDownloadStore} from '@/services/player/store/downloadStore';
-import {ActivityIndicator} from 'react-native';
 import {CheckIcon} from '@/components/Icons';
 import {Ionicons} from '@expo/vector-icons';
 import {useCollectionDownloadState} from '@/hooks/useCollectionDownloadState';
@@ -389,7 +395,13 @@ export const PlaylistContextSheet = (props: SheetProps<'playlist-context'>) => {
       id={props.sheetId}
       containerStyle={[
         styles.sheetContainer,
-        {backgroundColor: theme.colors.background},
+        {
+          backgroundColor: theme.colors.background,
+          borderTopWidth: StyleSheet.hairlineWidth,
+          borderLeftWidth: StyleSheet.hairlineWidth,
+          borderRightWidth: StyleSheet.hairlineWidth,
+          borderColor: Color(theme.colors.text).alpha(0.08).toString(),
+        },
       ]}
       indicatorStyle={[
         styles.indicator,
@@ -402,26 +414,39 @@ export const PlaylistContextSheet = (props: SheetProps<'playlist-context'>) => {
         </Text>
 
         {isDownloadingPlaylist && (
-          <View style={styles.progressContainer}>
+          <View
+            style={[
+              styles.progressContainer,
+              {
+                backgroundColor: Color(theme.colors.text)
+                  .alpha(0.04)
+                  .toString(),
+              },
+            ]}>
             <View style={styles.progressHeader}>
               <Text style={[styles.progressText, {color: theme.colors.text}]}>
                 Downloading playlist...
               </Text>
               <Text
-                style={[
-                  styles.progressPercentage,
-                  {color: theme.colors.primary},
-                ]}>
+                style={[styles.progressPercentage, {color: theme.colors.text}]}>
                 {Math.round(downloadProgress.percentage)}%
               </Text>
             </View>
-            <View style={styles.progressBarContainer}>
+            <View
+              style={[
+                styles.progressBarContainer,
+                {
+                  backgroundColor: Color(theme.colors.text)
+                    .alpha(0.08)
+                    .toString(),
+                },
+              ]}>
               <View
                 style={[
                   styles.progressBar,
                   {
                     width: `${downloadProgress.percentage}%`,
-                    backgroundColor: theme.colors.primary,
+                    backgroundColor: theme.colors.text,
                   },
                 ]}
               />
@@ -436,72 +461,95 @@ export const PlaylistContextSheet = (props: SheetProps<'playlist-context'>) => {
           </View>
         )}
 
-        <View style={styles.optionsContainer}>
+        <View
+          style={[
+            styles.optionsCard,
+            {
+              backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+              borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+            },
+          ]}>
           {options.map((option, index) => (
-            <TouchableOpacity
-              key={index}
-              style={[
-                styles.option,
-                !option.destructive && {backgroundColor: theme.colors.card},
-                option.disabled && styles.optionDisabled,
-                option.destructive && [
-                  styles.optionDestructive,
-                  {backgroundColor: 'rgba(255, 68, 68, 0.1)'},
-                ],
-              ]}
-              onPress={option.onPress}
-              disabled={option.disabled}
-              activeOpacity={option.disabled ? 1 : 0.7}>
-              {isDownloadingPlaylist && option.isDownloadOption ? (
-                <ActivityIndicator
-                  size="small"
-                  color={theme.colors.primary}
-                  style={styles.downloadIcon}
-                />
-              ) : option.isDownloadOption ? (
-                downloadState.allDownloaded && !downloadState.hasNoTracks ? (
-                  <CheckIcon
-                    color={
-                      option.disabled
-                        ? theme.colors.textSecondary
-                        : theme.colors.text
-                    }
-                    size={moderateScale(20)}
-                  />
-                ) : (
-                  <Ionicons
-                    name="arrow-down"
-                    size={moderateScale(20)}
-                    color={
-                      option.disabled
-                        ? theme.colors.textSecondary
-                        : theme.colors.text
-                    }
-                  />
-                )
-              ) : (
-                <Feather
-                  name={option.icon as any}
-                  size={moderateScale(20)}
-                  color={
-                    option.disabled
-                      ? theme.colors.textSecondary
-                      : option.destructive
-                      ? '#ff4444'
-                      : theme.colors.text
-                  }
+            <React.Fragment key={index}>
+              {index > 0 && (
+                <View
+                  style={[
+                    styles.divider,
+                    {
+                      backgroundColor: Color(theme.colors.text)
+                        .alpha(0.06)
+                        .toString(),
+                    },
+                  ]}
                 />
               )}
-              <Text
-                style={[
-                  styles.optionText,
-                  {color: theme.colors.text},
-                  option.disabled && styles.optionTextDisabled,
-                  option.destructive && styles.optionTextDestructive,
-                ]}>
-                {option.label}
-              </Text>
-            </TouchableOpacity>
+              <Pressable
+                style={({pressed}) => [
+                  styles.option,
+                  option.disabled && styles.optionDisabled,
+                  option.destructive && {
+                    backgroundColor: 'rgba(255, 68, 68, 0.1)',
+                  },
+                  pressed &&
+                    !option.disabled && {
+                      backgroundColor: Color(theme.colors.text)
+                        .alpha(0.06)
+                        .toString(),
+                    },
+                ]}
+                onPress={option.onPress}
+                disabled={option.disabled}>
+                {isDownloadingPlaylist && option.isDownloadOption ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={theme.colors.text}
+                    style={styles.downloadIcon}
+                  />
+                ) : option.isDownloadOption ? (
+                  downloadState.allDownloaded && !downloadState.hasNoTracks ? (
+                    <CheckIcon
+                      color={
+                        option.disabled
+                          ? theme.colors.textSecondary
+                          : theme.colors.text
+                      }
+                      size={moderateScale(20)}
+                    />
+                  ) : (
+                    <Ionicons
+                      name="arrow-down"
+                      size={moderateScale(20)}
+                      color={
+                        option.disabled
+                          ? theme.colors.textSecondary
+                          : theme.colors.text
+                      }
+                    />
+                  )
+                ) : (
+                  <Feather
+                    name={option.icon as any}
+                    size={moderateScale(20)}
+                    color={
+                      option.disabled
+                        ? theme.colors.textSecondary
+                        : option.destructive
+                        ? '#ff4444'
+                        : theme.colors.text
+                    }
+                  />
+                )}
+                <Text
+                  style={[
+                    styles.optionText,
+                    {color: Color(theme.colors.text).alpha(0.85).toString()},
+                    option.disabled && styles.optionTextDisabled,
+                    option.destructive && styles.optionTextDestructive,
+                  ]}>
+                  {option.label}
+                </Text>
+              </Pressable>
+            </React.Fragment>
           ))}
         </View>
       </View>
@@ -517,6 +565,7 @@ const styles = StyleSheet.create({
   },
   indicator: {
     width: moderateScale(40),
+    height: 2.5,
   },
   container: {
     padding: moderateScale(16),
@@ -524,28 +573,28 @@ const styles = StyleSheet.create({
   },
   playlistName: {
     fontSize: moderateScale(18),
-    fontWeight: '600',
+    fontFamily: 'Manrope-SemiBold',
     textAlign: 'center',
     marginBottom: moderateScale(20),
   },
-  optionsContainer: {
-    gap: moderateScale(8),
+  optionsCard: {
+    borderWidth: 1,
+    borderRadius: moderateScale(14),
+    overflow: 'hidden',
   },
   option: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingVertical: moderateScale(16),
     paddingHorizontal: moderateScale(16),
-    borderRadius: moderateScale(8),
   },
   optionDisabled: {
     opacity: 0.5,
   },
-  optionDestructive: {},
   optionText: {
-    fontSize: moderateScale(16),
+    fontSize: moderateScale(13.5),
     marginLeft: moderateScale(12),
-    fontWeight: '500',
+    fontFamily: 'Manrope-Medium',
   },
   optionTextDisabled: {
     opacity: 0.5,
@@ -553,11 +602,13 @@ const styles = StyleSheet.create({
   optionTextDestructive: {
     color: '#ff4444',
   },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+  },
   progressContainer: {
     marginBottom: moderateScale(16),
     padding: moderateScale(12),
     borderRadius: moderateScale(8),
-    backgroundColor: 'rgba(99, 102, 241, 0.1)',
   },
   progressHeader: {
     flexDirection: 'row',
@@ -567,15 +618,14 @@ const styles = StyleSheet.create({
   },
   progressText: {
     fontSize: moderateScale(14),
-    fontWeight: '500',
+    fontFamily: 'Manrope-Medium',
   },
   progressPercentage: {
     fontSize: moderateScale(14),
-    fontWeight: '600',
+    fontFamily: 'Manrope-SemiBold',
   },
   progressBarContainer: {
     height: moderateScale(4),
-    backgroundColor: 'rgba(0, 0, 0, 0.1)',
     borderRadius: moderateScale(2),
     overflow: 'hidden',
     marginBottom: moderateScale(4),

--- a/components/sheets/RewayatInfoSheet.tsx
+++ b/components/sheets/RewayatInfoSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {View, Text, TouchableOpacity, Dimensions} from 'react-native';
+import {View, Text, Pressable, Dimensions, StyleSheet} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import ActionSheet, {
@@ -85,14 +85,14 @@ Each Rewayah may have slight variations in pronunciation, elongation, or articul
           <Text style={styles.sectionTitle}>Available Rewayat</Text>
           <View style={styles.rewayatList}>
             {availableRewayat.map(rewayat => (
-              <TouchableOpacity
+              <Pressable
                 key={rewayat.id}
-                style={[
+                style={({pressed}) => [
                   styles.rewayatItem,
                   selectedRewayatId === rewayat.id && styles.selectedRewayat,
+                  pressed && styles.rewayatItemPressed,
                 ]}
-                onPress={() => handleRewayatSelect(rewayat.id)}
-                activeOpacity={0.7}>
+                onPress={() => handleRewayatSelect(rewayat.id)}>
                 <View>
                   <Text style={styles.rewayatName}>{rewayat.name}</Text>
                   <Text style={styles.rewayatStyle}>{rewayat.style}</Text>
@@ -100,7 +100,7 @@ Each Rewayah may have slight variations in pronunciation, elongation, or articul
                 {selectedRewayatId === rewayat.id && (
                   <View style={styles.selectedIndicator} />
                 )}
-              </TouchableOpacity>
+              </Pressable>
             ))}
           </View>
         </View>
@@ -118,15 +118,21 @@ const createStyles = (theme: Theme) =>
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
       height: SCREEN_HEIGHT * 0.85,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
+      backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     headerContainer: {
       alignItems: 'center',
       paddingVertical: moderateScale(16),
-      borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerTitle: {
       fontSize: moderateScale(18),
@@ -155,15 +161,17 @@ const createStyles = (theme: Theme) =>
       marginTop: moderateScale(8),
     },
     divider: {
-      height: 1,
-      backgroundColor: Color(theme.colors.border).alpha(0.1).toString(),
+      height: StyleSheet.hairlineWidth,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
       marginVertical: moderateScale(10),
     },
     sectionTitle: {
-      fontSize: moderateScale(18),
-      fontFamily: 'Manrope-Bold',
-      color: theme.colors.text,
+      fontSize: moderateScale(10.5),
+      fontFamily: 'Manrope-SemiBold',
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
       marginBottom: moderateScale(16),
+      letterSpacing: 1.2,
+      textTransform: 'uppercase',
     },
     rewayatList: {
       gap: moderateScale(12),
@@ -173,12 +181,17 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       justifyContent: 'space-between',
       padding: moderateScale(16),
-      backgroundColor: theme.colors.card,
-      borderRadius: moderateScale(12),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderRadius: moderateScale(14),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     selectedRewayat: {
-      backgroundColor: Color(theme.colors.text).alpha(0.1).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
       borderColor: theme.colors.text,
+    },
+    rewayatItemPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     rewayatName: {
       fontSize: moderateScale(16),

--- a/components/sheets/SelectPlaylistSheet.tsx
+++ b/components/sheets/SelectPlaylistSheet.tsx
@@ -1,5 +1,12 @@
 import React, {useCallback, useState} from 'react';
-import {View, Text, TouchableOpacity, Alert, Dimensions} from 'react-native';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  Alert,
+  Dimensions,
+} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -153,13 +160,13 @@ export const SelectPlaylistSheet = (props: SheetProps<'select-playlist'>) => {
             nestedScrollEnabled={true}>
             {/* Add to Loved Option */}
             {reciterId && (
-              <TouchableOpacity
-                style={[
+              <Pressable
+                style={({pressed}) => [
                   styles.lovedOption,
                   isLovedState && styles.lovedOptionActive,
+                  pressed && styles.lovedOptionPressed,
                 ]}
-                onPress={handleToggleLoved}
-                activeOpacity={0.7}>
+                onPress={handleToggleLoved}>
                 <View
                   style={[
                     styles.lovedIconContainer,
@@ -178,26 +185,28 @@ export const SelectPlaylistSheet = (props: SheetProps<'select-playlist'>) => {
                   ]}>
                   Loved
                 </Text>
-              </TouchableOpacity>
+              </Pressable>
             )}
 
             {/* Create New Playlist Button */}
-            <TouchableOpacity
-              style={styles.createButton}
+            <Pressable
+              style={({pressed}) => [
+                styles.createButton,
+                pressed && styles.createButtonPressed,
+              ]}
               onPress={handleShowCreatePlaylist}
-              activeOpacity={0.7}
               disabled={isCreating}>
               <View style={styles.createButtonContent}>
                 <Feather
                   name="plus"
-                  size={moderateScale(20)}
+                  size={moderateScale(18)}
                   color={theme.colors.text}
                 />
                 <Text style={styles.createButtonText}>
                   {isCreating ? 'Creating...' : 'Create New Playlist'}
                 </Text>
               </View>
-            </TouchableOpacity>
+            </Pressable>
 
             {/* Existing Playlists */}
             {playlists.length > 0 && (
@@ -241,18 +250,23 @@ const createStyles = (theme: Theme) =>
       backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
       paddingTop: moderateScale(8),
       height: SCREEN_HEIGHT * 0.75,
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     headerContainer: {
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerTitle: {
       fontSize: moderateScale(18),
@@ -266,18 +280,18 @@ const createStyles = (theme: Theme) =>
     header: {
       alignItems: 'center',
       marginVertical: moderateScale(16),
-      gap: moderateScale(4),
+      gap: moderateScale(2),
     },
     surahName: {
-      fontSize: moderateScale(20),
+      fontSize: moderateScale(18),
       fontFamily: 'Manrope-Bold',
       color: theme.colors.text,
       textAlign: 'center',
     },
     surahTranslation: {
-      fontSize: moderateScale(14),
+      fontSize: moderateScale(13),
       fontFamily: 'Manrope-Medium',
-      color: theme.colors.textSecondary,
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
       textAlign: 'center',
     },
     scrollView: {
@@ -288,15 +302,18 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       paddingVertical: moderateScale(12),
       paddingHorizontal: moderateScale(16),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
       borderRadius: moderateScale(12),
       marginBottom: moderateScale(16),
       borderWidth: 1,
-      borderColor: 'transparent',
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     lovedOptionActive: {
       backgroundColor: Color('#FF6B6B').alpha(0.08).toString(),
       borderColor: Color('#FF6B6B').alpha(0.2).toString(),
+    },
+    lovedOptionPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     lovedIconContainer: {
       width: moderateScale(50),
@@ -312,7 +329,7 @@ const createStyles = (theme: Theme) =>
     },
     lovedText: {
       flex: 1,
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: theme.colors.text,
       marginLeft: moderateScale(12),
@@ -321,21 +338,26 @@ const createStyles = (theme: Theme) =>
       color: '#FF6B6B',
     },
     createButton: {
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
       borderRadius: moderateScale(12),
       marginBottom: moderateScale(20),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+    },
+    createButtonPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     createButtonContent: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
+      paddingVertical: moderateScale(14),
+      paddingHorizontal: moderateScale(14),
     },
     createButtonText: {
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: theme.colors.text,
-      marginLeft: moderateScale(12),
+      marginLeft: moderateScale(10),
     },
     playlistsContainer: {
       marginBottom: moderateScale(20),

--- a/components/sheets/SelectReciterSheet.tsx
+++ b/components/sheets/SelectReciterSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {View, Text, TouchableOpacity, Switch} from 'react-native';
+import {View, Text, Pressable, Switch, StyleSheet} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useReciterStore} from '@/store/reciterStore';
@@ -21,7 +21,6 @@ export const SelectReciterSheet = (props: SheetProps<'select-reciter'>) => {
   const styles = createStyles(theme);
   const defaultReciter = useReciterStore(state => state.defaultReciter);
   const [, setSurahName] = useState<string>('');
-  const [pressedOption, setPressedOption] = useState<string | null>(null);
   const {playWithReciter, playWithRandomReciter} = useReciterSelection();
 
   const payload = props.payload;
@@ -115,58 +114,49 @@ export const SelectReciterSheet = (props: SheetProps<'select-reciter'>) => {
         </View>
 
         <View style={styles.optionsGrid}>
-          <TouchableOpacity
-            style={[
+          <Pressable
+            style={({pressed}) => [
               styles.option,
-              pressedOption === 'default' && styles.optionPressed,
+              pressed && styles.optionPressed,
             ]}
             onPress={() =>
               handleReciterSelection(handleUseDefaultReciter, 'useDefault')
-            }
-            onPressIn={() => setPressedOption('default')}
-            onPressOut={() => setPressedOption(null)}
-            activeOpacity={1}>
+            }>
             <Ionicons
               name="person-outline"
               size={moderateScale(20)}
               color={theme.colors.text}
             />
             <Text style={styles.optionText}>Use Default Reciter</Text>
-          </TouchableOpacity>
+          </Pressable>
 
-          <TouchableOpacity
-            style={[
+          <Pressable
+            style={({pressed}) => [
               styles.option,
-              pressedOption === 'random' && styles.optionPressed,
+              pressed && styles.optionPressed,
             ]}
             onPress={() =>
               handleReciterSelection(handleUseRandomReciter, 'randomReciter')
-            }
-            onPressIn={() => setPressedOption('random')}
-            onPressOut={() => setPressedOption(null)}
-            activeOpacity={1}>
+            }>
             <DiscoverIcon size={moderateScale(20)} color={theme.colors.text} />
             <Text style={styles.optionText}>Random Reciter</Text>
-          </TouchableOpacity>
+          </Pressable>
 
-          <TouchableOpacity
-            style={[
+          <Pressable
+            style={({pressed}) => [
               styles.option,
-              pressedOption === 'browse' && styles.optionPressed,
+              pressed && styles.optionPressed,
             ]}
             onPress={() =>
               handleReciterSelection(handleBrowseAllReciters, 'browseAll')
-            }
-            onPressIn={() => setPressedOption('browse')}
-            onPressOut={() => setPressedOption(null)}
-            activeOpacity={1}>
+            }>
             <Ionicons
               name="people-outline"
               size={moderateScale(20)}
               color={theme.colors.text}
             />
             <Text style={styles.optionText}>Browse All Reciters</Text>
-          </TouchableOpacity>
+          </Pressable>
         </View>
 
         <View style={styles.askEveryTimeContainer}>
@@ -175,10 +165,10 @@ export const SelectReciterSheet = (props: SheetProps<'select-reciter'>) => {
             value={askEveryTime}
             onValueChange={handleAskEveryTimeToggle}
             trackColor={{
-              false: Color(theme.colors.border).alpha(0.3).toString(),
-              true: Color(theme.colors.text).alpha(0.3).toString(),
+              false: Color(theme.colors.text).alpha(0.1).toString(),
+              true: Color(theme.colors.text).alpha(0.65).toString(),
             }}
-            thumbColor={theme.colors.text}
+            thumbColor="#FFFFFF"
           />
         </View>
       </View>
@@ -193,10 +183,15 @@ const createStyles = (theme: Theme) =>
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       paddingHorizontal: moderateScale(20),
@@ -221,11 +216,13 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       paddingHorizontal: moderateScale(16),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
       borderRadius: moderateScale(12),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     optionPressed: {
-      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     optionText: {
       flex: 1,
@@ -241,7 +238,7 @@ const createStyles = (theme: Theme) =>
       paddingVertical: moderateScale(16),
       marginTop: moderateScale(16),
       borderTopWidth: 1,
-      borderTopColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderTopColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     askEveryTimeText: {
       fontSize: moderateScale(15),

--- a/components/sheets/SimilarVersesSheet.tsx
+++ b/components/sheets/SimilarVersesSheet.tsx
@@ -396,6 +396,7 @@ const createStyles = (theme: Theme) =>
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       paddingHorizontal: moderateScale(16),

--- a/components/sheets/SleepTimerSheet.tsx
+++ b/components/sheets/SleepTimerSheet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {TouchableOpacity, Text, View} from 'react-native';
+import {Pressable, StyleSheet, Text, View} from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -66,11 +66,14 @@ export const SleepTimerSheet = (props: SheetProps<'sleep-timer'>) => {
               timeToCompare > 0 && Math.abs(timeToCompare - minutes) <= 2;
 
             return (
-              <TouchableOpacity
+              <Pressable
                 key={minutes}
-                style={[styles.option, isSelected && styles.selectedTimer]}
-                onPress={() => handleTimerSelect(minutes)}
-                activeOpacity={0.7}>
+                style={({pressed}) => [
+                  styles.option,
+                  isSelected && styles.selectedTimer,
+                  pressed && !isSelected && styles.optionPressed,
+                ]}
+                onPress={() => handleTimerSelect(minutes)}>
                 <Text
                   style={[
                     styles.timerText,
@@ -78,17 +81,19 @@ export const SleepTimerSheet = (props: SheetProps<'sleep-timer'>) => {
                   ]}>
                   {minutes} min
                 </Text>
-              </TouchableOpacity>
+              </Pressable>
             );
           })}
         </View>
         {(sleepTimer > 0 || remainingTime !== null) && (
-          <TouchableOpacity
-            style={styles.turnOffButton}
-            onPress={handleTurnOff}
-            activeOpacity={0.7}>
+          <Pressable
+            style={({pressed}) => [
+              styles.turnOffButton,
+              pressed && styles.optionPressed,
+            ]}
+            onPress={handleTurnOff}>
             <Text style={styles.turnOffText}>Turn Off Timer</Text>
-          </TouchableOpacity>
+          </Pressable>
         )}
       </View>
     </ActionSheet>
@@ -102,16 +107,21 @@ const createStyles = (theme: Theme) =>
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
       paddingTop: moderateScale(8),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
     },
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     headerContainer: {
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerTitle: {
       fontSize: moderateScale(18),
@@ -140,7 +150,10 @@ const createStyles = (theme: Theme) =>
       paddingVertical: moderateScale(10),
       paddingHorizontal: moderateScale(20),
       borderRadius: moderateScale(20),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+    },
+    optionPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.1).toString(),
     },
     selectedTimer: {
       backgroundColor: theme.colors.text,

--- a/components/sheets/SurahOptionsSheet.tsx
+++ b/components/sheets/SurahOptionsSheet.tsx
@@ -2,7 +2,8 @@ import React, {useCallback, useState, useMemo} from 'react';
 import {
   View,
   Text,
-  TouchableOpacity,
+  Pressable,
+  StyleSheet,
   useWindowDimensions,
   Dimensions,
 } from 'react-native';
@@ -63,7 +64,6 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
   const {theme} = useTheme();
   const styles = createStyles(theme);
   const {width} = useWindowDimensions();
-  const [pressedOption, setPressedOption] = useState<string | null>(null);
   const [showSurahInfo, setShowSurahInfo] = useState(false);
 
   // Extract payload - these hooks only run when sheet is shown
@@ -301,20 +301,17 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
             </Text>
           </View>
 
-          <View style={styles.optionsGrid}>
-            <TouchableOpacity
-              style={[
+          <View style={styles.card}>
+            <Pressable
+              style={({pressed}) => [
                 styles.option,
                 !reciterId && styles.optionDisabled,
-                pressedOption === 'loved' && styles.optionPressed,
+                pressed && styles.optionPressed,
               ]}
-              onPress={handleToggleLove}
-              onPressIn={() => setPressedOption('loved')}
-              onPressOut={() => setPressedOption(null)}
-              activeOpacity={1}>
+              onPress={handleToggleLove}>
               <HeartIcon
                 color={theme.colors.text}
-                size={moderateScale(20)}
+                size={moderateScale(18)}
                 filled={isLovedState}
               />
               <Text
@@ -324,31 +321,30 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
                 ]}>
                 {isLovedState ? 'Remove from Loved' : 'Add to Loved'}
               </Text>
-            </TouchableOpacity>
+            </Pressable>
 
-            <TouchableOpacity
-              style={[
+            <View style={styles.divider} />
+
+            <Pressable
+              style={({pressed}) => [
                 styles.option,
                 !reciterId && styles.optionDisabled,
-                pressedOption === 'download' && styles.optionPressed,
+                pressed && styles.optionPressed,
               ]}
-              onPress={handleDownload}
-              onPressIn={() => setPressedOption('download')}
-              onPressOut={() => setPressedOption(null)}
-              activeOpacity={1}>
+              onPress={handleDownload}>
               {isCurrentlyDownloading ? (
                 <CircularProgress
                   progress={downloadProgress}
-                  size={moderateScale(20)}
+                  size={moderateScale(18)}
                   strokeWidth={moderateScale(2.5)}
                   color={theme.colors.text}
                 />
               ) : isTrackDownloaded ? (
-                <CheckIcon color={theme.colors.text} size={moderateScale(20)} />
+                <CheckIcon color={theme.colors.text} size={moderateScale(18)} />
               ) : (
                 <Ionicons
                   name="arrow-down"
-                  size={moderateScale(20)}
+                  size={moderateScale(18)}
                   color={theme.colors.text}
                 />
               )}
@@ -359,22 +355,21 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
                   ? 'Downloaded'
                   : 'Download'}
               </Text>
-            </TouchableOpacity>
+            </Pressable>
 
-            <TouchableOpacity
-              style={[
+            <View style={styles.divider} />
+
+            <Pressable
+              style={({pressed}) => [
                 styles.option,
                 !onAddToQueue && styles.optionDisabled,
-                pressedOption === 'queue' && styles.optionPressed,
+                pressed && styles.optionPressed,
               ]}
-              onPress={handleAddToQueue}
-              onPressIn={() => setPressedOption('queue')}
-              onPressOut={() => setPressedOption(null)}
-              activeOpacity={1}>
+              onPress={handleAddToQueue}>
               <View style={styles.rotatedIcon}>
                 <QueueIcon
                   color={theme.colors.text}
-                  size={moderateScale(20)}
+                  size={moderateScale(18)}
                   filled={true}
                 />
               </View>
@@ -385,21 +380,20 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
                 ]}>
                 Add to Queue
               </Text>
-            </TouchableOpacity>
+            </Pressable>
 
-            <TouchableOpacity
-              style={[
+            <View style={styles.divider} />
+
+            <Pressable
+              style={({pressed}) => [
                 styles.option,
                 !reciterId && styles.optionDisabled,
-                pressedOption === 'collection' && styles.optionPressed,
+                pressed && styles.optionPressed,
               ]}
-              onPress={handleAddToPlaylist}
-              onPressIn={() => setPressedOption('collection')}
-              onPressOut={() => setPressedOption(null)}
-              activeOpacity={1}>
+              onPress={handleAddToPlaylist}>
               <Feather
                 name="plus-circle"
-                size={moderateScale(20)}
+                size={moderateScale(18)}
                 color={theme.colors.text}
               />
               <Text
@@ -409,65 +403,63 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
                 ]}>
                 Add to Collection
               </Text>
-            </TouchableOpacity>
+            </Pressable>
 
             {reciterId && !payload?.hideGoToReciter && (
-              <TouchableOpacity
-                style={[
-                  styles.option,
-                  pressedOption === 'reciter' && styles.optionPressed,
-                ]}
-                onPress={handleGoToReciter}
-                onPressIn={() => setPressedOption('reciter')}
-                onPressOut={() => setPressedOption(null)}
-                activeOpacity={1}>
-                <ProfileIcon
-                  color={theme.colors.text}
-                  size={moderateScale(20)}
-                  filled={false}
-                />
-                <Text style={styles.optionText}>Go to Reciter</Text>
-              </TouchableOpacity>
+              <>
+                <View style={styles.divider} />
+                <Pressable
+                  style={({pressed}) => [
+                    styles.option,
+                    pressed && styles.optionPressed,
+                  ]}
+                  onPress={handleGoToReciter}>
+                  <ProfileIcon
+                    color={theme.colors.text}
+                    size={moderateScale(18)}
+                    filled={false}
+                  />
+                  <Text style={styles.optionText}>Go to Reciter</Text>
+                </Pressable>
+              </>
             )}
 
-            <TouchableOpacity
-              style={[
+            <View style={styles.divider} />
+
+            <Pressable
+              style={({pressed}) => [
                 styles.option,
-                pressedOption === 'info' && styles.optionPressed,
+                pressed && styles.optionPressed,
               ]}
-              onPress={handleViewInfo}
-              onPressIn={() => setPressedOption('info')}
-              onPressOut={() => setPressedOption(null)}
-              activeOpacity={1}>
+              onPress={handleViewInfo}>
               <Feather
                 name="info"
-                size={moderateScale(20)}
+                size={moderateScale(18)}
                 color={theme.colors.text}
               />
               <Text style={styles.optionText}>Learn About Surah</Text>
-            </TouchableOpacity>
+            </Pressable>
+          </View>
 
-            {onRemoveFromPlaylist && (
-              <TouchableOpacity
-                style={[
+          {onRemoveFromPlaylist && (
+            <View style={styles.destructiveCard}>
+              <Pressable
+                style={({pressed}) => [
                   styles.optionDestructive,
-                  pressedOption === 'remove' && styles.optionDestructivePressed,
+                  pressed && styles.optionDestructivePressed,
                 ]}
-                onPress={handleRemoveFromPlaylist}
-                onPressIn={() => setPressedOption('remove')}
-                onPressOut={() => setPressedOption(null)}
-                activeOpacity={1}>
+                onPress={handleRemoveFromPlaylist}>
                 <Feather
                   name="minus-circle"
-                  size={moderateScale(20)}
+                  size={moderateScale(18)}
                   color="#ff4444"
                 />
                 <Text style={styles.optionTextDestructive}>
                   Remove from Playlist
                 </Text>
-              </TouchableOpacity>
-            )}
-          </View>
+              </Pressable>
+            </View>
+          )}
         </View>
       )}
     </ActionSheet>
@@ -480,6 +472,10 @@ const createStyles = (theme: Theme) =>
       backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
       paddingTop: moderateScale(8),
     },
     sheetContainerExpanded: {
@@ -488,6 +484,7 @@ const createStyles = (theme: Theme) =>
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       paddingHorizontal: moderateScale(20),
@@ -495,45 +492,58 @@ const createStyles = (theme: Theme) =>
     },
     header: {
       alignItems: 'center',
-      marginTop: moderateScale(8),
-      marginBottom: moderateScale(20),
-      gap: moderateScale(4),
+      marginTop: moderateScale(4),
+      marginBottom: moderateScale(14),
+      gap: moderateScale(2),
     },
     surahName: {
-      fontSize: moderateScale(20),
+      fontSize: moderateScale(18),
       fontFamily: 'Manrope-Bold',
       color: theme.colors.text,
       textAlign: 'center',
     },
     surahTranslation: {
-      fontSize: moderateScale(14),
+      fontSize: moderateScale(13),
       fontFamily: 'Manrope-Medium',
-      color: theme.colors.textSecondary,
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
       textAlign: 'center',
     },
-    optionsGrid: {
-      gap: moderateScale(8),
+    card: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+      marginBottom: moderateScale(8),
+    },
+    destructiveCard: {
+      backgroundColor: 'rgba(255, 68, 68, 0.1)',
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+    },
+    divider: {
+      height: 1,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      marginHorizontal: moderateScale(14),
     },
     option: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
     },
     optionDisabled: {
       opacity: 0.5,
     },
     optionPressed: {
-      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     optionText: {
       flex: 1,
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: theme.colors.text,
-      marginLeft: moderateScale(12),
+      marginLeft: moderateScale(10),
     },
     optionTextDisabled: {
       color: theme.colors.textSecondary,
@@ -544,27 +554,25 @@ const createStyles = (theme: Theme) =>
     optionDestructive: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
-      backgroundColor: 'rgba(255, 68, 68, 0.1)',
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
     },
     optionDestructivePressed: {
       backgroundColor: 'rgba(255, 68, 68, 0.18)',
     },
     optionTextDestructive: {
       flex: 1,
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: '#ff4444',
-      marginLeft: moderateScale(12),
+      marginLeft: moderateScale(10),
     },
     // Surah Info styles
     headerContainer: {
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerTitle: {
       fontSize: moderateScale(18),

--- a/components/sheets/UploadOptionsSheet.tsx
+++ b/components/sheets/UploadOptionsSheet.tsx
@@ -3,6 +3,7 @@ import {
   View,
   Text,
   Pressable,
+  StyleSheet,
   Alert,
   useWindowDimensions,
   Dimensions,
@@ -129,7 +130,6 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
   const surah = surahNumber ? getSurahById(surahNumber) : null;
   const surahId = surah?.id?.toString() ?? '';
   const currentSurahInfo = surah ? surahInfo[surah.id] : null;
-  const isSurahType = recitation?.type === 'surah' && !!surah;
   const hasSurah = !!surah;
   const hasReciter = !!reciterId;
 
@@ -253,6 +253,139 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
   const title = getDisplayTitle(recitation);
   const subtitle = getDisplaySubtitle(recitation);
 
+  // Build option entries for the grouped card
+  const optionEntries: {key: string; render: () => React.ReactNode}[] = [];
+
+  optionEntries.push({
+    key: 'play',
+    render: () => (
+      <Pressable
+        style={({pressed}) => [styles.option, pressed && styles.optionPressed]}
+        onPress={handlePlay}>
+        <PlayIcon color={theme.colors.text} size={moderateScale(18)} />
+        <Text style={styles.optionText}>Play Now</Text>
+      </Pressable>
+    ),
+  });
+
+  optionEntries.push({
+    key: 'organize',
+    render: () => (
+      <Pressable
+        style={({pressed}) => [styles.option, pressed && styles.optionPressed]}
+        onPress={handleOrganize}>
+        <Feather
+          name="sliders"
+          size={moderateScale(18)}
+          color={theme.colors.text}
+        />
+        <Text style={styles.optionText}>Edit Details</Text>
+      </Pressable>
+    ),
+  });
+
+  optionEntries.push({
+    key: 'queue',
+    render: () => (
+      <Pressable
+        style={({pressed}) => [styles.option, pressed && styles.optionPressed]}
+        onPress={handleAddToQueue}>
+        <View style={styles.rotatedIcon}>
+          <QueueIcon
+            color={theme.colors.text}
+            size={moderateScale(18)}
+            filled={true}
+          />
+        </View>
+        <Text style={styles.optionText}>Add to Queue</Text>
+      </Pressable>
+    ),
+  });
+
+  if (hasSurah && hasReciter) {
+    optionEntries.push({
+      key: 'love',
+      render: () => (
+        <Pressable
+          style={({pressed}) => [
+            styles.option,
+            pressed && styles.optionPressed,
+          ]}
+          onPress={handleToggleLove}>
+          <HeartIcon
+            color={theme.colors.text}
+            size={moderateScale(18)}
+            filled={isLovedState}
+          />
+          <Text style={styles.optionText}>
+            {isLovedState ? 'Remove from Loved' : 'Add to Loved'}
+          </Text>
+        </Pressable>
+      ),
+    });
+
+    optionEntries.push({
+      key: 'collection',
+      render: () => (
+        <Pressable
+          style={({pressed}) => [
+            styles.option,
+            pressed && styles.optionPressed,
+          ]}
+          onPress={handleAddToPlaylist}>
+          <Feather
+            name="plus-circle"
+            size={moderateScale(18)}
+            color={theme.colors.text}
+          />
+          <Text style={styles.optionText}>Add to Collection</Text>
+        </Pressable>
+      ),
+    });
+  }
+
+  if (hasReciter) {
+    optionEntries.push({
+      key: 'reciter',
+      render: () => (
+        <Pressable
+          style={({pressed}) => [
+            styles.option,
+            pressed && styles.optionPressed,
+          ]}
+          onPress={handleGoToReciter}>
+          <ProfileIcon
+            color={theme.colors.text}
+            size={moderateScale(18)}
+            filled={false}
+          />
+          <Text style={styles.optionText}>Go to Reciter</Text>
+        </Pressable>
+      ),
+    });
+  }
+
+  if (hasSurah) {
+    optionEntries.push({
+      key: 'info',
+      render: () => (
+        <Pressable
+          style={({pressed}) => [
+            styles.option,
+            pressed && styles.optionPressed,
+          ]}
+          onPress={handleViewInfo}>
+          <Feather
+            name="info"
+            size={moderateScale(18)}
+            color={theme.colors.text}
+          />
+          <Text style={styles.optionText}>Learn About Surah</Text>
+        </Pressable>
+      ),
+    });
+  }
+
   return (
     <ActionSheet
       id={props.sheetId}
@@ -303,113 +436,16 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
             ) : null}
           </View>
 
-          <View style={styles.optionsGrid}>
-            <Pressable
-              style={({pressed}) => [
-                styles.option,
-                pressed && styles.optionPressed,
-              ]}
-              onPress={handlePlay}>
-              <PlayIcon color={theme.colors.text} size={moderateScale(20)} />
-              <Text style={styles.optionText}>Play Now</Text>
-            </Pressable>
+          <View style={styles.card}>
+            {optionEntries.map((entry, idx) => (
+              <React.Fragment key={entry.key}>
+                {idx > 0 && <View style={styles.divider} />}
+                {entry.render()}
+              </React.Fragment>
+            ))}
+          </View>
 
-            <Pressable
-              style={({pressed}) => [
-                styles.option,
-                pressed && styles.optionPressed,
-              ]}
-              onPress={handleOrganize}>
-              <Feather
-                name="sliders"
-                size={moderateScale(20)}
-                color={theme.colors.text}
-              />
-              <Text style={styles.optionText}>Edit Details</Text>
-            </Pressable>
-
-            <Pressable
-              style={({pressed}) => [
-                styles.option,
-                pressed && styles.optionPressed,
-              ]}
-              onPress={handleAddToQueue}>
-              <View style={styles.rotatedIcon}>
-                <QueueIcon
-                  color={theme.colors.text}
-                  size={moderateScale(20)}
-                  filled={true}
-                />
-              </View>
-              <Text style={styles.optionText}>Add to Queue</Text>
-            </Pressable>
-
-            {hasSurah && hasReciter && (
-              <Pressable
-                style={({pressed}) => [
-                  styles.option,
-                  pressed && styles.optionPressed,
-                ]}
-                onPress={handleToggleLove}>
-                <HeartIcon
-                  color={theme.colors.text}
-                  size={moderateScale(20)}
-                  filled={isLovedState}
-                />
-                <Text style={styles.optionText}>
-                  {isLovedState ? 'Remove from Loved' : 'Add to Loved'}
-                </Text>
-              </Pressable>
-            )}
-
-            {hasSurah && hasReciter && (
-              <Pressable
-                style={({pressed}) => [
-                  styles.option,
-                  pressed && styles.optionPressed,
-                ]}
-                onPress={handleAddToPlaylist}>
-                <Feather
-                  name="plus-circle"
-                  size={moderateScale(20)}
-                  color={theme.colors.text}
-                />
-                <Text style={styles.optionText}>Add to Collection</Text>
-              </Pressable>
-            )}
-
-            {hasReciter && (
-              <Pressable
-                style={({pressed}) => [
-                  styles.option,
-                  pressed && styles.optionPressed,
-                ]}
-                onPress={handleGoToReciter}>
-                <ProfileIcon
-                  color={theme.colors.text}
-                  size={moderateScale(20)}
-                  filled={false}
-                />
-                <Text style={styles.optionText}>Go to Reciter</Text>
-              </Pressable>
-            )}
-
-            {hasSurah && (
-              <Pressable
-                style={({pressed}) => [
-                  styles.option,
-                  pressed && styles.optionPressed,
-                ]}
-                onPress={handleViewInfo}>
-                <Feather
-                  name="info"
-                  size={moderateScale(20)}
-                  color={theme.colors.text}
-                />
-                <Text style={styles.optionText}>Learn About Surah</Text>
-              </Pressable>
-            )}
-
+          <View style={styles.destructiveCard}>
             <Pressable
               style={({pressed}) => [
                 styles.optionDestructive,
@@ -418,7 +454,7 @@ export const UploadOptionsSheet = (props: SheetProps<'upload-options'>) => {
               onPress={handleDelete}>
               <Feather
                 name="trash-2"
-                size={moderateScale(20)}
+                size={moderateScale(18)}
                 color="#ff4444"
               />
               <Text style={styles.optionTextDestructive}>Delete</Text>
@@ -436,6 +472,10 @@ const createStyles = (theme: Theme) =>
       backgroundColor: theme.colors.background,
       borderTopLeftRadius: moderateScale(20),
       borderTopRightRadius: moderateScale(20),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
       paddingTop: moderateScale(8),
     },
     sheetContainerExpanded: {
@@ -444,6 +484,7 @@ const createStyles = (theme: Theme) =>
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       paddingHorizontal: moderateScale(20),
@@ -451,60 +492,71 @@ const createStyles = (theme: Theme) =>
     },
     header: {
       alignItems: 'center',
-      marginTop: moderateScale(8),
-      marginBottom: moderateScale(20),
-      gap: moderateScale(4),
+      marginTop: moderateScale(4),
+      marginBottom: moderateScale(14),
+      gap: moderateScale(2),
     },
     title: {
-      fontSize: moderateScale(20),
+      fontSize: moderateScale(18),
       fontFamily: 'Manrope-Bold',
       color: theme.colors.text,
       textAlign: 'center',
     },
     subtitle: {
-      fontSize: moderateScale(14),
+      fontSize: moderateScale(13),
       fontFamily: 'Manrope-Medium',
-      color: theme.colors.textSecondary,
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
       textAlign: 'center',
     },
-    optionsGrid: {
-      gap: moderateScale(8),
+    card: {
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+      marginBottom: moderateScale(8),
+    },
+    destructiveCard: {
+      backgroundColor: 'rgba(255, 68, 68, 0.1)',
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+    },
+    divider: {
+      height: 1,
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      marginHorizontal: moderateScale(14),
     },
     option: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
-      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
     },
     optionPressed: {
-      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     optionText: {
       flex: 1,
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: theme.colors.text,
-      marginLeft: moderateScale(12),
+      marginLeft: moderateScale(10),
     },
     optionDestructive: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: moderateScale(16),
-      paddingHorizontal: moderateScale(16),
-      backgroundColor: 'rgba(255, 68, 68, 0.1)',
-      borderRadius: moderateScale(12),
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
     },
     optionDestructivePressed: {
       backgroundColor: 'rgba(255, 68, 68, 0.18)',
     },
     optionTextDestructive: {
       flex: 1,
-      fontSize: moderateScale(15),
+      fontSize: moderateScale(14),
       fontFamily: 'Manrope-SemiBold',
       color: '#ff4444',
-      marginLeft: moderateScale(12),
+      marginLeft: moderateScale(10),
     },
     rotatedIcon: {
       transform: [{rotate: '180deg'}],
@@ -513,7 +565,7 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       paddingVertical: moderateScale(16),
       borderBottomWidth: 1,
-      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
     },
     headerTitle: {
       fontSize: moderateScale(18),

--- a/components/sheets/VerseCopySheet.tsx
+++ b/components/sheets/VerseCopySheet.tsx
@@ -218,6 +218,7 @@ const createStyles = (theme: Theme) =>
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       padding: moderateScale(16),

--- a/components/sheets/VerseHighlightSheet.tsx
+++ b/components/sheets/VerseHighlightSheet.tsx
@@ -114,6 +114,7 @@ const createStyles = (theme: Theme) =>
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       padding: moderateScale(16),

--- a/components/sheets/VerseNoteSheet.tsx
+++ b/components/sheets/VerseNoteSheet.tsx
@@ -181,6 +181,7 @@ const createStyles = (theme: Theme) =>
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       padding: moderateScale(16),

--- a/components/sheets/VerseShareSheet.tsx
+++ b/components/sheets/VerseShareSheet.tsx
@@ -265,6 +265,7 @@ const createStyles = (theme: Theme) =>
     indicator: {
       backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
       width: moderateScale(40),
+      height: 2.5,
     },
     container: {
       padding: moderateScale(16),


### PR DESCRIPTION
## Summary
- Migrates all 28 bottom sheets + `Input` component to the unified alpha-based color system (`Color(theme.colors.text).alpha()`)
- Replaces old patterns (`theme.colors.card`, `theme.colors.border`, `TouchableOpacity`, `fontWeight` strings) with design system tokens
- Groups option rows into cards with internal hairline dividers, adds sheet container hairline borders, and standardizes indicator `height: 2.5` across all sheets

## Test plan
- [ ] Open each sheet type in iOS simulator (light + dark mode) and verify visual consistency
- [ ] Confirm Pressable press feedback (alpha 0.06 bg) works on all interactive rows
- [ ] Verify destructive option styling (red) is preserved
- [ ] Check Input component in Create Playlist and Playlist Modal sheets

🤖 Generated with [Claude Code](https://claude.com/claude-code)