### PR TITLE
feat: add word-by-word translation system

### DIFF
--- a/components/mushaf/reading/ReadingPageView.tsx
+++ b/components/mushaf/reading/ReadingPageView.tsx
@@ -66,6 +66,11 @@ const ReadingPageView: React.FC<ReadingPageViewProps> = ({
     s => s.showTransliteration,
   );
   const showTajweed = useMushafSettingsStore(s => s.showTajweed);
+  const showWBW = useMushafSettingsStore(s => s.showWBW);
+  const wbwShowTranslation = useMushafSettingsStore(s => s.wbwShowTranslation);
+  const wbwShowTransliteration = useMushafSettingsStore(
+    s => s.wbwShowTransliteration,
+  );
   const arabicFontSize = useMushafSettingsStore(s => s.arabicFontSize);
   const translationFontSize = useMushafSettingsStore(
     s => s.translationFontSize,
@@ -178,6 +183,9 @@ const ReadingPageView: React.FC<ReadingPageViewProps> = ({
           source="mushaf"
           translationName={translationName}
           translationId={selectedTranslationId}
+          showWBW={showWBW}
+          wbwShowTranslation={wbwShowTranslation}
+          wbwShowTransliteration={wbwShowTransliteration}
         />
       );
     },
@@ -198,6 +206,9 @@ const ReadingPageView: React.FC<ReadingPageViewProps> = ({
       handleVersePress,
       translationName,
       selectedTranslationId,
+      showWBW,
+      wbwShowTranslation,
+      wbwShowTransliteration,
     ],
   );
 

--- a/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
+++ b/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
@@ -20,6 +20,7 @@ import {mediumHaptics} from '@/utils/haptics';
 import {tajweedColors} from '@/constants/tajweedColors';
 import type {IndexedTajweedData} from '@/utils/tajweedLoader';
 import SkiaVerseText from './SkiaVerseText';
+import {WBWVerseView} from './WBWVerseView';
 import {
   isBundledTranslation,
   getBundledFootnotes,
@@ -75,6 +76,9 @@ interface VerseItemProps {
   translationName?: string;
   translationId?: string;
   source?: 'player' | 'mushaf';
+  showWBW?: boolean;
+  wbwShowTranslation?: boolean;
+  wbwShowTransliteration?: boolean;
 }
 
 /**
@@ -106,6 +110,9 @@ export const VerseItem = memo<VerseItemProps>(
     translationName,
     translationId,
     source,
+    showWBW,
+    wbwShowTranslation,
+    wbwShowTransliteration,
   }) => {
     const verseKey = verse.verse_key;
 
@@ -141,9 +148,15 @@ export const VerseItem = memo<VerseItemProps>(
       setArabicContainerWidth(prev => (Math.abs(prev - w) > 1 ? w : prev));
     }, []);
 
-    // Reset footnote when cell is recycled by FlashList
+    // Track which WBW word is highlighted (cleared when sheet closes)
+    const [selectedWordPosition, setSelectedWordPosition] = useState<
+      number | null
+    >(null);
+
+    // Reset footnote and word highlight when cell is recycled by FlashList
     useEffect(() => {
       setActiveFootnote(null);
+      setSelectedWordPosition(null);
     }, [verseKey]);
 
     // Batch all Color() derivations — only recomputed on theme or highlight change
@@ -229,6 +242,18 @@ export const VerseItem = memo<VerseItemProps>(
         },
       });
     }, [verseKey, verse, selectVerse]);
+
+    const handleWordPress = useCallback(
+      (position: number) => {
+        setSelectedWordPosition(position);
+        SheetManager.show('word-detail', {
+          payload: {verseKey, position},
+        }).then(() => {
+          setSelectedWordPosition(null);
+        });
+      },
+      [verseKey],
+    );
 
     const handlePress = useCallback(() => {
       onVersePress(verseKey);
@@ -382,27 +407,43 @@ export const VerseItem = memo<VerseItemProps>(
           </View>
         </View>
         {/* ---> Arabic Text Rendering <-- */}
-        <View onLayout={handleArabicLayout}>
-          {fontMgr && arabicContainerWidth > 0 ? (
-            // DK Skia Rendering (Uthmani with Digital Khatt font)
-            <SkiaVerseText
-              verseKey={verseKey}
-              fontMgr={fontMgr}
-              fontFamily={dkFontFamily}
-              fontSize={moderateScale(arabicFontSize)}
-              textColor={textColor}
-              showTajweed={showTajweed}
-              width={arabicContainerWidth}
-              indexedTajweedData={indexedTajweedData}
-            />
-          ) : isQPCSelected && tajweedNodes ? (
-            // QPC Rendering: Always use generated tajweedNodes
-            <Text style={arabicStyleNoColor}>{tajweedNodes}</Text>
-          ) : (
-            // Fallback (e.g., data is loading/missing)
-            <Text style={arabicStyle}>{verse.text || 'Loading...'}</Text>
-          )}
-        </View>
+        {showWBW ? (
+          <WBWVerseView
+            verseKey={verseKey}
+            textColor={textColor}
+            arabicFontSize={arabicFontSize}
+            dkFontFamily={dkFontFamily}
+            fontMgr={fontMgr}
+            showTranslation={wbwShowTranslation ?? true}
+            showTransliteration={wbwShowTransliteration ?? false}
+            onWordPress={handleWordPress}
+            selectedWordPosition={selectedWordPosition}
+            showTajweed={showTajweed}
+            indexedTajweedData={indexedTajweedData}
+          />
+        ) : (
+          <View onLayout={handleArabicLayout}>
+            {fontMgr && arabicContainerWidth > 0 ? (
+              // DK Skia Rendering (Uthmani with Digital Khatt font)
+              <SkiaVerseText
+                verseKey={verseKey}
+                fontMgr={fontMgr}
+                fontFamily={dkFontFamily}
+                fontSize={moderateScale(arabicFontSize)}
+                textColor={textColor}
+                showTajweed={showTajweed}
+                width={arabicContainerWidth}
+                indexedTajweedData={indexedTajweedData}
+              />
+            ) : isQPCSelected && tajweedNodes ? (
+              // QPC Rendering: Always use generated tajweedNodes
+              <Text style={arabicStyleNoColor}>{tajweedNodes}</Text>
+            ) : (
+              // Fallback (e.g., data is loading/missing)
+              <Text style={arabicStyle}>{verse.text || 'Loading...'}</Text>
+            )}
+          </View>
+        )}
         {/* ---> End Conditional Rendering <--- */}
         {showTransliteration && verse.transliteration && (
           <FormattedTextRenderer

--- a/components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx
+++ b/components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx
@@ -1,0 +1,709 @@
+import React, {memo, useCallback, useEffect, useMemo, useState} from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type GestureResponderEvent,
+  type LayoutChangeEvent,
+} from 'react-native';
+import {moderateScale, verticalScale} from 'react-native-size-matters';
+import {
+  Canvas,
+  Paragraph,
+  Skia,
+  TextHeightBehavior,
+  TextDirection,
+  type SkTypefaceFontProvider,
+} from '@shopify/react-native-skia';
+import Color from 'color';
+import {
+  digitalKhattDataService,
+  type DKWordInfo,
+} from '@/services/mushaf/DigitalKhattDataService';
+import {wbwDataService, type WBWWord} from '@/services/wbw/WBWDataService';
+import {useTheme} from '@/hooks/useTheme';
+import {mediumHaptics} from '@/utils/haptics';
+import {
+  alignWordTajweed,
+  detectWordTafkhim,
+} from '@/services/mushaf/TajweedAlignmentService';
+import {tajweedColors} from '@/constants/tajweedColors';
+import type {IndexedTajweedData} from '@/utils/tajweedLoader';
+
+// --- Constants ---
+
+const skParagraphStyle = {
+  textHeightBehavior: TextHeightBehavior.DisableAll,
+  textDirection: TextDirection.RTL,
+};
+
+const GAP = moderateScale(16);
+const DIVIDER_MARGIN = verticalScale(4);
+const DIVIDER_TOTAL_H = DIVIDER_MARGIN * 2 + StyleSheet.hairlineWidth;
+const TRANSLIT_LINE_H = moderateScale(14);
+const TRANS_LINE_H = moderateScale(14);
+const PADDING_VERTICAL = verticalScale(8);
+const TRANS_FONT_SIZE = moderateScale(11);
+const TRANSLIT_FONT_SIZE = moderateScale(10.5);
+const MIN_COL_WIDTH = moderateScale(36);
+const HIGHLIGHT_PADDING = moderateScale(4);
+const HIGHLIGHT_RADIUS = moderateScale(6);
+
+// --- Types ---
+
+interface WBWVerseViewProps {
+  verseKey: string;
+  textColor: string;
+  arabicFontSize: number;
+  dkFontFamily: string;
+  fontMgr: SkTypefaceFontProvider | null;
+  showTranslation: boolean;
+  showTransliteration: boolean;
+  onWordPress: (position: number) => void;
+  selectedWordPosition: number | null;
+  showTajweed: boolean;
+  indexedTajweedData: IndexedTajweedData | null;
+}
+
+interface MatchedWord {
+  dkWord: DKWordInfo;
+  wbwWord: WBWWord;
+}
+
+interface PositionedWord {
+  paragraph: ReturnType<ReturnType<typeof Skia.ParagraphBuilder.Make>['build']>;
+  arabicWidth: number;
+  arabicHeight: number;
+  columnWidth: number;
+  x: number;
+  y: number;
+  totalItemHeight: number;
+  /** DK word position — always unique, used as React key */
+  dkPosition: number;
+  /** WBW word position — used for tap lookup in WordDetailSheet */
+  position: number;
+  translation: string;
+  transliteration: string;
+  isEndMarker: boolean;
+}
+
+interface ComputedLayout {
+  items: PositionedWord[];
+  totalHeight: number;
+}
+
+// --- Helpers ---
+
+/** Strip Arabic diacritics for fuzzy text comparison between DK and WBW words */
+const ARABIC_DIACRITICS =
+  /[\u064B-\u065F\u0670\u06D6-\u06ED\u0617-\u061A\u08D3-\u08FF\u0640\u06E5\u06E6\u0653-\u0655\u065F\uFE70-\uFE7F\u0610-\u0615\u0656-\u065E\u0660-\u066F]/g;
+
+function stripDiacritics(text: string): string {
+  return text.replace(ARABIC_DIACRITICS, '').trim();
+}
+
+function buildParagraph(
+  text: string,
+  fontMgr: SkTypefaceFontProvider,
+  fontFamily: string,
+  fontSize: number,
+  textColor: string,
+  charToRule?: Map<number, string> | null,
+) {
+  const baseColor = Skia.Color(textColor);
+  const baseStyle = {
+    color: baseColor,
+    fontFamilies: [fontFamily],
+    fontSize,
+  };
+  const builder = Skia.ParagraphBuilder.Make(skParagraphStyle, fontMgr);
+  builder.pushStyle(baseStyle);
+
+  if (charToRule && charToRule.size > 0) {
+    // Per-character tajweed coloring
+    for (let i = 0; i < text.length; i++) {
+      const rule = charToRule.get(i);
+      if (rule && tajweedColors[rule]) {
+        builder.pushStyle({
+          ...baseStyle,
+          color: Skia.Color(tajweedColors[rule]),
+        });
+        builder.addText(text.charAt(i));
+        builder.pop();
+      } else {
+        builder.addText(text.charAt(i));
+      }
+    }
+  } else {
+    builder.addText(text);
+  }
+
+  builder.pop();
+  const p = builder.build();
+  p.layout(1000); // Large width — single word never wraps
+  return {
+    paragraph: p,
+    width: Math.ceil(p.getLongestLine()) + 1,
+    height: p.getHeight(),
+  };
+}
+
+const skLTRParagraphStyle = {
+  textHeightBehavior: TextHeightBehavior.DisableAll,
+  textDirection: TextDirection.LTR,
+};
+
+function measureTextWidth(
+  text: string,
+  fontMgr: SkTypefaceFontProvider,
+  fontSize: number,
+): number {
+  const builder = Skia.ParagraphBuilder.Make(skLTRParagraphStyle, fontMgr);
+  builder.pushStyle({
+    fontFamilies: ['ManropeRegular'],
+    fontSize,
+  });
+  builder.addText(text);
+  builder.pop();
+  const p = builder.build();
+  p.layout(10000);
+  return Math.ceil(p.getLongestLine()) + 1;
+}
+
+function computeColumnWidth(
+  arabicWidth: number,
+  translation: string,
+  transliteration: string,
+  showTranslation: boolean,
+  showTransliteration: boolean,
+  fontMgr: SkTypefaceFontProvider,
+): number {
+  let maxWidth = arabicWidth;
+  if (showTranslation && translation) {
+    maxWidth = Math.max(
+      maxWidth,
+      measureTextWidth(translation, fontMgr, TRANS_FONT_SIZE),
+    );
+  }
+  if (showTransliteration && transliteration) {
+    maxWidth = Math.max(
+      maxWidth,
+      measureTextWidth(transliteration, fontMgr, TRANSLIT_FONT_SIZE),
+    );
+  }
+  return Math.max(maxWidth, MIN_COL_WIDTH);
+}
+
+function computeRTLLayout(
+  items: Array<{
+    paragraph: ReturnType<
+      ReturnType<typeof Skia.ParagraphBuilder.Make>['build']
+    >;
+    arabicWidth: number;
+    arabicHeight: number;
+    columnWidth: number;
+    dkPosition: number;
+    position: number;
+    translation: string;
+    transliteration: string;
+    isEndMarker: boolean;
+  }>,
+  containerWidth: number,
+  subTextHeight: number,
+): ComputedLayout {
+  const positioned: PositionedWord[] = [];
+  let cursorX = containerWidth;
+  let cursorY = 0;
+  let rowMaxHeight = 0;
+
+  for (const item of items) {
+    const colWidth = item.columnWidth;
+    const itemH = item.arabicHeight + (item.isEndMarker ? 0 : subTextHeight);
+
+    // Wrap to next row if doesn't fit (unless it's the first item in a row)
+    if (cursorX - colWidth < 0 && cursorX < containerWidth) {
+      cursorY += rowMaxHeight + GAP;
+      cursorX = containerWidth;
+      rowMaxHeight = 0;
+    }
+
+    cursorX -= colWidth;
+
+    positioned.push({
+      ...item,
+      x: cursorX,
+      y: cursorY,
+      totalItemHeight: itemH,
+    });
+
+    rowMaxHeight = Math.max(rowMaxHeight, itemH);
+    cursorX -= GAP;
+  }
+
+  return {
+    items: positioned,
+    totalHeight: cursorY + rowMaxHeight,
+  };
+}
+
+// --- Main component ---
+
+export const WBWVerseView = memo<WBWVerseViewProps>(
+  ({
+    verseKey,
+    textColor,
+    arabicFontSize,
+    dkFontFamily,
+    fontMgr,
+    showTranslation,
+    showTransliteration,
+    onWordPress,
+    selectedWordPosition,
+    showTajweed,
+    indexedTajweedData,
+  }) => {
+    const {theme} = useTheme();
+    const [containerWidth, setContainerWidth] = useState(0);
+
+    // Try sync cache first, fall back to async
+    const cachedWords = useMemo(
+      () => wbwDataService.getVerseWordsCached(verseKey),
+      [verseKey],
+    );
+    const [asyncWords, setAsyncWords] = useState<WBWWord[] | null>(null);
+
+    useEffect(() => {
+      if (cachedWords) return; // Already have data synchronously
+      let cancelled = false;
+      setAsyncWords(null);
+      wbwDataService.getVerseWords(verseKey).then(words => {
+        if (!cancelled) setAsyncWords(words);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }, [verseKey, cachedWords]);
+
+    const wbwWords = cachedWords ?? asyncWords;
+
+    // Get DK words synchronously
+    const dkWords = useMemo(
+      () => digitalKhattDataService.getVerseWords(verseKey),
+      [verseKey],
+    );
+
+    // Match DK words with WBW words using text-aware sequential alignment.
+    // DK sometimes splits compound words (e.g. "بَعْدَ مَا") into two tokens
+    // while Quran.com keeps them as one, so position-based matching would
+    // misalign all subsequent words. This handles both 1:1 and N:1 cases.
+    const {matchedWords, verseEndMarker} = useMemo(() => {
+      if (!wbwWords || wbwWords.length === 0)
+        return {
+          matchedWords: [] as MatchedWord[],
+          verseEndMarker: null as DKWordInfo | null,
+        };
+
+      const result: MatchedWord[] = [];
+      let endMarker: DKWordInfo | null = null;
+      let wbwIdx = 0;
+      let accumulated = '';
+
+      for (let dkIdx = 0; dkIdx < dkWords.length; dkIdx++) {
+        const dkWord = dkWords[dkIdx];
+
+        if (wbwIdx >= wbwWords.length) {
+          endMarker = dkWord;
+          continue;
+        }
+
+        const wbwWord = wbwWords[wbwIdx];
+        const dkNorm = stripDiacritics(dkWord.text);
+        const wbwNorm = stripDiacritics(wbwWord.textUthmani);
+
+        // Build accumulated DK text for current WBW word
+        accumulated = accumulated ? accumulated + ' ' + dkNorm : dkNorm;
+
+        if (accumulated === wbwNorm || !wbwNorm) {
+          // Exact match (1:1 or end of N:1 merge) — pair and advance WBW
+          result.push({dkWord, wbwWord});
+          wbwIdx++;
+          accumulated = '';
+        } else if (wbwNorm.startsWith(accumulated + ' ')) {
+          // DK word is a prefix of the WBW word — pair but don't advance WBW
+          // (the next DK word will continue accumulating into the same WBW word)
+          result.push({dkWord, wbwWord});
+        } else {
+          // No text match — fallback to direct pairing and advance
+          result.push({dkWord, wbwWord});
+          wbwIdx++;
+          accumulated = '';
+        }
+      }
+
+      return {matchedWords: result, verseEndMarker: endMarker};
+    }, [dkWords, wbwWords]);
+
+    // Derive colors once
+    const derivedColors = useMemo(
+      () => ({
+        divider: Color(theme.colors.text).alpha(0.06).toString(),
+        transliteration: Color(theme.colors.textSecondary)
+          .alpha(0.5)
+          .toString(),
+        translation: Color(theme.colors.text).alpha(0.7).toString(),
+      }),
+      [theme.colors.text, theme.colors.textSecondary],
+    );
+
+    const handleLayout = useCallback((e: LayoutChangeEvent) => {
+      const w = e.nativeEvent.layout.width;
+      setContainerWidth(prev => (Math.abs(prev - w) > 1 ? w : prev));
+    }, []);
+
+    // Tajweed word data for this verse (null when tajweed is off)
+    const tajweedWords = useMemo(
+      () =>
+        showTajweed && indexedTajweedData
+          ? indexedTajweedData[verseKey] ?? null
+          : null,
+      [showTajweed, indexedTajweedData, verseKey],
+    );
+
+    // Build all Skia paragraphs + compute RTL layout in one pass
+    const computedLayout = useMemo<ComputedLayout | null>(() => {
+      if (!fontMgr || containerWidth <= 0 || matchedWords.length === 0)
+        return null;
+
+      const scaledFontSize = moderateScale(arabicFontSize);
+      const subTextH =
+        DIVIDER_TOTAL_H +
+        (showTransliteration ? TRANSLIT_LINE_H : 0) +
+        (showTranslation ? TRANS_LINE_H : 0);
+
+      const items = matchedWords.map(({dkWord, wbwWord}) => {
+        // Compute per-character tajweed rules for this word
+        let wordCharToRule: Map<number, string> | null = null;
+        if (tajweedWords) {
+          const tajweedWord = tajweedWords.find(w => {
+            const pos = parseInt(w.location.split(':')[2], 10);
+            return pos === dkWord.wordPositionInVerse;
+          });
+          wordCharToRule = tajweedWord
+            ? alignWordTajweed(dkWord.text, tajweedWord.segments)
+            : detectWordTafkhim(dkWord.text);
+        }
+
+        const {paragraph, width, height} = buildParagraph(
+          dkWord.text,
+          fontMgr,
+          dkFontFamily,
+          scaledFontSize,
+          textColor,
+          wordCharToRule,
+        );
+        return {
+          paragraph,
+          arabicWidth: width,
+          arabicHeight: height,
+          columnWidth: computeColumnWidth(
+            width,
+            wbwWord.translation,
+            wbwWord.transliteration,
+            showTranslation,
+            showTransliteration,
+            fontMgr,
+          ),
+          dkPosition: dkWord.wordPositionInVerse,
+          position: wbwWord.position,
+          translation: wbwWord.translation,
+          transliteration: wbwWord.transliteration,
+          isEndMarker: false,
+        };
+      });
+
+      if (verseEndMarker) {
+        const {paragraph, width, height} = buildParagraph(
+          verseEndMarker.text,
+          fontMgr,
+          dkFontFamily,
+          scaledFontSize,
+          textColor,
+        );
+        items.push({
+          paragraph,
+          arabicWidth: width,
+          arabicHeight: height,
+          columnWidth: width,
+          dkPosition: verseEndMarker.wordPositionInVerse,
+          position: -1,
+          translation: '',
+          transliteration: '',
+          isEndMarker: true,
+        });
+      }
+
+      return computeRTLLayout(items, containerWidth, subTextH);
+    }, [
+      fontMgr,
+      containerWidth,
+      matchedWords,
+      verseEndMarker,
+      arabicFontSize,
+      dkFontFamily,
+      textColor,
+      showTranslation,
+      showTransliteration,
+      tajweedWords,
+    ]);
+
+    // Highlight color for selected word
+    const highlightColor = useMemo(
+      () => Color(theme.colors.text).alpha(0.08).toString(),
+      [theme.colors.text],
+    );
+
+    // Find layout items for the currently selected word (may be multiple DK
+    // items when a compound word like "بَعْدَ مَا" maps to a single WBW word)
+    const selectedItems = useMemo(() => {
+      if (selectedWordPosition == null || !computedLayout) return [];
+      return computedLayout.items.filter(
+        item => !item.isEndMarker && item.position === selectedWordPosition,
+      );
+    }, [selectedWordPosition, computedLayout]);
+
+    // Hit-test tap to find which word was pressed
+    const handleWordPress = useCallback(
+      (e: GestureResponderEvent) => {
+        if (!computedLayout) return;
+        const {locationX, locationY} = e.nativeEvent;
+        // Adjust for padding
+        const adjY = locationY - PADDING_VERTICAL;
+        for (const item of computedLayout.items) {
+          if (item.isEndMarker) continue;
+          if (
+            locationX >= item.x &&
+            locationX <= item.x + item.columnWidth &&
+            adjY >= item.y &&
+            adjY <= item.y + item.totalItemHeight
+          ) {
+            mediumHaptics();
+            onWordPress(item.position);
+            return;
+          }
+        }
+      },
+      [computedLayout, onWordPress],
+    );
+
+    if (!wbwWords) return null;
+
+    // Optimized single-canvas render when Skia is available and width is measured
+    if (fontMgr && computedLayout) {
+      return (
+        <Pressable
+          onLayout={handleLayout}
+          onPress={handleWordPress}
+          style={[
+            styles.singleCanvasContainer,
+            {height: computedLayout.totalHeight + PADDING_VERTICAL * 2},
+          ]}>
+          {/* Word highlight boxes (rendered before Canvas so text sits on top) */}
+          {selectedItems.map(item => (
+            <View
+              key={`hl-${item.dkPosition}`}
+              pointerEvents="none"
+              style={{
+                position: 'absolute',
+                left: item.x - HIGHLIGHT_PADDING,
+                top: PADDING_VERTICAL + item.y - HIGHLIGHT_PADDING,
+                width: item.columnWidth + HIGHLIGHT_PADDING * 2,
+                height: item.totalItemHeight + HIGHLIGHT_PADDING * 2,
+                borderRadius: HIGHLIGHT_RADIUS,
+                backgroundColor: highlightColor,
+              }}
+            />
+          ))}
+          {/* Single Canvas for ALL Arabic text */}
+          <Canvas
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              top: PADDING_VERTICAL,
+              left: 0,
+              width: containerWidth,
+              height: computedLayout.totalHeight,
+            }}>
+            {computedLayout.items.map(item => (
+              <Paragraph
+                key={item.dkPosition}
+                paragraph={item.paragraph}
+                x={item.x + (item.columnWidth - item.arabicWidth) / 2}
+                y={item.y}
+                width={item.arabicWidth}
+              />
+            ))}
+          </Canvas>
+          {/* Dividers + translation/transliteration overlays */}
+          {computedLayout.items.map(item => {
+            if (item.isEndMarker) return null;
+            return (
+              <View
+                key={`sub-${item.dkPosition}`}
+                style={[
+                  styles.subTextOverlay,
+                  {
+                    left: item.x,
+                    top: PADDING_VERTICAL + item.y + item.arabicHeight,
+                    width: item.columnWidth,
+                  },
+                ]}>
+                <View
+                  style={[
+                    styles.divider,
+                    {backgroundColor: derivedColors.divider},
+                  ]}
+                />
+                {showTransliteration && (
+                  <Text
+                    style={[
+                      styles.transliterationText,
+                      {color: derivedColors.transliteration},
+                    ]}
+                    numberOfLines={1}>
+                    {item.transliteration}
+                  </Text>
+                )}
+                {showTranslation && (
+                  <Text
+                    style={[
+                      styles.translationText,
+                      {color: derivedColors.translation},
+                    ]}
+                    numberOfLines={1}>
+                    {item.translation}
+                  </Text>
+                )}
+              </View>
+            );
+          })}
+        </Pressable>
+      );
+    }
+
+    // Fallback: flex-wrap with RN Text (no Skia canvases)
+    // Used when: fontMgr not ready, or containerWidth not measured yet
+    return (
+      <View onLayout={handleLayout} style={styles.fallbackContainer}>
+        {matchedWords.map(({dkWord, wbwWord}) => (
+          <Pressable
+            key={dkWord.wordPositionInVerse}
+            style={[
+              styles.fallbackWordUnit,
+              selectedWordPosition === wbwWord.position && {
+                backgroundColor: highlightColor,
+                borderRadius: HIGHLIGHT_RADIUS,
+              },
+            ]}
+            onPress={() => {
+              mediumHaptics();
+              onWordPress(wbwWord.position);
+            }}>
+            <Text
+              style={[
+                styles.fallbackArabicText,
+                {
+                  color: textColor,
+                  fontSize: moderateScale(arabicFontSize),
+                  fontFamily: dkFontFamily,
+                },
+              ]}>
+              {dkWord.text}
+            </Text>
+            <View
+              style={[styles.divider, {backgroundColor: derivedColors.divider}]}
+            />
+            {showTransliteration && (
+              <Text
+                style={[
+                  styles.transliterationText,
+                  {color: derivedColors.transliteration},
+                ]}>
+                {wbwWord.transliteration}
+              </Text>
+            )}
+            {showTranslation && (
+              <Text
+                style={[
+                  styles.translationText,
+                  {color: derivedColors.translation},
+                ]}>
+                {wbwWord.translation}
+              </Text>
+            )}
+          </Pressable>
+        ))}
+        {verseEndMarker && (
+          <View style={styles.fallbackWordUnit}>
+            <Text
+              style={[
+                styles.fallbackArabicText,
+                {
+                  color: textColor,
+                  fontSize: moderateScale(arabicFontSize),
+                  fontFamily: dkFontFamily,
+                },
+              ]}>
+              {verseEndMarker.text}
+            </Text>
+          </View>
+        )}
+      </View>
+    );
+  },
+);
+
+WBWVerseView.displayName = 'WBWVerseView';
+
+const styles = StyleSheet.create({
+  // --- Optimized single-canvas layout ---
+  singleCanvasContainer: {
+    position: 'relative',
+    width: '100%',
+  },
+  subTextOverlay: {
+    position: 'absolute',
+    alignItems: 'center',
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    width: '80%',
+    marginVertical: DIVIDER_MARGIN,
+  },
+  transliterationText: {
+    fontFamily: 'Manrope-Regular',
+    fontSize: moderateScale(10.5),
+    fontStyle: 'italic',
+    textAlign: 'center',
+  },
+  translationText: {
+    fontFamily: 'Manrope-Regular',
+    fontSize: moderateScale(11),
+    textAlign: 'center',
+  },
+  // --- Fallback flex-wrap layout (no Skia) ---
+  fallbackContainer: {
+    flexDirection: 'row-reverse',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-start',
+    gap: GAP,
+    paddingVertical: PADDING_VERTICAL,
+  },
+  fallbackWordUnit: {
+    alignItems: 'center',
+  },
+  fallbackArabicText: {
+    textAlign: 'center',
+    writingDirection: 'rtl',
+  },
+});

--- a/components/player/v2/PlayerContent/QuranView/index.tsx
+++ b/components/player/v2/PlayerContent/QuranView/index.tsx
@@ -112,6 +112,11 @@ export const QuranView: React.FC<QuranViewProps> = ({
   const selectedTranslationId = useMushafSettingsStore(
     s => s.selectedTranslationId,
   );
+  const showWBW = useMushafSettingsStore(s => s.showWBW);
+  const wbwShowTranslation = useMushafSettingsStore(s => s.wbwShowTranslation);
+  const wbwShowTransliteration = useMushafSettingsStore(
+    s => s.wbwShowTransliteration,
+  );
   const translationName = getTranslationName(selectedTranslationId);
 
   // Counter to force re-render when enhanced verses are rebuilt (async)
@@ -198,6 +203,9 @@ export const QuranView: React.FC<QuranViewProps> = ({
         isActive={isLocked && item.verse_key === currentVerseKey}
         translationName={translationName}
         translationId={selectedTranslationId}
+        showWBW={showWBW}
+        wbwShowTranslation={wbwShowTranslation}
+        wbwShowTransliteration={wbwShowTransliteration}
       />
     ),
     [
@@ -217,6 +225,9 @@ export const QuranView: React.FC<QuranViewProps> = ({
       isLocked,
       translationName,
       selectedTranslationId,
+      showWBW,
+      wbwShowTranslation,
+      wbwShowTransliteration,
     ],
   );
 
@@ -241,6 +252,7 @@ export const QuranView: React.FC<QuranViewProps> = ({
         ref={listRef}
         data={verses}
         renderItem={renderItem}
+        extraData={`${showWBW}-${wbwShowTranslation}-${wbwShowTransliteration}-${showTajweed}-${arabicFontSize}-${showTranslation}-${showTransliteration}`}
         keyExtractor={keyExtractor}
         ListHeaderComponent={
           <QuranListHeader

--- a/components/sheets/WordDetailSheet.tsx
+++ b/components/sheets/WordDetailSheet.tsx
@@ -1,0 +1,320 @@
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native';
+import {
+  ScaledSheet,
+  moderateScale,
+  verticalScale,
+} from 'react-native-size-matters';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import ActionSheet, {SheetProps} from 'react-native-actions-sheet';
+import Color from 'color';
+import {wbwDataService, type WBWWord} from '@/services/wbw/WBWDataService';
+import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
+import {createAudioPlayer, AudioPlayer} from 'expo-audio';
+import {PlayIcon, PauseIcon} from '@/components/Icons';
+
+export const WordDetailSheet = (props: SheetProps<'word-detail'>) => {
+  const {theme} = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const verseKey = props.payload?.verseKey ?? '';
+  const position = props.payload?.position ?? 0;
+
+  const [wbwWord, setWbwWord] = useState<WBWWord | null>(null);
+  const [arabicText, setArabicText] = useState('');
+  const [totalWords, setTotalWords] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [audioLoading, setAudioLoading] = useState(false);
+
+  const playerRef = useRef<AudioPlayer | null>(null);
+
+  // Load word data from both services
+  useEffect(() => {
+    if (!verseKey || !position) return;
+    let cancelled = false;
+
+    (async () => {
+      const words = await wbwDataService.getVerseWords(verseKey);
+      if (cancelled) return;
+
+      const word = words.find(w => w.position === position) ?? null;
+      setWbwWord(word);
+      setTotalWords(words.length);
+
+      // Get Arabic text from DigitalKhatt
+      const dkWords = digitalKhattDataService.getVerseWords(verseKey);
+      const dkWord = dkWords.find(w => w.wordPositionInVerse === position);
+      if (dkWord) {
+        setArabicText(dkWord.text);
+      }
+
+      setLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [verseKey, position]);
+
+  // Cleanup audio player on unmount
+  useEffect(() => {
+    return () => {
+      if (playerRef.current) {
+        try {
+          playerRef.current.pause();
+          playerRef.current.remove();
+        } catch {
+          // ignore cleanup errors
+        }
+        playerRef.current = null;
+      }
+    };
+  }, []);
+
+  // Build correct audio URL from verse key + position.
+  // The Quran.com API audio_url uses total-token numbering (includes stop marks),
+  // but qurancdn.com files use word-only numbering, causing mismatches on verses
+  // with stop marks. Generating from position is always correct.
+  const audioUrl = useMemo(() => {
+    if (!verseKey || !position) return '';
+    const [s, a] = verseKey.split(':');
+    return `https://audio.qurancdn.com/wbw/${s.padStart(3, '0')}_${a.padStart(
+      3,
+      '0',
+    )}_${String(position).padStart(3, '0')}.mp3`;
+  }, [verseKey, position]);
+
+  const handlePlayPress = useCallback(() => {
+    if (!audioUrl) return;
+
+    // If already playing, pause
+    if (isPlaying && playerRef.current) {
+      try {
+        playerRef.current.pause();
+      } catch {
+        // ignore
+      }
+      setIsPlaying(false);
+      return;
+    }
+
+    // Release previous player if any
+    if (playerRef.current) {
+      try {
+        playerRef.current.pause();
+        playerRef.current.remove();
+      } catch {
+        // ignore
+      }
+      playerRef.current = null;
+    }
+
+    setAudioLoading(true);
+
+    try {
+      const player = createAudioPlayer({uri: audioUrl});
+      playerRef.current = player;
+
+      const subscription = player.addListener(
+        'playbackStatusUpdate',
+        status => {
+          if (status.playing) {
+            setAudioLoading(false);
+            setIsPlaying(true);
+          }
+          if (status.didJustFinish) {
+            setIsPlaying(false);
+          }
+        },
+      );
+
+      player.play();
+
+      // Store cleanup for subscription
+      const originalCleanup = playerRef.current;
+      if (originalCleanup) {
+        const origRemove = originalCleanup.remove.bind(originalCleanup);
+        originalCleanup.remove = () => {
+          subscription.remove();
+          origRemove();
+        };
+      }
+    } catch (error) {
+      console.error('[WordDetailSheet] Audio playback failed:', error);
+      setAudioLoading(false);
+      setIsPlaying(false);
+    }
+  }, [audioUrl, isPlaying]);
+
+  if (!props.payload) return null;
+
+  const [surahNum, ayahNum] = verseKey.split(':');
+
+  return (
+    <ActionSheet
+      id={props.sheetId}
+      containerStyle={styles.sheetContainer}
+      indicatorStyle={styles.indicator}
+      gestureEnabled={true}>
+      <View style={styles.container}>
+        {loading ? (
+          <ActivityIndicator
+            size="small"
+            color={theme.colors.textSecondary}
+            style={styles.loader}
+          />
+        ) : (
+          <>
+            {/* Arabic text */}
+            {arabicText ? (
+              <Text style={styles.arabicText}>{arabicText}</Text>
+            ) : null}
+
+            {/* Transliteration */}
+            {wbwWord?.transliteration ? (
+              <Text style={styles.transliteration}>
+                {wbwWord.transliteration}
+              </Text>
+            ) : null}
+
+            {/* Translation */}
+            {wbwWord?.translation ? (
+              <Text style={styles.translation}>
+                &ldquo;{wbwWord.translation}&rdquo;
+              </Text>
+            ) : null}
+
+            {/* Play button — card style matching VerseActionsSheet */}
+            {audioUrl ? (
+              <View style={styles.card}>
+                <Pressable
+                  style={({pressed}) => [
+                    styles.option,
+                    pressed && styles.optionPressed,
+                  ]}
+                  onPress={handlePlayPress}>
+                  {audioLoading ? (
+                    <ActivityIndicator size="small" color={theme.colors.text} />
+                  ) : isPlaying ? (
+                    <PauseIcon
+                      size={moderateScale(18)}
+                      color={theme.colors.text}
+                    />
+                  ) : (
+                    <PlayIcon
+                      size={moderateScale(18)}
+                      color={theme.colors.text}
+                    />
+                  )}
+                  <Text style={styles.optionText}>
+                    {audioLoading
+                      ? 'Loading...'
+                      : isPlaying
+                      ? 'Pause'
+                      : 'Play Pronunciation'}
+                  </Text>
+                </Pressable>
+              </View>
+            ) : null}
+
+            {/* Context footer */}
+            <Text style={styles.contextText}>
+              Verse {surahNum}:{ayahNum} {'\u00B7'} Word {position} of{' '}
+              {totalWords}
+            </Text>
+          </>
+        )}
+      </View>
+    </ActionSheet>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  ScaledSheet.create({
+    sheetContainer: {
+      backgroundColor: theme.colors.background,
+      borderTopLeftRadius: moderateScale(20),
+      borderTopRightRadius: moderateScale(20),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderRightWidth: StyleSheet.hairlineWidth,
+      borderColor: Color(theme.colors.text).alpha(0.08).toString(),
+      paddingTop: moderateScale(8),
+    },
+    indicator: {
+      backgroundColor: Color(theme.colors.text).alpha(0.3).toString(),
+      width: moderateScale(40),
+      height: 2.5,
+    },
+    container: {
+      paddingHorizontal: moderateScale(20),
+      paddingBottom: moderateScale(30),
+      alignItems: 'center',
+    },
+    loader: {
+      marginTop: verticalScale(40),
+      marginBottom: verticalScale(40),
+    },
+    arabicText: {
+      fontSize: moderateScale(36),
+      fontFamily: 'Uthmani',
+      color: theme.colors.text,
+      textAlign: 'center',
+      marginTop: moderateScale(12),
+      marginBottom: moderateScale(8),
+    },
+    transliteration: {
+      fontSize: moderateScale(13),
+      fontFamily: 'Manrope-Regular',
+      fontStyle: 'italic',
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+      textAlign: 'center',
+      marginBottom: moderateScale(4),
+    },
+    translation: {
+      fontSize: moderateScale(15),
+      fontFamily: 'Manrope-Medium',
+      color: Color(theme.colors.text).alpha(0.85).toString(),
+      textAlign: 'center',
+      marginBottom: moderateScale(16),
+    },
+    card: {
+      width: '100%',
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      borderRadius: moderateScale(12),
+      overflow: 'hidden',
+      marginBottom: moderateScale(14),
+    },
+    option: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: moderateScale(11),
+      paddingHorizontal: moderateScale(14),
+    },
+    optionPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+    },
+    optionText: {
+      flex: 1,
+      fontSize: moderateScale(14),
+      fontFamily: 'Manrope-SemiBold',
+      color: theme.colors.text,
+      marginLeft: moderateScale(10),
+    },
+    contextText: {
+      fontSize: moderateScale(12),
+      fontFamily: 'Manrope-Regular',
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+      textAlign: 'center',
+    },
+  });

--- a/components/sheets/sheets.tsx
+++ b/components/sheets/sheets.tsx
@@ -34,6 +34,7 @@ import {SimilarVersesSheet} from './SimilarVersesSheet';
 import {MushafPlayerOptionsSheet} from './MushafPlayerOptionsSheet';
 import {MushafRepeatOptionsSheet} from './MushafRepeatOptionsSheet';
 import {FollowAlongSheet} from './FollowAlongSheet';
+import {WordDetailSheet} from './WordDetailSheet';
 
 // Register all sheets
 registerSheet('surah-options', SurahOptionsSheet);
@@ -64,6 +65,7 @@ registerSheet('similar-verses', SimilarVersesSheet);
 registerSheet('mushaf-player-options', MushafPlayerOptionsSheet);
 registerSheet('mushaf-repeat-options', MushafRepeatOptionsSheet);
 registerSheet('follow-along', FollowAlongSheet);
+registerSheet('word-detail', WordDetailSheet);
 
 // Type definitions for payloads
 declare module 'react-native-actions-sheet' {
@@ -271,6 +273,12 @@ declare module 'react-native-actions-sheet' {
       };
     }>;
     'follow-along': SheetDefinition;
+    'word-detail': SheetDefinition<{
+      payload: {
+        verseKey: string;
+        position: number;
+      };
+    }>;
   }
 }
 

--- a/docs/plans/2026-03-04-continuous-scroll-design.md
+++ b/docs/plans/2026-03-04-continuous-scroll-design.md
@@ -1,0 +1,161 @@
+# Continuous Scroll Mushaf — Design Document
+
+**Date:** 2026-03-04
+**Status:** Approved
+
+## Summary
+
+Replace the current horizontal page-swipe mushaf with a single continuous vertical scroll experience. One scroll from the first ayah of Al-Fatiha to the last ayah of An-Nas. Two sub-modes: Mushaf Scroll (Skia pages stitched seamlessly) and Verse Scroll (flowing text that adapts based on translation toggle).
+
+## Mode Architecture
+
+Continuous scroll is the only reading experience. No page-swipe mode exists.
+
+### Two Sub-Modes
+
+| Mode | Content | Translation | Verse Interaction |
+|------|---------|-------------|-------------------|
+| **Mushaf Scroll** | 604 Skia pages stitched vertically | No | Long-press drag to select range |
+| **Verse Scroll** | 6,236 verses as continuous list | Adapts layout | Tap to select single verse |
+
+### Verse Scroll Layout Adapts Based on Translation Toggle
+
+- **Translation OFF (Inline Flow):** Arabic text flows as continuous RTL paragraphs. Verse-end markers (۝ with Arabic numeral) appear inline. Surah dividers are the only structural breaks. No page numbers. Clean reading experience.
+- **Translation ON (Stacked Cards):** Each verse is a VerseItem card (verse number + Arabic + translation + optional transliteration). Surah dividers between surahs. Ultra-subtle page number markers at mushaf page boundaries.
+
+### Settings Store Change
+
+Replace `viewMode: 'mushaf' | 'reading'` with `scrollMode: 'mushaf' | 'verse'`. Mode is selected in mushaf settings (accessible from within the mushaf screen).
+
+## Navigation
+
+All navigation is page-aware. The page concept is an internal coordinate system.
+
+1. User picks a target (surah from search, verse from bookmark, last read, etc.)
+2. System resolves to a verse key (e.g., `'2:142'`)
+3. **Mushaf scroll:** verse key → page number → FlashList index (page item) → `scrollToIndex`
+4. **Verse scroll:** verse key → FlashList index (verse/chunk item) → `scrollToIndex`
+
+### Last Read
+
+Single verse key stored (e.g., `'2:142'`). On resume, scrolls to that verse regardless of mode. No separate "mushaf last read" vs "scroll last read" — one source of truth.
+
+### Recent Reads (Chains)
+
+Same concept as current — array of verse keys instead of page numbers. Jump to any recent read scrolls to that verse.
+
+## Visual Design
+
+### Mushaf Scroll Mode
+
+Zero visual breaks between pages. Skia canvases rendered flush — no page numbers, no dividers between pages, no card boundaries, no spacing. One continuous river of mushaf text.
+
+The only visual breaks are surah headers (ornamental dividers already rendered within the Skia text as part of the mushaf layout).
+
+### Verse Scroll — Translation OFF (Inline Flow)
+
+Arabic text flows as continuous RTL paragraphs within page-sized chunks. Verse-end markers (۝١) appear inline within the text. Surah dividers appear between surahs. No page numbers.
+
+### Verse Scroll — Translation ON (Stacked Cards)
+
+Each verse is a VerseItem component card. Surah dividers between surahs. Ultra-subtle page number markers at mushaf page boundaries:
+- Style: `· 42 ·` centered
+- Font: `Manrope-Regular`, `ms(10)`
+- Color: `Color(theme.colors.text).alpha(0.15)`
+- Spacing: ~8pt padding above and below (whisper-thin)
+
+### Header Bar
+
+```
+← Back   Al-Baqarah · p.5     ⚙
+         Juz 1
+```
+
+- Dynamically updates surah name + page number of topmost visible verse
+- Juz indicator in secondary text
+- Settings gear opens mushaf settings
+- Search icon opens MushafSearchView
+- Hides/shows on tap (immersive mode, same as current)
+
+### Immersive Mode
+
+Tap anywhere to toggle header + player bar visibility. Same behavior as current.
+
+## Playback Integration
+
+### Auto-Scroll
+
+- During ayah-by-ayah playback, scroll smoothly follows the current verse
+- Playing verse positioned ~30% from top of screen
+- If user manually scrolls away, auto-scroll re-engages after 3 seconds of no touch
+
+### Verse Highlighting
+
+- **Mushaf scroll:** Subtle background overlay on Skia canvas (same as current)
+- **Verse scroll (inline):** Background highlight on the current verse text within paragraph
+- **Verse scroll (stacked):** Highlighted border/background on verse card
+
+## Technical Architecture
+
+### Rendering Engine: FlashList
+
+Single vertical FlashList replaces the current horizontal FlatList. Virtualization handles all modes efficiently.
+
+### FlashList Item Types Per Mode
+
+**Mushaf Scroll:**
+
+| Type | Count | Height |
+|------|-------|--------|
+| `mushaf-page` | 604 | Fixed (canvas height) |
+
+**Verse Scroll (translation OFF):**
+
+| Type | Count | Height |
+|------|-------|--------|
+| `surah-divider` | 114 | ~60pt |
+| `paragraph-chunk` | ~604 | Variable (wrapped text) |
+
+Each `paragraph-chunk` contains one mushaf page's worth of verses rendered as a flowing RTL paragraph with inline verse markers.
+
+**Verse Scroll (translation ON):**
+
+| Type | Count | Height |
+|------|-------|--------|
+| `surah-divider` | 114 | ~60pt |
+| `verse-item` | 6,236 | Variable |
+| `page-marker` | ~604 | ~24pt |
+
+### Position Tracking
+
+- `onViewableItemsChanged` detects topmost visible item
+- Map item → verse key → page number → surah name
+- Update header display (debounced 200ms)
+- Save last-read verse key to store on blur/background
+
+### Position Sync Between Modes
+
+When switching modes, track the currently visible verse key and scroll to that verse in the new mode.
+
+### Performance
+
+- `estimatedItemSize`: calibrated per mode
+- `windowSize={7}` (render ±3.5 screens)
+- `maxToRenderPerBatch={3}`
+- Skia canvases wrapped in `React.memo`
+- MushafLayoutCacheService provides pre-computed heights for mushaf pages
+
+## Key Files to Modify/Create
+
+### Modify
+- `components/mushaf/main.tsx` — Replace horizontal FlatList with vertical FlashList, mode switching logic
+- `store/mushafSettingsStore.ts` — Replace `viewMode` with `scrollMode`
+- `components/mushaf/MushafSearchView.tsx` — Navigation resolves to verse key + scroll position
+- `hooks/useMushafAutoPageTurn.ts` → Rename/refactor to `useMushafAutoScroll.ts`
+- `components/MushafSettingsContent.tsx` — Update mode toggle UI
+
+### Create
+- `components/mushaf/continuous/ContinuousMushafScroll.tsx` — Main vertical FlashList wrapper
+- `components/mushaf/continuous/ParagraphChunk.tsx` — Inline flow paragraph block
+- `components/mushaf/continuous/PageMarker.tsx` — Subtle page number marker
+- `utils/continuousScrollData.ts` — Build FlashList data arrays for each mode

--- a/docs/plans/2026-03-04-word-by-word-implementation.md
+++ b/docs/plans/2026-03-04-word-by-word-implementation.md
@@ -1,0 +1,570 @@
+# Word-by-Word Translation — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add inline word-by-word translation to scroll mode, with configurable per-word translation/transliteration, subtle underlines, and a long-press word detail sheet.
+
+**Architecture:** New `WBWDataService` singleton loads word data from bundled SQLite (`wbw-en.db`). A new `WBWVerseView` component renders the RTL flex-wrap word grid, replacing the Arabic text block in `VerseItem` when WBW is enabled. Settings stored in existing `mushafSettingsStore`. Long-press opens a new `WordDetailSheet` bottom sheet.
+
+**Tech Stack:** expo-sqlite, Zustand, react-native-actions-sheet, expo-audio (for per-word playback)
+
+**Design doc:** `docs/plans/2026-03-04-word-by-word-translation-design.md`
+
+**IMPORTANT:** Use `frontend-design` skill for all UI/styling decisions. Follow the app's alpha-based design system from CLAUDE.md.
+
+---
+
+### Task 1: Add WBW State to mushafSettingsStore
+
+**Files:**
+- Modify: `store/mushafSettingsStore.ts`
+
+**Step 1: Add WBW fields to the interface**
+
+Add to `MushafSettingsState` interface (after line 37, below `showTajweed`):
+
+```typescript
+// Word-by-word settings
+showWBW: boolean;
+wbwShowTranslation: boolean;
+wbwShowTransliteration: boolean;
+```
+
+Add actions (after line 66, below `toggleTajweed`):
+
+```typescript
+toggleWBW: () => void;
+toggleWBWTranslation: () => void;
+toggleWBWTransliteration: () => void;
+```
+
+**Step 2: Add defaults and action implementations**
+
+In the `persist` create block (after line 88, below `showTajweed: false`):
+
+```typescript
+showWBW: false,
+wbwShowTranslation: true,
+wbwShowTransliteration: false,
+```
+
+Actions (after line 105, below `toggleTajweed`):
+
+```typescript
+toggleWBW: () => set(state => ({ showWBW: !state.showWBW })),
+toggleWBWTranslation: () => set(state => ({ wbwShowTranslation: !state.wbwShowTranslation })),
+toggleWBWTransliteration: () => set(state => ({ wbwShowTransliteration: !state.wbwShowTransliteration })),
+```
+
+**Step 3: Bump store version and add migration**
+
+Change `version: 7` to `version: 8`. Add migration case after the `version < 7` block:
+
+```typescript
+if (version < 8) {
+  state.showWBW = false;
+  state.wbwShowTranslation = true;
+  state.wbwShowTransliteration = false;
+}
+```
+
+**Step 4: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: No new errors
+
+**Step 5: Commit**
+
+```
+feat(store): add word-by-word settings to mushafSettingsStore
+```
+
+---
+
+### Task 2: Create WBWDataService
+
+**Files:**
+- Create: `services/wbw/WBWDataService.ts`
+
+**Step 1: Create the service**
+
+```typescript
+import * as SQLite from 'expo-sqlite';
+
+export interface WBWWord {
+  position: number;
+  translation: string;
+  transliteration: string;
+  audioUrl: string;
+}
+
+class WBWDataService {
+  private db: SQLite.SQLiteDatabase | null = null;
+  private cache: Map<string, WBWWord[]> = new Map();
+  private _initialized = false;
+  private _initializing: Promise<void> | null = null;
+
+  get initialized(): boolean {
+    return this._initialized;
+  }
+
+  async initialize(): Promise<void> {
+    if (this._initialized) return;
+    if (this._initializing) return this._initializing;
+    this._initializing = this._doInit();
+    return this._initializing;
+  }
+
+  private async _doInit(): Promise<void> {
+    try {
+      const dbName = 'wbw-en.db';
+      let db = await SQLite.openDatabaseAsync(dbName);
+
+      const tableCheck = await db
+        .getFirstAsync<{ name: string }>(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='words';",
+        )
+        .catch(() => null);
+
+      if (!tableCheck) {
+        await db.closeAsync();
+        await SQLite.deleteDatabaseAsync(dbName);
+        await SQLite.importDatabaseFromAssetAsync(dbName, {
+          assetId: require('../../data/wbw/wbw-en.db'),
+        });
+        db = await SQLite.openDatabaseAsync(dbName);
+      }
+
+      this.db = db;
+      this._initialized = true;
+      console.log('[WBWDataService] Initialized');
+    } catch (error) {
+      console.error('[WBWDataService] Initialization failed:', error);
+      this._initializing = null;
+      throw error;
+    }
+  }
+
+  async getVerseWords(verseKey: string): Promise<WBWWord[]> {
+    const cached = this.cache.get(verseKey);
+    if (cached) return cached;
+
+    if (!this.db) return [];
+
+    const rows = await this.db.getAllAsync<{
+      position: number;
+      translation: string;
+      transliteration: string;
+      audio_url: string;
+    }>(
+      'SELECT position, translation, transliteration, audio_url FROM words WHERE verse_key = ? ORDER BY position',
+      [verseKey],
+    );
+
+    const words: WBWWord[] = rows.map(row => ({
+      position: row.position,
+      translation: row.translation,
+      transliteration: row.transliteration,
+      audioUrl: row.audio_url,
+    }));
+
+    this.cache.set(verseKey, words);
+    return words;
+  }
+}
+
+export const wbwDataService = new WBWDataService();
+```
+
+**Step 2: Run type check**
+
+Run: `npx tsc --noEmit`
+
+**Step 3: Commit**
+
+```
+feat(wbw): create WBWDataService for word-by-word SQLite lookups
+```
+
+---
+
+### Task 3: Register WBWDataService in AppInitializer
+
+**Files:**
+- Modify: `services/AppInitializer.ts`
+
+**Step 1: Add import**
+
+Add after the tafseerDbService import (line 9):
+
+```typescript
+import {wbwDataService} from '@/services/wbw/WBWDataService';
+```
+
+**Step 2: Register service**
+
+Add after the Tafseer DB registration block (after line 390):
+
+```typescript
+/**
+ * WBW Data Service (Priority 10)
+ * Opens wbw-en.db for word-by-word translations.
+ * Non-critical — WBW features degrade gracefully without it.
+ */
+appInitializer.registerService({
+  name: 'WBW Data',
+  priority: 10,
+  critical: false,
+  initialize: async () => {
+    await wbwDataService.initialize();
+  },
+});
+```
+
+**Step 3: Commit**
+
+```
+feat(wbw): register WBWDataService in AppInitializer
+```
+
+---
+
+### Task 4: Create WBWVerseView Component
+
+**Files:**
+- Create: `components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx`
+
+**IMPORTANT:** Invoke `frontend-design` skill before writing this component. Follow the alpha-based design system.
+
+This is the core visual component — the RTL flex-wrap grid of word units.
+
+**Key requirements:**
+- `flexDirection: 'row-reverse'` + `flexWrap: 'wrap'` for RTL flow
+- Each word unit: Arabic (top) → subtle hairline → transliteration (optional) → translation (optional)
+- Subtle line under each Arabic word: `Color(theme.colors.text).alpha(0.06)`, `StyleSheet.hairlineWidth`
+- No backgrounds or borders on individual word units — spacing creates grouping
+- Arabic: same font as current Mushaf settings (DK font family, user's arabicFontSize)
+- Translation: `Manrope-Regular`, `ms(11)`, `Color(theme.colors.text).alpha(0.7)`
+- Transliteration: `Manrope-Regular`, `ms(10.5)`, `Color(theme.colors.textSecondary).alpha(0.5)`, italic
+- Word units centered-aligned internally, with consistent padding/gap
+- `onWordLongPress(position)` callback for opening detail sheet
+- Each word unit is a `Pressable` with `onLongPress`
+
+**Props interface:**
+
+```typescript
+interface WBWVerseViewProps {
+  verseKey: string;
+  textColor: string;
+  arabicFontSize: number;
+  dkFontFamily: string;
+  showTranslation: boolean;
+  showTransliteration: boolean;
+  onWordLongPress: (position: number) => void;
+}
+```
+
+**Data loading pattern:**
+- Use `useState` + `useEffect` to call `wbwDataService.getVerseWords(verseKey)`
+- Match WBW positions to `digitalKhattDataService.getVerseWords(verseKey)` for Arabic text
+- Render each word as a vertical stack
+
+**Step 1: Write the component**
+
+Use `frontend-design` skill for exact styling decisions. The component should:
+- Map DKWordInfo + WBWWord arrays by matching `wordPositionInVerse === position`
+- Filter out verse end markers (DK words without matching WBW position)
+- Render with `flexDirection: 'row-reverse'`, `flexWrap: 'wrap'`, `gap: moderateScale(16)`
+- Each word unit: `alignItems: 'center'`, `marginBottom: verticalScale(12)`
+- Haptic feedback on long press via `mediumHaptics()`
+
+**Step 2: Run type check**
+
+**Step 3: Commit**
+
+```
+feat(wbw): create WBWVerseView component with RTL flex-wrap grid
+```
+
+---
+
+### Task 5: Add WBW Card to MushafSettingsContent
+
+**Files:**
+- Modify: `components/MushafSettingsContent.tsx`
+
+**IMPORTANT:** Invoke `frontend-design` skill. Match the exact card/switch pattern used by existing Transliteration card (lines 644-670).
+
+**Step 1: Add store subscriptions**
+
+Add `showWBW`, `wbwShowTranslation`, `wbwShowTransliteration`, `toggleWBW`, `toggleWBWTranslation`, `toggleWBWTransliteration` to the destructured `useMushafSettingsStore()` call at line 397.
+
+**Step 2: Add WBW settings card**
+
+Insert ABOVE the Transliteration card (before line 644), inside the `(context !== 'mushaf' || viewMode === 'reading')` conditional:
+
+```tsx
+<View style={styles.card}>
+  <View style={styles.optionRow}>
+    <Text style={styles.optionLabel}>Word by Word</Text>
+    <Switch
+      trackColor={trackColor}
+      thumbColor="#FFFFFF"
+      ios_backgroundColor={trackColor.false}
+      onValueChange={toggleWBW}
+      value={showWBW}
+      style={styles.switchStyle}
+    />
+  </View>
+  <Text style={styles.helperText}>
+    Inline word translations under each Arabic word
+  </Text>
+  {showWBW && (
+    <>
+      <View style={styles.divider} />
+      {/* Sub-toggle: Translation */}
+      <Pressable
+        style={({pressed}) => [styles.optionRow, pressed && styles.pressed]}
+        onPress={toggleWBWTranslation}>
+        <Text style={styles.optionLabel}>Translation</Text>
+        <View style={[styles.checkbox, wbwShowTranslation && styles.checkboxActive]}>
+          {wbwShowTranslation && (
+            <Feather name="check" size={moderateScale(12)} color={theme.colors.background} />
+          )}
+        </View>
+      </Pressable>
+      <View style={styles.divider} />
+      {/* Sub-toggle: Transliteration */}
+      <Pressable
+        style={({pressed}) => [styles.optionRow, pressed && styles.pressed]}
+        onPress={toggleWBWTransliteration}>
+        <Text style={styles.optionLabel}>Transliteration</Text>
+        <View style={[styles.checkbox, wbwShowTransliteration && styles.checkboxActive]}>
+          {wbwShowTransliteration && (
+            <Feather name="check" size={moderateScale(12)} color={theme.colors.background} />
+          )}
+        </View>
+      </Pressable>
+    </>
+  )}
+</View>
+```
+
+**Step 3: Add checkbox styles**
+
+Add to `createStyles` — use `frontend-design` for exact tokens:
+
+```typescript
+checkbox: {
+  width: moderateScale(20),
+  height: moderateScale(20),
+  borderRadius: moderateScale(4),
+  borderWidth: 1.5,
+  borderColor: Color(theme.colors.text).alpha(0.2).toString(),
+  alignItems: 'center',
+  justifyContent: 'center',
+},
+checkboxActive: {
+  backgroundColor: theme.colors.text,
+  borderColor: theme.colors.text,
+},
+pressed: {
+  backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+},
+```
+
+**Step 4: Format and type check**
+
+Run: `npx prettier --write components/MushafSettingsContent.tsx && npx tsc --noEmit`
+
+**Step 5: Commit**
+
+```
+feat(wbw): add Word by Word settings card with sub-toggles
+```
+
+---
+
+### Task 6: Integrate WBW into VerseItem
+
+**Files:**
+- Modify: `components/player/v2/PlayerContent/QuranView/VerseItem.tsx`
+
+**Step 1: Add WBW props to VerseItemProps**
+
+Add to the interface (after line 77):
+
+```typescript
+showWBW?: boolean;
+wbwShowTranslation?: boolean;
+wbwShowTransliteration?: boolean;
+```
+
+Add to destructured props in the component.
+
+**Step 2: Conditionally render WBWVerseView**
+
+Replace the Arabic text rendering block (lines 384-405). When `showWBW` is true, render `WBWVerseView` instead of the Skia/QPC/fallback block:
+
+```tsx
+{showWBW ? (
+  <WBWVerseView
+    verseKey={verseKey}
+    textColor={textColor}
+    arabicFontSize={arabicFontSize}
+    dkFontFamily={dkFontFamily}
+    showTranslation={wbwShowTranslation ?? true}
+    showTransliteration={wbwShowTransliteration ?? false}
+    onWordLongPress={handleWordLongPress}
+  />
+) : (
+  <View onLayout={handleArabicLayout}>
+    {/* existing Skia/QPC/fallback rendering unchanged */}
+  </View>
+)}
+```
+
+**Step 3: Add handleWordLongPress callback**
+
+```typescript
+const handleWordLongPress = useCallback(
+  (position: number) => {
+    mediumHaptics();
+    SheetManager.show('word-detail', {
+      payload: { verseKey, position },
+    });
+  },
+  [verseKey],
+);
+```
+
+**Step 4: Format and type check**
+
+**Step 5: Commit**
+
+```
+feat(wbw): integrate WBWVerseView into VerseItem with conditional rendering
+```
+
+---
+
+### Task 7: Wire WBW Props Through QuranView
+
+**Files:**
+- Modify: `components/player/v2/PlayerContent/QuranView/index.tsx`
+
+**Step 1: Add store subscriptions**
+
+Add after the `showTajweed` selector (line 110):
+
+```typescript
+const showWBW = useMushafSettingsStore(s => s.showWBW);
+const wbwShowTranslation = useMushafSettingsStore(s => s.wbwShowTranslation);
+const wbwShowTransliteration = useMushafSettingsStore(s => s.wbwShowTransliteration);
+```
+
+**Step 2: Pass props to VerseItem**
+
+Add to the `<VerseItem>` JSX in `renderItem` (after `translationId` prop, around line 200):
+
+```tsx
+showWBW={showWBW}
+wbwShowTranslation={wbwShowTranslation}
+wbwShowTransliteration={wbwShowTransliteration}
+```
+
+Add the three variables to the `renderItem` dependency array.
+
+**Step 3: Format and type check**
+
+**Step 4: Commit**
+
+```
+feat(wbw): wire WBW store state through QuranView to VerseItem
+```
+
+---
+
+### Task 8: Create WordDetailSheet
+
+**Files:**
+- Create: `components/sheets/WordDetailSheet.tsx`
+- Modify: `components/sheets/sheets.tsx`
+
+**IMPORTANT:** Invoke `frontend-design` skill. Follow existing sheet patterns (see `SimilarVersesSheet.tsx` or `VerseActionsSheet.tsx` for reference).
+
+**Step 1: Create the sheet component**
+
+The sheet receives `{ verseKey, position }` as payload. It should:
+- Look up word data from `wbwDataService.getVerseWords(verseKey)` — find by position
+- Look up Arabic text from `digitalKhattDataService.getVerseWords(verseKey)` — find by `wordPositionInVerse`
+- Display: large Arabic word (centered), transliteration, translation
+- Play button that loads audio from `https://audio.qurancdn.com/${audioUrl}`
+- Footer: "Verse X:Y · Word N of M"
+- Use `ActionSheet` from `react-native-actions-sheet` as the container
+- Style: alpha-based design system, centered layout
+
+**Audio playback:** Use `createAudioPlayer` from `expo-audio` for the word audio. Create a player on mount, clean up on unmount. Play button toggles play/pause.
+
+**Step 2: Register sheet in sheets.tsx**
+
+Add import:
+```typescript
+import {WordDetailSheet} from './WordDetailSheet';
+```
+
+Add registration:
+```typescript
+registerSheet('word-detail', WordDetailSheet);
+```
+
+Add type definition:
+```typescript
+'word-detail': SheetDefinition<{
+  payload: {
+    verseKey: string;
+    position: number;
+  };
+}>;
+```
+
+**Step 3: Format and type check**
+
+**Step 4: Commit**
+
+```
+feat(wbw): create WordDetailSheet with audio playback
+```
+
+---
+
+### Task 9: Final Integration Testing and Polish
+
+**Step 1: Test the full flow**
+
+- Open app in scroll/reading mode
+- Open Mushaf Settings → verify WBW card appears in PLAYER VIEW
+- Toggle WBW ON → verify word grid renders RTL with subtle lines
+- Toggle sub-options (translation, transliteration) → verify they show/hide per-word
+- Long-press a word → verify detail sheet opens with correct data
+- Test Play button in detail sheet → verify audio plays
+- Toggle WBW OFF → verify normal Arabic text block returns
+- Verify existing Translation/Transliteration blocks still work independently below
+
+**Step 2: Run prettier on all modified files**
+
+```bash
+npx prettier --write store/mushafSettingsStore.ts services/wbw/WBWDataService.ts services/AppInitializer.ts components/MushafSettingsContent.tsx components/player/v2/PlayerContent/QuranView/VerseItem.tsx components/player/v2/PlayerContent/QuranView/index.tsx components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx components/sheets/WordDetailSheet.tsx components/sheets/sheets.tsx
+```
+
+**Step 3: Run type check**
+
+```bash
+npx tsc --noEmit
+```
+
+**Step 4: Final commit**
+
+```
+feat(wbw): word-by-word translation integration complete
+```

--- a/docs/plans/2026-03-04-word-by-word-translation-design.md
+++ b/docs/plans/2026-03-04-word-by-word-translation-design.md
@@ -1,0 +1,150 @@
+# Word-by-Word Translation — Design Document
+
+**Date:** 2026-03-04
+**Status:** Approved
+**Scope:** Scroll mode only (reading view)
+
+---
+
+## Overview
+
+Add inline word-by-word (WBW) translation to the scroll/reading mode. When enabled, the Arabic text area transforms from a single text block into an RTL flex-wrap grid where each Arabic word is paired with its English translation (and optionally transliteration) directly underneath.
+
+## Data Source
+
+- **Database:** `data/wbw/wbw-en.db` (8.14 MB, 77,429 words, all 6,236 verses)
+- **Source:** Quran Foundation API v4 (`?words=true`)
+- **Schema:** `(verse_key, position) -> translation, transliteration, audio_url`
+- **Position mapping:** API `position` maps 1:1 to existing `DKWordInfo.wordPositionInVerse`
+- **Fetch script:** `scripts/fetch-wbw-translations.js` (supports `--language` flag for other languages)
+
+## Verse Layout (WBW ON)
+
+```
+┌──────────────────────────────────────────────────┐
+│  1:1                                             │
+│                                                  │
+│   ٱلرَّحِيمِ      ٱلرَّحْمَـٰنِ      ٱللَّهِ        بِسْمِ   │
+│   ──────     ──────     ──────     ──────   │  ← subtle line under each word
+│   the Most    the Most   (of) Allah  In (the)  │
+│   Merciful    Gracious                 name    │
+│                                                  │
+│  ─────────────────────────────────────────────── │
+│  Transliteration block (if ON, unchanged)        │
+│  ─────────────────────────────────────────────── │
+│  Translation block (if ON, unchanged)            │
+└──────────────────────────────────────────────────┘
+```
+
+### Layout Rules
+
+- RTL flex-wrap: `flexDirection: 'row-reverse'`, `flexWrap: 'wrap'`
+- Each word unit is a vertical stack: Arabic → subtle line → transliteration (optional) → translation (optional)
+- No background or border on word units — spacing + alignment creates grouping
+- Subtle hairline under each Arabic word for visual separation (same as app's divider token: `Color(text).alpha(0.06)`)
+- Arabic uses current Mushaf font/size settings (DK V1/V2/IndoPak)
+- Translation/transliteration in Manrope, smaller and subdued
+- Verse end markers (position 51 in dk_words for the ayah number glyph) are excluded from WBW grid
+
+### When WBW is OFF
+
+Normal behavior — full Arabic text block, no changes.
+
+## Settings UI
+
+New **Word by Word** card in the PLAYER VIEW section, placed above Transliteration and Translation cards:
+
+```
+PLAYER VIEW
+
+┌───────────────────────────────────────┐
+│  Arabic Font Size    [-] 5 [+]       │
+└───────────────────────────────────────┘
+
+┌───────────────────────────────────────┐
+│  Word by Word             [switch]   │
+│  Inline word translations            │  ← helper text (always visible)
+│  ─────────────────────────────────── │  ← divider (when ON)
+│    Translation            [✓]       │  ← checkbox (when ON)
+│    Transliteration        [✓]       │  ← checkbox (when ON)
+└───────────────────────────────────────┘
+
+┌───────────────────────────────────────┐
+│  Transliteration          [switch]   │
+└───────────────────────────────────────┘
+
+┌───────────────────────────────────────┐
+│  Translation              [switch]   │
+└───────────────────────────────────────┘
+```
+
+Sub-toggles expand/collapse with WBW switch (same animation pattern as existing font size controls). All existing toggles remain independent and unchanged.
+
+## Long-Press Word Modal
+
+Long-pressing a word in the WBW grid opens a bottom sheet:
+
+```
+┌───────────────────────────────────────┐
+│           ٱلرَّحْمَـٰنِ                   │  ← Large Arabic, centered
+│          l-rahmani                   │  ← Transliteration
+│       "the Most Gracious"            │  ← Translation
+│                                       │
+│          [ ▶ Play ]                  │  ← wbw audio from qurancdn.com
+│                                       │
+│  ─────────────────────────────────── │
+│  Verse 1:1 · Word 3 of 4            │  ← Context
+└───────────────────────────────────────┘
+```
+
+**v1:** Translation, transliteration, audio playback, verse/word position.
+**Future:** Morphology, root/lemma, grammar (QUL resources).
+
+## Store Changes
+
+Add to `mushafSettingsStore`:
+
+```typescript
+// New state
+showWBW: boolean;              // default: false
+wbwShowTranslation: boolean;   // default: true
+wbwShowTransliteration: boolean; // default: false
+
+// New actions
+toggleWBW: () => void;
+toggleWBWTranslation: () => void;
+toggleWBWTransliteration: () => void;
+```
+
+All persisted via AsyncStorage (same as existing settings).
+
+## Data Flow
+
+```
+wbw-en.db (bundled asset)
+    ↓ expo-sqlite importDatabaseFromAssetAsync
+WBWDataService (new singleton, registered in AppInitializer)
+    ↓ getVerseWords(verseKey) → { position, translation, transliteration, audioUrl }[]
+    ↓ cached in memory after first load per verse
+VerseItem component
+    ↓ when showWBW: maps DKWordInfo[] positions to WBW translations
+    ↓ renders RTL flex-wrap grid instead of single text block
+Long-press handler
+    ↓ opens WordDetailSheet with word data + audio playback
+```
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `services/wbw/WBWDataService.ts` | SQLite service for WBW lookups |
+| `components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx` | RTL flex-wrap word grid component |
+| `components/sheets/WordDetailSheet.tsx` | Long-press word detail bottom sheet |
+| `data/wbw/wbw-en.db` | Bundled WBW database |
+
+## Performance Considerations
+
+- WBW data loaded lazily per-verse (not all 77K words at once)
+- Each verse lookup is a single indexed SQLite query: `WHERE verse_key = ? ORDER BY position`
+- FlashList virtualization still applies — only visible verses render WBW grids
+- Word units are simple View + Text stacks, no heavy computation

--- a/scripts/fetch-wbw-translations.js
+++ b/scripts/fetch-wbw-translations.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+
+/**
+ * Fetches word-by-word translations from the Quran Foundation API (v4)
+ * and builds a SQLite database for bundling in the app.
+ *
+ * Usage:
+ *   node scripts/fetch-wbw-translations.js [--language en]
+ *
+ * Output:
+ *   data/wbw/wbw-en.db   (SQLite database)
+ *   data/wbw/wbw-en.json  (intermediate JSON, can be deleted)
+ */
+
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+// ── Config ──────────────────────────────────────────────────────────
+
+const API_BASE = 'https://api.quran.com/api/v4';
+const TOTAL_CHAPTERS = 114;
+const PER_PAGE = 50; // API max per request
+const DELAY_MS = 300; // Be respectful to the API
+const OUTPUT_DIR = path.join(__dirname, '..', 'data', 'wbw');
+
+// Parse --language flag (default: en)
+const langIdx = process.argv.indexOf('--language');
+const LANGUAGE = langIdx !== -1 ? process.argv[langIdx + 1] : 'en';
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function fetchJSON(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      let data = '';
+      res.on('data', chunk => (data += chunk));
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(data));
+        } catch (e) {
+          reject(new Error(`Failed to parse JSON from ${url}: ${e.message}`));
+        }
+      });
+      res.on('error', reject);
+    }).on('error', reject);
+  });
+}
+
+// ── Fetch all words for a single chapter (handles pagination) ──────
+
+async function fetchChapterWords(chapterNumber) {
+  const words = [];
+  let page = 1;
+  let totalPages = 1;
+
+  while (page <= totalPages) {
+    const url =
+      `${API_BASE}/verses/by_chapter/${chapterNumber}` +
+      `?language=${LANGUAGE}&words=true&per_page=${PER_PAGE}&page=${page}` +
+      `&word_fields=text_uthmani,text_indopak`;
+
+    const json = await fetchJSON(url);
+    totalPages = json.pagination.total_pages;
+
+    for (const verse of json.verses) {
+      for (const word of verse.words) {
+        // Skip verse-end markers (٧, ٢, etc.)
+        if (word.char_type_name !== 'word') continue;
+
+        words.push({
+          verse_key: verse.verse_key,
+          position: word.position,
+          text_uthmani: word.text_uthmani || '',
+          text_indopak: word.text_indopak || '',
+          translation: word.translation?.text || '',
+          transliteration: word.transliteration?.text || '',
+          audio_url: word.audio_url || '',
+        });
+      }
+    }
+
+    page++;
+    if (page <= totalPages) await sleep(DELAY_MS);
+  }
+
+  return words;
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`\nFetching word-by-word translations (language: ${LANGUAGE})`);
+  console.log('─'.repeat(55));
+
+  // Ensure output directory exists
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+
+  const allWords = [];
+  const startTime = Date.now();
+
+  for (let ch = 1; ch <= TOTAL_CHAPTERS; ch++) {
+    process.stdout.write(`  Chapter ${String(ch).padStart(3)}/114 ...`);
+    const words = await fetchChapterWords(ch);
+    allWords.push(...words);
+    console.log(` ${words.length} words`);
+    if (ch < TOTAL_CHAPTERS) await sleep(DELAY_MS);
+  }
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log('─'.repeat(55));
+  console.log(`  Total: ${allWords.length} words in ${elapsed}s\n`);
+
+  // Save intermediate JSON
+  const jsonPath = path.join(OUTPUT_DIR, `wbw-${LANGUAGE}.json`);
+  fs.writeFileSync(jsonPath, JSON.stringify(allWords));
+  console.log(`  JSON saved: ${jsonPath}`);
+
+  // Build SQLite database using Python (built-in sqlite3)
+  const dbPath = path.join(OUTPUT_DIR, `wbw-${LANGUAGE}.db`);
+  buildSQLite(jsonPath, dbPath);
+
+  console.log(`  SQLite saved: ${dbPath}`);
+  console.log(
+    `  Size: ${(fs.statSync(dbPath).size / 1024 / 1024).toFixed(2)} MB\n`,
+  );
+
+  // Print sample for verification
+  console.log('  Sample (1:1):');
+  const sample = allWords.filter(w => w.verse_key === '1:1');
+  for (const w of sample) {
+    console.log(
+      `    [${w.position}] ${w.text_uthmani} → "${w.translation}" (${w.transliteration})`,
+    );
+  }
+  console.log();
+}
+
+// ── SQLite builder (calls Python with execFileSync — no shell) ──────
+
+function buildSQLite(jsonPath, dbPath) {
+  if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+
+  const pythonScript = `
+import json, sqlite3, sys
+
+with open(sys.argv[1], 'r') as f:
+    words = json.load(f)
+
+conn = sqlite3.connect(sys.argv[2])
+c = conn.cursor()
+
+c.execute('''
+    CREATE TABLE words (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        verse_key TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        text_uthmani TEXT,
+        text_indopak TEXT,
+        translation TEXT NOT NULL,
+        transliteration TEXT,
+        audio_url TEXT
+    )
+''')
+
+c.execute('CREATE INDEX idx_words_verse ON words (verse_key, position)')
+
+c.executemany(
+    'INSERT INTO words (verse_key, position, text_uthmani, text_indopak, translation, transliteration, audio_url) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    [(w['verse_key'], w['position'], w['text_uthmani'], w['text_indopak'], w['translation'], w['transliteration'], w['audio_url']) for w in words]
+)
+
+conn.commit()
+conn.close()
+print(f'  Created SQLite with {len(words)} rows')
+`;
+
+  execFileSync('python3', ['-c', pythonScript, jsonPath, dbPath], {
+    stdio: 'inherit',
+  });
+}
+
+main().catch(err => {
+  console.error('\nError:', err.message);
+  process.exit(1);
+});

--- a/services/AppInitializer.ts
+++ b/services/AppInitializer.ts
@@ -7,6 +7,7 @@ import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
 import {qulDataService} from '@/services/mushaf/QulDataService';
 import {translationDbService} from '@/services/translation/TranslationDbService';
 import {tafseerDbService} from '@/services/tafseer/TafseerDbService';
+import {wbwDataService} from '@/services/wbw/WBWDataService';
 import {warmBookmarkCache} from '@/components/mushaf/BookmarkChips';
 import {timestampService} from '@/services/timestamps/TimestampService';
 import {useTimestampStore} from '@/store/timestampStore';
@@ -386,6 +387,20 @@ appInitializer.registerService({
   critical: false,
   initialize: async () => {
     await tafseerDbService.initialize();
+  },
+});
+
+/**
+ * WBW Data Service (Priority 10)
+ * Opens wbw-en.db for word-by-word translations.
+ * Non-critical — WBW features degrade gracefully without it.
+ */
+appInitializer.registerService({
+  name: 'WBW Data',
+  priority: 10,
+  critical: false,
+  initialize: async () => {
+    await wbwDataService.initialize();
   },
 });
 

--- a/services/mushaf/MushafPreloadService.ts
+++ b/services/mushaf/MushafPreloadService.ts
@@ -14,6 +14,7 @@ const FONT_ASSETS: Record<string, number> = {
   SurahNameV4: require('@/data/mushaf/surah-name-v4.ttf'),
   SurahNameQCF: require('@/data/mushaf/surah-name-qcf.ttf'),
   ManropeSemiBold: require('@/assets/fonts/Manrope-SemiBold.ttf'),
+  ManropeRegular: require('@/assets/fonts/Manrope-Regular.ttf'),
 };
 
 /**

--- a/services/wbw/WBWDataService.ts
+++ b/services/wbw/WBWDataService.ts
@@ -1,0 +1,94 @@
+import * as SQLite from 'expo-sqlite';
+
+export interface WBWWord {
+  position: number;
+  textUthmani: string;
+  translation: string;
+  transliteration: string;
+  audioUrl: string;
+}
+
+class WBWDataService {
+  private db: SQLite.SQLiteDatabase | null = null;
+  private cache: Map<string, WBWWord[]> = new Map();
+  private _initialized = false;
+  private _initializing: Promise<void> | null = null;
+
+  get initialized(): boolean {
+    return this._initialized;
+  }
+
+  async initialize(): Promise<void> {
+    if (this._initialized) return;
+    if (this._initializing) return this._initializing;
+    this._initializing = this._doInit();
+    return this._initializing;
+  }
+
+  private async _doInit(): Promise<void> {
+    try {
+      const dbName = 'wbw-en.db';
+      let db = await SQLite.openDatabaseAsync(dbName);
+
+      const tableCheck = await db
+        .getFirstAsync<{name: string}>(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='words';",
+        )
+        .catch(() => null);
+
+      if (!tableCheck) {
+        await db.closeAsync();
+        await SQLite.deleteDatabaseAsync(dbName);
+        await SQLite.importDatabaseFromAssetAsync(dbName, {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          assetId: require('../../data/wbw/wbw-en.db'),
+        });
+        db = await SQLite.openDatabaseAsync(dbName);
+      }
+
+      this.db = db;
+      this._initialized = true;
+      console.log('[WBWDataService] Initialized');
+    } catch (error) {
+      console.error('[WBWDataService] Initialization failed:', error);
+      this._initializing = null;
+      throw error;
+    }
+  }
+
+  /** Synchronous cache-only lookup — returns null on cache miss */
+  getVerseWordsCached(verseKey: string): WBWWord[] | null {
+    return this.cache.get(verseKey) ?? null;
+  }
+
+  async getVerseWords(verseKey: string): Promise<WBWWord[]> {
+    const cached = this.cache.get(verseKey);
+    if (cached) return cached;
+
+    if (!this.db) return [];
+
+    const rows = await this.db.getAllAsync<{
+      position: number;
+      text_uthmani: string;
+      translation: string;
+      transliteration: string;
+      audio_url: string;
+    }>(
+      'SELECT position, text_uthmani, translation, transliteration, audio_url FROM words WHERE verse_key = ? ORDER BY position',
+      [verseKey],
+    );
+
+    const words: WBWWord[] = rows.map(row => ({
+      position: row.position,
+      textUthmani: row.text_uthmani || '',
+      translation: row.translation,
+      transliteration: row.transliteration,
+      audioUrl: row.audio_url,
+    }));
+
+    this.cache.set(verseKey, words);
+    return words;
+  }
+}
+
+export const wbwDataService = new WBWDataService();

--- a/store/mushafSettingsStore.ts
+++ b/store/mushafSettingsStore.ts
@@ -36,6 +36,11 @@ interface MushafSettingsState {
   showTransliteration: boolean;
   showTajweed: boolean;
 
+  // Word-by-word settings
+  showWBW: boolean;
+  wbwShowTranslation: boolean;
+  wbwShowTransliteration: boolean;
+
   // Mushaf page layout
   pageLayout: MushafPageLayout;
 
@@ -64,6 +69,9 @@ interface MushafSettingsState {
   toggleTranslation: () => void;
   toggleTransliteration: () => void;
   toggleTajweed: () => void;
+  toggleWBW: () => void;
+  toggleWBWTranslation: () => void;
+  toggleWBWTransliteration: () => void;
   setArabicFontSize: (size: number) => void;
   setTranslationFontSize: (size: number) => void;
   setTransliterationFontSize: (size: number) => void;
@@ -86,6 +94,9 @@ export const useMushafSettingsStore = create<MushafSettingsState>()(
       showTranslation: true,
       showTransliteration: false,
       showTajweed: false,
+      showWBW: false,
+      wbwShowTranslation: true,
+      wbwShowTransliteration: false,
       arabicFontSize: getActualFontSize(5), // Default: middle of scale
       translationFontSize: getActualFontSize(3),
       transliterationFontSize: getActualFontSize(3),
@@ -103,6 +114,11 @@ export const useMushafSettingsStore = create<MushafSettingsState>()(
       toggleTransliteration: () =>
         set(state => ({showTransliteration: !state.showTransliteration})),
       toggleTajweed: () => set(state => ({showTajweed: !state.showTajweed})),
+      toggleWBW: () => set(state => ({showWBW: !state.showWBW})),
+      toggleWBWTranslation: () =>
+        set(state => ({wbwShowTranslation: !state.wbwShowTranslation})),
+      toggleWBWTransliteration: () =>
+        set(state => ({wbwShowTransliteration: !state.wbwShowTransliteration})),
       setArabicFontSize: (size: number) => set({arabicFontSize: size}),
       setTranslationFontSize: (size: number) =>
         set({translationFontSize: size}),
@@ -155,7 +171,7 @@ export const useMushafSettingsStore = create<MushafSettingsState>()(
     {
       name: 'mushaf-settings',
       storage: createJSONStorage(() => AsyncStorage),
-      version: 7,
+      version: 8,
       migrate: (persistedState: unknown, version: number) => {
         const state = persistedState as Record<string, unknown>;
         if (version === 0) {
@@ -192,6 +208,11 @@ export const useMushafSettingsStore = create<MushafSettingsState>()(
         }
         if (version < 7) {
           state.viewMode = 'mushaf';
+        }
+        if (version < 8) {
+          state.showWBW = false;
+          state.wbwShowTranslation = true;
+          state.wbwShowTransliteration = false;
         }
         return state as unknown as MushafSettingsState;
       },


### PR DESCRIPTION
## Summary
- **WBW rendering**: Single-canvas Skia layout with RTL word positioning, text-aware DK/WBW alignment for compound Arabic words, per-character tajweed coloring
- **Tap interaction**: Tap words to view detail sheet (not long-press), with highlight box behind selected word. Scroll-safe on Android via Pressable's built-in gesture handling
- **Audio fix**: Generate audio URLs from `verseKey + position` instead of using the API's broken token-numbered `audio_url` field (qurancdn uses word-only numbering)
- **WordDetailSheet redesign**: Matches alpha-based design system with custom PlayIcon/PauseIcon, card pattern from VerseActionsSheet
- **Settings**: showWBW, wbwShowTranslation, wbwShowTransliteration toggles in mushafSettingsStore

## Test plan
- [ ] Enable WBW in mushaf settings, verify words render with translations/transliterations below each Arabic word
- [ ] Tap a word — highlight box appears, WordDetailSheet opens with correct Arabic, transliteration, translation
- [ ] Play pronunciation from WordDetailSheet for verses with stop marks (13:1, 2:255) — audio matches the selected word
- [ ] Verify tajweed coloring applies to WBW words when tajweed is enabled
- [ ] Scroll through verses with WBW on — no accidental word taps during scroll
- [ ] Check verses 2:181, 8:6, 13:37 — compound word "بَعْدَ مَا" should show same translation under both DK tokens
- [ ] Dismiss WordDetailSheet — highlight clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)