### PR TITLE
fix: change WBW word activation from tap to long-press

### DIFF
--- a/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
+++ b/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
@@ -420,6 +420,8 @@ export const VerseItem = memo<VerseItemProps>(
             selectedWordPosition={selectedWordPosition}
             showTajweed={showTajweed}
             indexedTajweedData={indexedTajweedData}
+            onTap={handlePress}
+            onLongPress={handleLongPress}
           />
         ) : (
           <View onLayout={handleArabicLayout}>

--- a/components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx
+++ b/components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx
@@ -64,6 +64,8 @@ interface WBWVerseViewProps {
   selectedWordPosition: number | null;
   showTajweed: boolean;
   indexedTajweedData: IndexedTajweedData | null;
+  onTap?: () => void;
+  onLongPress?: () => void;
 }
 
 interface MatchedWord {
@@ -262,6 +264,8 @@ export const WBWVerseView = memo<WBWVerseViewProps>(
     selectedWordPosition,
     showTajweed,
     indexedTajweedData,
+    onTap,
+    onLongPress,
   }) => {
     const {theme} = useTheme();
     const [containerWidth, setContainerWidth] = useState(0);
@@ -492,8 +496,10 @@ export const WBWVerseView = memo<WBWVerseViewProps>(
             return;
           }
         }
+        // No word hit — forward to parent long-press handler
+        onLongPress?.();
       },
-      [computedLayout, onWordPress],
+      [computedLayout, onWordPress, onLongPress],
     );
 
     if (!wbwWords) return null;
@@ -503,7 +509,8 @@ export const WBWVerseView = memo<WBWVerseViewProps>(
       return (
         <Pressable
           onLayout={handleLayout}
-          onPress={handleWordPress}
+          onPress={onTap}
+          onLongPress={handleWordPress}
           style={[
             styles.singleCanvasContainer,
             {height: computedLayout.totalHeight + PADDING_VERTICAL * 2},
@@ -605,7 +612,8 @@ export const WBWVerseView = memo<WBWVerseViewProps>(
                 borderRadius: HIGHLIGHT_RADIUS,
               },
             ]}
-            onPress={() => {
+            onPress={onTap}
+            onLongPress={() => {
               mediumHaptics();
               onWordPress(wbwWord.position);
             }}>


### PR DESCRIPTION
## Summary
- Tap on a WBW word now passes through to toggle immersive mode (show/hide header/footer)
- Long-press on a word opens the word detail sheet with haptic feedback
- Long-press on a non-word area within the WBW view forwards to the verse actions sheet

## Test plan
- [ ] Enable WBW mode in reading view
- [ ] Tap on a word → immersive mode toggles
- [ ] Long-press on a word → word detail sheet opens
- [ ] Long-press on non-word area → verse actions sheet opens
- [ ] Tap on non-WBW verse area → immersive mode toggles (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)