### PR TITLE
fix: show error message when mushaf timestamps unavailable

### DIFF
--- a/components/mushaf/MushafPlayerBar.tsx
+++ b/components/mushaf/MushafPlayerBar.tsx
@@ -38,6 +38,7 @@ export const MushafPlayerBar: React.FC<MushafPlayerBarProps> = ({
   const playbackState = useMushafPlayerStore(s => s.playbackState);
   const currentSurah = useMushafPlayerStore(s => s.currentSurah);
   const currentAyah = useMushafPlayerStore(s => s.currentAyah);
+  const timestampError = useMushafPlayerStore(s => s.timestampError);
   const isIdle = playbackState === 'idle';
   const isLoading = playbackState === 'loading';
   const isPlaying = playbackState === 'playing';
@@ -92,6 +93,41 @@ export const MushafPlayerBar: React.FC<MushafPlayerBarProps> = ({
     });
   }, [currentPage]);
 
+  const handleChangeReciter = useCallback(() => {
+    useMushafPlayerStore.setState({timestampError: null, currentPage});
+    SheetManager.show('mushaf-player-options', {
+      payload: {currentPage},
+    });
+  }, [currentPage]);
+
+  // ── Error state: show message + change reciter button ────
+  if (isIdle && timestampError) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text
+          style={[
+            styles.errorText,
+            {color: Color(theme.colors.text).alpha(0.7).toString()},
+          ]}
+          numberOfLines={1}>
+          {timestampError}
+        </Text>
+        <Pressable
+          style={[
+            styles.changeReciterButton,
+            {backgroundColor: Color(theme.colors.text).alpha(0.08).toString()},
+          ]}
+          onPress={handleChangeReciter}
+          accessibilityRole="button"
+          accessibilityLabel="Change reciter">
+          <Text style={[styles.changeReciterText, {color: theme.colors.text}]}>
+            Change Reciter
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
   // ── Idle state: [Search] — spacer — [Play] — spacer — [Options] ────
   if (isIdle) {
     return (
@@ -110,7 +146,10 @@ export const MushafPlayerBar: React.FC<MushafPlayerBarProps> = ({
 
         <View style={styles.controlsCenter}>
           <Pressable
-            style={[styles.playButtonRect, {backgroundColor: Color(theme.colors.text).alpha(0.1).toString()}]}
+            style={[
+              styles.playButtonRect,
+              {backgroundColor: Color(theme.colors.text).alpha(0.1).toString()},
+            ]}
             onPress={handlePlayPress}
             accessibilityRole="button"
             accessibilityLabel="Play">
@@ -219,6 +258,27 @@ export const MushafPlayerBar: React.FC<MushafPlayerBarProps> = ({
 };
 
 const styles = StyleSheet.create({
+  errorContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: moderateScale(52),
+    paddingHorizontal: moderateScale(12),
+    gap: moderateScale(10),
+  },
+  errorText: {
+    flex: 1,
+    fontSize: moderateScale(11.5),
+    fontFamily: 'Manrope-Regular',
+  },
+  changeReciterButton: {
+    paddingHorizontal: moderateScale(14),
+    paddingVertical: moderateScale(8),
+    borderRadius: moderateScale(10),
+  },
+  changeReciterText: {
+    fontSize: moderateScale(12),
+    fontFamily: 'Manrope-SemiBold',
+  },
   idleRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/store/mushafPlayerStore.ts
+++ b/store/mushafPlayerStore.ts
@@ -44,6 +44,7 @@ export interface MushafPlayerStoreState {
   rangeEnd: RangeEndpoint | null;
   availableReciters: AvailableReciter[];
   pendingStartVerseKey: string | null;
+  timestampError: string | null;
   _versePlayCount: number;
   _rangePlayCount: number;
 
@@ -86,6 +87,7 @@ export const useMushafPlayerStore = create<MushafPlayerStoreState>()(
       rangeEnd: null,
       availableReciters: [],
       pendingStartVerseKey: null,
+      timestampError: null,
       _versePlayCount: 1,
       _rangePlayCount: 1,
       isImmersive: false,
@@ -145,6 +147,7 @@ export const useMushafPlayerStore = create<MushafPlayerStoreState>()(
           playbackState: 'loading',
           currentPage: page,
           pendingStartVerseKey: null,
+          timestampError: null,
           _versePlayCount: 1,
           _rangePlayCount: 1,
         });
@@ -173,10 +176,14 @@ export const useMushafPlayerStore = create<MushafPlayerStoreState>()(
             surahNumber,
           );
           if (!timestamps) {
-            console.error(
+            console.warn(
               `[MushafPlayerStore] No timestamps for rewayat=${rewayatId} surah=${surahNumber}`,
             );
-            set({playbackState: 'idle'});
+            set({
+              playbackState: 'idle',
+              timestampError:
+                'Timestamps unavailable for this reciter on this surah. Try a different reciter.',
+            });
             return;
           }
 
@@ -386,6 +393,7 @@ export const useMushafPlayerStore = create<MushafPlayerStoreState>()(
           timestamps: null,
           rangeStart: null,
           rangeEnd: null,
+          timestampError: null,
           _versePlayCount: 1,
           _rangePlayCount: 1,
         });


### PR DESCRIPTION
## Summary
- When a reciter doesn't have timestamps for a surah in the mushaf player, show a user-facing error message instead of silently failing
- Adds a "Change Reciter" button that opens the reciter picker sheet
- Error auto-clears on next playback attempt or when stop is called

## Test plan
- [ ] Pick a reciter without timestamps for the current surah → error message appears with "Change Reciter" button
- [ ] Tap "Change Reciter" → opens reciter picker sheet
- [ ] Pick a different reciter with timestamps → playback works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)