### PR TITLE
feat: 2-axis mushaf view modes with vertical scroll

### DIFF
--- a/app/(tabs)/(a.home)/adhkar/[superId]/index.tsx
+++ b/app/(tabs)/(a.home)/adhkar/[superId]/index.tsx
@@ -1,6 +1,27 @@
-import React, {useMemo, useCallback, useEffect, useState, useLayoutEffect, useRef} from 'react';
-import {View, SectionList, FlatList, Text, Platform, ViewToken, Pressable, StyleSheet} from 'react-native';
-import {useLocalSearchParams, useRouter, useNavigation, Link} from 'expo-router';
+import React, {
+  useMemo,
+  useCallback,
+  useEffect,
+  useState,
+  useLayoutEffect,
+  useRef,
+} from 'react';
+import {
+  View,
+  SectionList,
+  FlatList,
+  Text,
+  Platform,
+  ViewToken,
+  Pressable,
+  StyleSheet,
+} from 'react-native';
+import {
+  useLocalSearchParams,
+  useRouter,
+  useNavigation,
+  Link,
+} from 'expo-router';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {useAdhkar} from '@/hooks/useAdhkar';
 import {useTheme} from '@/hooks/useTheme';
@@ -59,7 +80,9 @@ const SuperCategoryListScreen: React.FC = () => {
   );
   const [categoryGroups, setCategoryGroups] = useState<CategoryGroup[]>([]);
   const [loading, setLoading] = useState(true);
-  const [currentSectionTitle, setCurrentSectionTitle] = useState<string | null>(null);
+  const [currentSectionTitle, setCurrentSectionTitle] = useState<string | null>(
+    null,
+  );
 
   useEffect(() => {
     async function loadData() {
@@ -238,7 +261,17 @@ const SuperCategoryListScreen: React.FC = () => {
         </View>
       ),
     });
-  }, [navigation, displayTitle, currentSectionTitle, isSingleCategory, handlePlayAll, isThisCategoryPlaying, loading, allAdhkarForPlayAll.length, theme]);
+  }, [
+    navigation,
+    displayTitle,
+    currentSectionTitle,
+    isSingleCategory,
+    handlePlayAll,
+    isThisCategoryPlaying,
+    loading,
+    allAdhkarForPlayAll.length,
+    theme,
+  ]);
 
   const renderItem = useCallback(
     ({item}: {item: DhikrItem}) => (
@@ -322,9 +355,15 @@ const SuperCategoryListScreen: React.FC = () => {
           keyExtractor={keyExtractor}
           contentContainerStyle={styles.listContent}
           contentInset={Platform.OS === 'ios' ? {top: headerHeight} : undefined}
-          contentOffset={Platform.OS === 'ios' ? {x: 0, y: -headerHeight} : undefined}
-          scrollIndicatorInsets={Platform.OS === 'ios' ? {top: headerHeight} : undefined}
-          style={Platform.OS === 'android' ? {marginTop: headerHeight} : undefined}
+          contentOffset={
+            Platform.OS === 'ios' ? {x: 0, y: -headerHeight} : undefined
+          }
+          scrollIndicatorInsets={
+            Platform.OS === 'ios' ? {top: headerHeight} : undefined
+          }
+          style={
+            Platform.OS === 'android' ? {marginTop: headerHeight} : undefined
+          }
           showsVerticalScrollIndicator={false}
           initialNumToRender={10}
           maxToRenderPerBatch={10}
@@ -341,9 +380,15 @@ const SuperCategoryListScreen: React.FC = () => {
           stickySectionHeadersEnabled={false}
           contentContainerStyle={styles.listContent}
           contentInset={Platform.OS === 'ios' ? {top: headerHeight} : undefined}
-          contentOffset={Platform.OS === 'ios' ? {x: 0, y: -headerHeight} : undefined}
-          scrollIndicatorInsets={Platform.OS === 'ios' ? {top: headerHeight} : undefined}
-          style={Platform.OS === 'android' ? {marginTop: headerHeight} : undefined}
+          contentOffset={
+            Platform.OS === 'ios' ? {x: 0, y: -headerHeight} : undefined
+          }
+          scrollIndicatorInsets={
+            Platform.OS === 'ios' ? {top: headerHeight} : undefined
+          }
+          style={
+            Platform.OS === 'android' ? {marginTop: headerHeight} : undefined
+          }
           showsVerticalScrollIndicator={false}
           initialNumToRender={20}
           maxToRenderPerBatch={15}

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1002,61 +1002,237 @@ export const MushafPagePillIcon: React.FC<IconProps> = ({color, size}) => (
       stroke={color}
       strokeWidth={1.3}
     />
-    <Rect
-      x="5.5"
-      y="4"
-      width="13"
-      height="16"
-      rx={1}
-      stroke={color}
-      strokeWidth={0.8}
-      opacity={0.4}
-    />
-    <Line
-      x1="7.5"
-      y1="7.5"
-      x2="16.5"
-      y2="7.5"
-      stroke={color}
-      strokeWidth={1}
-      strokeLinecap="round"
-      opacity={0.6}
-    />
-    <Line
-      x1="8"
-      y1="10"
-      x2="16"
-      y2="10"
-      stroke={color}
-      strokeWidth={1}
-      strokeLinecap="round"
-      opacity={0.6}
-    />
-    <Line
-      x1="7.5"
-      y1="12.5"
-      x2="16.5"
-      y2="12.5"
-      stroke={color}
-      strokeWidth={1}
-      strokeLinecap="round"
-      opacity={0.6}
-    />
-    <Line
-      x1="8"
-      y1="15"
-      x2="16"
-      y2="15"
-      stroke={color}
-      strokeWidth={1}
-      strokeLinecap="round"
-      opacity={0.6}
-    />
+    {/* Divider 1 */}
+    <Line x1="6" y1="4" x2="18" y2="4" stroke={color} strokeWidth={1.4} strokeLinecap="round" opacity={0.9} />
+    {/* Surah 1 */}
+    <Line x1="7" y1="5.8" x2="17" y2="5.8" stroke={color} strokeWidth={0.7} strokeLinecap="round" opacity={0.45} />
+    <Line x1="8" y1="7.2" x2="16" y2="7.2" stroke={color} strokeWidth={0.7} strokeLinecap="round" opacity={0.45} />
+    {/* Divider 2 */}
+    <Line x1="6" y1="9" x2="18" y2="9" stroke={color} strokeWidth={1.4} strokeLinecap="round" opacity={0.9} />
+    {/* Surah 2 */}
+    <Line x1="7" y1="10.8" x2="17" y2="10.8" stroke={color} strokeWidth={0.7} strokeLinecap="round" opacity={0.45} />
+    <Line x1="7.5" y1="12.2" x2="16.5" y2="12.2" stroke={color} strokeWidth={0.7} strokeLinecap="round" opacity={0.45} />
+    <Line x1="9" y1="13.6" x2="15" y2="13.6" stroke={color} strokeWidth={0.7} strokeLinecap="round" opacity={0.45} />
+    {/* Divider 3 */}
+    <Line x1="6" y1="15.4" x2="18" y2="15.4" stroke={color} strokeWidth={1.4} strokeLinecap="round" opacity={0.9} />
+    {/* Surah 3 */}
+    <Line x1="7" y1="17.2" x2="17" y2="17.2" stroke={color} strokeWidth={0.7} strokeLinecap="round" opacity={0.45} />
+    <Line x1="8" y1="18.6" x2="16" y2="18.6" stroke={color} strokeWidth={0.7} strokeLinecap="round" opacity={0.45} />
+    <Line x1="9" y1="20" x2="15" y2="20" stroke={color} strokeWidth={0.7} strokeLinecap="round" opacity={0.45} />
   </Svg>
 );
 
 // Scroll Mode — Page + Arrow (pill icon)
 export const ScrollModePillIcon: React.FC<IconProps> = ({color, size}) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <Rect
+      x="4"
+      y="2"
+      width="16"
+      height="20"
+      rx={2}
+      stroke={color}
+      strokeWidth={1.3}
+    />
+    <Line
+      x1="8"
+      y1="6"
+      x2="16"
+      y2="6"
+      stroke={color}
+      strokeWidth={1}
+      strokeLinecap="round"
+      opacity={0.5}
+    />
+    <Line
+      x1="8"
+      y1="9"
+      x2="16"
+      y2="9"
+      stroke={color}
+      strokeWidth={1}
+      strokeLinecap="round"
+      opacity={0.5}
+    />
+    <Line
+      x1="8"
+      y1="12"
+      x2="16"
+      y2="12"
+      stroke={color}
+      strokeWidth={1}
+      strokeLinecap="round"
+      opacity={0.5}
+    />
+    <Line
+      x1="8"
+      y1="15"
+      x2="14"
+      y2="15"
+      stroke={color}
+      strokeWidth={1}
+      strokeLinecap="round"
+      opacity={0.5}
+    />
+    <Path
+      d="M12 18V22M10 20L12 22L14 20"
+      stroke={color}
+      strokeWidth={1.2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
+// List View — Flowing text lines (no page border)
+export const ListViewPillIcon: React.FC<IconProps> = ({color, size}) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <Line
+      x1="3"
+      y1="4.5"
+      x2="21"
+      y2="4.5"
+      stroke={color}
+      strokeWidth={1.3}
+      strokeLinecap="round"
+    />
+    <Line
+      x1="3"
+      y1="8"
+      x2="19"
+      y2="8"
+      stroke={color}
+      strokeWidth={1.3}
+      strokeLinecap="round"
+      opacity={0.7}
+    />
+    <Line
+      x1="3"
+      y1="11.5"
+      x2="21"
+      y2="11.5"
+      stroke={color}
+      strokeWidth={1.3}
+      strokeLinecap="round"
+    />
+    <Line
+      x1="3"
+      y1="15"
+      x2="17"
+      y2="15"
+      stroke={color}
+      strokeWidth={1.3}
+      strokeLinecap="round"
+      opacity={0.7}
+    />
+    <Line
+      x1="3"
+      y1="18.5"
+      x2="21"
+      y2="18.5"
+      stroke={color}
+      strokeWidth={1.3}
+      strokeLinecap="round"
+    />
+  </Svg>
+);
+
+// Horizontal Scroll — Two pages with horizontal arrow
+export const HorizontalScrollPillIcon: React.FC<IconProps> = ({
+  color,
+  size,
+}) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <Rect
+      x="2"
+      y="4"
+      width="8"
+      height="12"
+      rx={1.2}
+      stroke={color}
+      strokeWidth={1.2}
+    />
+    <Line
+      x1="4"
+      y1="7"
+      x2="8"
+      y2="7"
+      stroke={color}
+      strokeWidth={0.8}
+      strokeLinecap="round"
+      opacity={0.5}
+    />
+    <Line
+      x1="4"
+      y1="9.5"
+      x2="8"
+      y2="9.5"
+      stroke={color}
+      strokeWidth={0.8}
+      strokeLinecap="round"
+      opacity={0.5}
+    />
+    <Line
+      x1="4"
+      y1="12"
+      x2="7"
+      y2="12"
+      stroke={color}
+      strokeWidth={0.8}
+      strokeLinecap="round"
+      opacity={0.5}
+    />
+    <Rect
+      x="14"
+      y="4"
+      width="8"
+      height="12"
+      rx={1.2}
+      stroke={color}
+      strokeWidth={1.2}
+    />
+    <Line
+      x1="16"
+      y1="7"
+      x2="20"
+      y2="7"
+      stroke={color}
+      strokeWidth={0.8}
+      strokeLinecap="round"
+      opacity={0.5}
+    />
+    <Line
+      x1="16"
+      y1="9.5"
+      x2="20"
+      y2="9.5"
+      stroke={color}
+      strokeWidth={0.8}
+      strokeLinecap="round"
+      opacity={0.5}
+    />
+    <Line
+      x1="16"
+      y1="12"
+      x2="19"
+      y2="12"
+      stroke={color}
+      strokeWidth={0.8}
+      strokeLinecap="round"
+      opacity={0.5}
+    />
+    <Path
+      d="M10.5 20H13.5M12 18.5L13.5 20L12 21.5"
+      stroke={color}
+      strokeWidth={1.2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
+// Vertical Scroll — Page with downward arrow
+export const VerticalScrollPillIcon: React.FC<IconProps> = ({color, size}) => (
   <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
     <Rect
       x="4"

--- a/components/MushafSettingsContent.tsx
+++ b/components/MushafSettingsContent.tsx
@@ -8,7 +8,9 @@ import {Icon} from '@rneui/themed';
 import {Feather} from '@expo/vector-icons';
 import {
   MushafPagePillIcon,
-  ScrollModePillIcon,
+  ListViewPillIcon,
+  HorizontalScrollPillIcon,
+  VerticalScrollPillIcon,
   BookLayoutPillIcon,
   FullscreenPillIcon,
 } from '@/components/Icons';
@@ -28,6 +30,7 @@ import {
   DISPLAY_MIN,
   DISPLAY_MAX,
   type MushafRenderer,
+  type MushafScrollDirection,
 } from '@/store/mushafSettingsStore';
 
 // --- Pre-cache Translation/Transliteration Data --- //
@@ -416,6 +419,8 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
     setPageLayout,
     viewMode,
     setViewMode,
+    scrollDirection,
+    setScrollDirection,
     showWBW,
     wbwShowTranslation,
     wbwShowTransliteration,
@@ -430,8 +435,8 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
     mushafRenderer === 'dk_indopak'
       ? 'DigitalKhattIndoPak'
       : mushafRenderer === 'dk_v1'
-      ? 'DigitalKhattV1'
-      : 'DigitalKhattV2';
+        ? 'DigitalKhattV1'
+        : 'DigitalKhattV2';
   const fontMgr =
     mushafPreloadService.initialized && digitalKhattDataService.initialized
       ? mushafPreloadService.fontMgr
@@ -490,10 +495,10 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
     <View style={[styles.container, containerStyle]}>
       {showTitle && <Text style={styles.title}>Mushaf Settings</Text>}
 
-      {/* SCROLL DIRECTION Section (hidden from player context) */}
+      {/* VIEW TYPE Section (hidden from player context) */}
       {context !== 'player' && (
         <>
-          <Text style={styles.sectionHeader}>SCROLL DIRECTION</Text>
+          <Text style={styles.sectionHeader}>VIEW TYPE</Text>
           <View style={styles.card}>
             <Pressable
               style={({pressed}) => [
@@ -505,7 +510,7 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
                 size={moderateScale(20)}
                 color={Color(theme.colors.text).alpha(0.7).toString()}
               />
-              <Text style={styles.settingRowLabel}>Horizontal</Text>
+              <Text style={styles.settingRowLabel}>Mushaf</Text>
               {viewMode === 'mushaf' && (
                 <Feather
                   name="check"
@@ -520,13 +525,13 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
                 styles.settingRow,
                 pressed && styles.settingRowPressed,
               ]}
-              onPress={() => setViewMode('reading')}>
-              <ScrollModePillIcon
+              onPress={() => setViewMode('list')}>
+              <ListViewPillIcon
                 size={moderateScale(20)}
                 color={Color(theme.colors.text).alpha(0.7).toString()}
               />
-              <Text style={styles.settingRowLabel}>Vertical</Text>
-              {viewMode === 'reading' && (
+              <Text style={styles.settingRowLabel}>List</Text>
+              {viewMode === 'list' && (
                 <Feather
                   name="check"
                   size={moderateScale(18)}
@@ -536,20 +541,20 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
             </Pressable>
           </View>
 
-          <Text style={styles.sectionHeader}>PAGE DESIGN</Text>
+          <Text style={styles.sectionHeader}>SCROLL DIRECTION</Text>
           <View style={styles.card}>
             <Pressable
               style={({pressed}) => [
                 styles.settingRow,
                 pressed && styles.settingRowPressed,
               ]}
-              onPress={() => setPageLayout('fullscreen')}>
-              <FullscreenPillIcon
+              onPress={() => setScrollDirection('horizontal')}>
+              <HorizontalScrollPillIcon
                 size={moderateScale(20)}
                 color={Color(theme.colors.text).alpha(0.7).toString()}
               />
-              <Text style={styles.settingRowLabel}>Fullscreen</Text>
-              {pageLayout === 'fullscreen' && (
+              <Text style={styles.settingRowLabel}>Horizontal</Text>
+              {scrollDirection === 'horizontal' && (
                 <Feather
                   name="check"
                   size={moderateScale(18)}
@@ -563,13 +568,13 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
                 styles.settingRow,
                 pressed && styles.settingRowPressed,
               ]}
-              onPress={() => setPageLayout('book')}>
-              <BookLayoutPillIcon
+              onPress={() => setScrollDirection('vertical')}>
+              <VerticalScrollPillIcon
                 size={moderateScale(20)}
                 color={Color(theme.colors.text).alpha(0.7).toString()}
               />
-              <Text style={styles.settingRowLabel}>Book</Text>
-              {pageLayout === 'book' && (
+              <Text style={styles.settingRowLabel}>Vertical</Text>
+              {scrollDirection === 'vertical' && (
                 <Feather
                   name="check"
                   size={moderateScale(18)}
@@ -578,11 +583,59 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
               )}
             </Pressable>
           </View>
+
+          {/* PAGE DESIGN: only in mushaf view + horizontal */}
+          {viewMode === 'mushaf' && scrollDirection === 'horizontal' && (
+            <>
+              <Text style={styles.sectionHeader}>PAGE DESIGN</Text>
+              <View style={styles.card}>
+                <Pressable
+                  style={({pressed}) => [
+                    styles.settingRow,
+                    pressed && styles.settingRowPressed,
+                  ]}
+                  onPress={() => setPageLayout('fullscreen')}>
+                  <FullscreenPillIcon
+                    size={moderateScale(20)}
+                    color={Color(theme.colors.text).alpha(0.7).toString()}
+                  />
+                  <Text style={styles.settingRowLabel}>Fullscreen</Text>
+                  {pageLayout === 'fullscreen' && (
+                    <Feather
+                      name="check"
+                      size={moderateScale(18)}
+                      color={Color(theme.colors.text).alpha(0.7).toString()}
+                    />
+                  )}
+                </Pressable>
+                <View style={styles.divider} />
+                <Pressable
+                  style={({pressed}) => [
+                    styles.settingRow,
+                    pressed && styles.settingRowPressed,
+                  ]}
+                  onPress={() => setPageLayout('book')}>
+                  <BookLayoutPillIcon
+                    size={moderateScale(20)}
+                    color={Color(theme.colors.text).alpha(0.7).toString()}
+                  />
+                  <Text style={styles.settingRowLabel}>Book</Text>
+                  {pageLayout === 'book' && (
+                    <Feather
+                      name="check"
+                      size={moderateScale(18)}
+                      color={Color(theme.colors.text).alpha(0.7).toString()}
+                    />
+                  )}
+                </Pressable>
+              </View>
+            </>
+          )}
         </>
       )}
 
-      {/* Word by Word Section */}
-      {context !== 'player' && (
+      {/* Word by Word Section — only in list view */}
+      {context !== 'player' && viewMode === 'list' && (
         <>
           <Text style={styles.sectionHeader}>WORD BY WORD</Text>
           <View style={styles.card}>
@@ -637,8 +690,8 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
         </>
       )}
 
-      {/* Player View Section (shown in player context OR mushaf reading mode) */}
-      {(context !== 'mushaf' || viewMode === 'reading') && (
+      {/* Translation/Transliteration Section (shown in player context OR list view mode) */}
+      {(context !== 'mushaf' || viewMode === 'list') && (
         <>
           <View style={styles.card}>
             <FontSizeControl

--- a/components/mushaf/main.tsx
+++ b/components/mushaf/main.tsx
@@ -47,6 +47,10 @@ import {useMushafAutoPageTurn} from '@/hooks/useMushafAutoPageTurn';
 import {MushafPlayerBar} from './MushafPlayerBar';
 import SkiaPage from './skia/SkiaPage';
 import ReadingPageView from './reading/ReadingPageView';
+import ContinuousListView, {
+  type ContinuousListViewHandle,
+} from './reading/ContinuousListView';
+import ContinuousMushafView from './skia/ContinuousMushafView';
 import PageEdgeDecoration, {
   EDGE_BORDER_RADIUS,
   EDGE_HORIZONTAL_INSET,
@@ -244,15 +248,16 @@ export default function MushafViewer({
   const [autoFocusSearch, setAutoFocusSearch] = useState(false);
   const setIsSearchMode = useCallback(
     (value: boolean | ((prev: boolean) => boolean), autoFocus?: boolean) => {
-      setIsSearchModeRaw(prev => {
-        const next = typeof value === 'function' ? value(prev) : value;
+      const next = typeof value === 'function' ? value(isSearchMode) : value;
+      setIsSearchModeRaw(next);
+      // Defer store update to avoid setState-during-render
+      queueMicrotask(() => {
         useMushafPlayerStore.setState({isSearchMode: next});
-        if (!next) setAutoFocusSearch(false);
-        else if (autoFocus) setAutoFocusSearch(true);
-        return next;
       });
+      if (!next) setAutoFocusSearch(false);
+      else if (autoFocus) setAutoFocusSearch(true);
     },
-    [],
+    [isSearchMode],
   );
   // iOS: sync search mode from store (toolbar search button sets store directly)
   const storeSearchMode = useMushafPlayerStore(s => s.isSearchMode);
@@ -268,6 +273,8 @@ export default function MushafViewer({
   const {theme, isDarkMode} = useTheme();
   const pageLayout = useMushafSettingsStore(s => s.pageLayout);
   const viewMode = useMushafSettingsStore(s => s.viewMode);
+  const scrollDirection = useMushafSettingsStore(s => s.scrollDirection);
+  const isVertical = scrollDirection === 'vertical';
   const isBookLayout = pageLayout === 'book';
   const edgeBg = isDarkMode ? '#000' : theme.colors.card;
   const pageBg = isDarkMode ? theme.colors.card : theme.colors.background;
@@ -277,6 +284,7 @@ export default function MushafViewer({
   const router = useRouter();
   const navigation = useNavigation();
   const flatListRef = useRef<FlatList>(null);
+  const continuousListRef = useRef<ContinuousListViewHandle>(null);
   const insets = useSafeAreaInsets();
 
   // Reanimated overlay animation (same pattern as PlayerContent)
@@ -321,7 +329,10 @@ export default function MushafViewer({
 
     if (isImmersive || isSearchMode) {
       // Hide native header — search overlay renders its own UI
-      navigation.setOptions({headerShown: false, headerSearchBarOptions: undefined});
+      navigation.setOptions({
+        headerShown: false,
+        headerSearchBarOptions: undefined,
+      });
       return;
     }
 
@@ -431,37 +442,56 @@ export default function MushafViewer({
     [],
   );
 
-  const navigateToPage = useCallback((targetPage: number) => {
-    setIsSearchMode(false);
-    // Explicit navigation = start a new chain (preserves old position)
-    const surahId = digitalKhattDataService.initialized
-      ? digitalKhattDataService.getPageToSurah()[targetPage]
-      : undefined;
-    if (surahId) {
-      useMushafSettingsStore.getState().startNewChain(surahId, targetPage);
-    }
-    flatListRef.current?.scrollToIndex({
-      index: targetPage - 1,
-      animated: false,
-    });
-  }, []);
+  const navigateToPage = useCallback(
+    (targetPage: number) => {
+      setIsSearchMode(false);
+      // Explicit navigation = start a new chain (preserves old position)
+      const surahId = digitalKhattDataService.initialized
+        ? digitalKhattDataService.getPageToSurah()[targetPage]
+        : undefined;
+      if (surahId) {
+        useMushafSettingsStore.getState().startNewChain(surahId, targetPage);
+      }
+      if (isVertical) {
+        continuousListRef.current?.scrollToPage(targetPage);
+      } else {
+        flatListRef.current?.scrollToIndex({
+          index: targetPage - 1,
+          animated: false,
+        });
+      }
+    },
+    [isVertical],
+  );
 
-  const navigateToPageAnimated = useCallback((targetPage: number) => {
-    flatListRef.current?.scrollToIndex({
-      index: targetPage - 1,
-      animated: true,
-    });
-  }, []);
+  const navigateToPageAnimated = useCallback(
+    (targetPage: number) => {
+      if (isVertical) {
+        continuousListRef.current?.scrollToPage(targetPage, true);
+      } else {
+        flatListRef.current?.scrollToIndex({
+          index: targetPage - 1,
+          animated: true,
+        });
+      }
+    },
+    [isVertical],
+  );
 
   // Auto-page-turn during mushaf playback
   useMushafAutoPageTurn(currentPage, navigateToPageAnimated);
 
   const navigateToSurah = useCallback(
     (surahId: number) => {
-      const targetPage = surahStartPages[surahId];
-      if (targetPage) navigateToPage(targetPage);
+      setIsSearchMode(false);
+      if (isVertical) {
+        continuousListRef.current?.scrollToSurah(surahId);
+      } else {
+        const targetPage = surahStartPages[surahId];
+        if (targetPage) navigateToPage(targetPage);
+      }
     },
-    [surahStartPages, navigateToPage],
+    [isVertical, surahStartPages, navigateToPage],
   );
 
   // Subscribe to external navigation requests (e.g. from SimilarVersesSheet)
@@ -490,27 +520,58 @@ export default function MushafViewer({
 
   const navigateToVerse = useCallback(
     (verseKey: string, page: number) => {
-      navigateToPage(page);
+      if (isVertical) {
+        setIsSearchMode(false);
+        continuousListRef.current?.scrollToVerse(verseKey);
+      } else {
+        navigateToPage(page);
+      }
       useMushafVerseSelectionStore.getState().selectVerse(verseKey, page);
       const timer = setTimeout(() => {
         useMushafVerseSelectionStore.getState().clearSelection();
       }, 3000);
       return () => clearTimeout(timer);
     },
-    [navigateToPage],
+    [isVertical, navigateToPage],
   );
 
-  const resumeChain = useCallback((index: number, page: number) => {
-    setIsSearchMode(false);
-    useMushafSettingsStore.getState().resumeChain(index);
-    flatListRef.current?.scrollToIndex({
-      index: page - 1,
-      animated: false,
-    });
-  }, []);
+  const resumeChain = useCallback(
+    (index: number, page: number) => {
+      setIsSearchMode(false);
+      useMushafSettingsStore.getState().resumeChain(index);
+      if (isVertical) {
+        continuousListRef.current?.scrollToPage(page);
+      } else {
+        flatListRef.current?.scrollToIndex({
+          index: page - 1,
+          animated: false,
+        });
+      }
+    },
+    [isVertical],
+  );
 
   const openSearchMode = useCallback(() => setIsSearchMode(true, false), []);
-  const openSearchWithFocus = useCallback(() => setIsSearchMode(true, true), []);
+  const openSearchWithFocus = useCallback(
+    () => setIsSearchMode(true, true),
+    [],
+  );
+
+  // Vertical mode callbacks — update the same state as horizontal FlatList
+  const handleContinuousPageChange = useCallback(
+    (page: number) => {
+      if (page !== currentPage) {
+        setCurrentPage(page);
+        useMushafPlayerStore.setState({currentPage: page});
+        mushafSessionStore.setLastReadPage(page);
+        const surahId = pageToSurah[page];
+        if (surahId) {
+          useMushafSettingsStore.getState().updateActiveChain(surahId, page);
+        }
+      }
+    },
+    [currentPage, pageToSurah],
+  );
 
   // Mushaf player state
   const mushafPlaybackState = useMushafPlayerStore(s => s.playbackState);
@@ -537,50 +598,77 @@ export default function MushafViewer({
     <View
       style={[
         styles.container,
-        {backgroundColor: isBookLayout ? edgeBg : theme.colors.card},
+        {
+          backgroundColor: isVertical
+            ? theme.colors.background
+            : isBookLayout
+              ? edgeBg
+              : theme.colors.card,
+        },
       ]}>
-      {/* FlatList fills the entire screen */}
-      <FlatList
-        ref={flatListRef}
-        data={pages}
-        renderItem={({item}) => {
-          const commonProps = {
-            pageNumber: item,
-            textColor: theme.colors.text,
-            surahLabel: getSurahNamesForPage(item),
-            juzLabel: `Juz ${getJuzForPage(item)}`,
-            pageLabel: String(item),
-            labelColor: theme.colors.textSecondary,
-            borderColor: edgeBorderColor,
-            cardColor: pageBg,
-            bgColor: edgeBg,
-            isBookLayout,
-            onTap: toggleImmersive,
-          };
-          return viewMode === 'reading' ? (
-            <ReadingPageView {...commonProps} />
-          ) : (
-            <DKPageView {...commonProps} />
-          );
-        }}
-        keyExtractor={item => item.toString()}
-        horizontal
-        pagingEnabled
-        showsHorizontalScrollIndicator={false}
-        initialScrollIndex={Math.min(initialPage - 1, TOTAL_PAGES - 1)}
-        getItemLayout={(_, index) => ({
-          length: SCREEN_WIDTH,
-          offset: SCREEN_WIDTH * index,
-          index,
-        })}
-        inverted
-        onViewableItemsChanged={onViewableItemsChanged}
-        viewabilityConfig={viewabilityConfig}
-        windowSize={7}
-        maxToRenderPerBatch={3}
-        initialNumToRender={1}
-        decelerationRate="fast"
-      />
+      {/* Content area: horizontal FlatList or vertical continuous view */}
+      {isVertical && viewMode === 'mushaf' ? (
+        <ContinuousMushafView
+          ref={continuousListRef}
+          textColor={theme.colors.text}
+          dividerColor={theme.colors.textSecondary}
+          onTap={toggleImmersive}
+          initialPage={currentPage}
+          onCurrentPageChange={handleContinuousPageChange}
+        />
+      ) : isVertical && viewMode === 'list' ? (
+        <ContinuousListView
+          ref={continuousListRef}
+          textColor={theme.colors.text}
+          labelColor={theme.colors.textSecondary}
+          borderColor={edgeBorderColor}
+          onTap={toggleImmersive}
+          initialPage={currentPage}
+          onCurrentPageChange={handleContinuousPageChange}
+        />
+      ) : (
+        <FlatList
+          ref={flatListRef}
+          data={pages}
+          renderItem={({item}) => {
+            const commonProps = {
+              pageNumber: item,
+              textColor: theme.colors.text,
+              surahLabel: getSurahNamesForPage(item),
+              juzLabel: `Juz ${getJuzForPage(item)}`,
+              pageLabel: String(item),
+              labelColor: theme.colors.textSecondary,
+              borderColor: edgeBorderColor,
+              cardColor: pageBg,
+              bgColor: edgeBg,
+              isBookLayout,
+              onTap: toggleImmersive,
+            };
+            return viewMode === 'list' ? (
+              <ReadingPageView {...commonProps} />
+            ) : (
+              <DKPageView {...commonProps} />
+            );
+          }}
+          keyExtractor={item => item.toString()}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          initialScrollIndex={Math.min(currentPage - 1, TOTAL_PAGES - 1)}
+          getItemLayout={(_, index) => ({
+            length: SCREEN_WIDTH,
+            offset: SCREEN_WIDTH * index,
+            index,
+          })}
+          inverted
+          onViewableItemsChanged={onViewableItemsChanged}
+          viewabilityConfig={viewabilityConfig}
+          windowSize={7}
+          maxToRenderPerBatch={3}
+          initialNumToRender={1}
+          decelerationRate="fast"
+        />
+      )}
 
       {/* ================================================================ */}
       {/* Normal mode header — fades out when immersive                    */}
@@ -687,7 +775,10 @@ export default function MushafViewer({
                 },
               ]}
               pointerEvents={isImmersive ? 'none' : 'auto'}>
-              <MushafPlayerBar currentPage={currentPage} onSearch={openSearchWithFocus} />
+              <MushafPlayerBar
+                currentPage={currentPage}
+                onSearch={openSearchWithFocus}
+              />
             </Animated.View>
           )}
         </>

--- a/components/mushaf/reading/ContinuousListView.tsx
+++ b/components/mushaf/reading/ContinuousListView.tsx
@@ -1,0 +1,374 @@
+import React, {
+  useMemo,
+  useCallback,
+  useRef,
+  useImperativeHandle,
+  forwardRef,
+} from 'react';
+import {View} from 'react-native';
+import {FlashList, type FlashListRef} from '@shopify/flash-list';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {moderateScale, verticalScale} from 'react-native-size-matters';
+import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
+import {useTajweedStore} from '@/store/tajweedStore';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
+import {mushafVerseMapService} from '@/services/mushaf/MushafVerseMapService';
+import {
+  enhancedVersesBySurah,
+  type EnhancedVerse,
+} from '@/utils/enhancedVerseData';
+import {VerseItem} from '@/components/player/v2/PlayerContent/QuranView/VerseItem';
+import SurahDivider from '@/components/player/v2/PlayerContent/QuranView/SurahDivider';
+import BasmalaHeader from '@/components/player/v2/PlayerContent/QuranView/BasmalaHeader';
+import {getTranslationName} from '@/utils/translationLookup';
+import {SCREEN_WIDTH} from '../constants';
+
+const surahData = require('@/data/surahData.json') as Array<{
+  id: number;
+  name: string;
+  bismillah_pre: boolean;
+  verses_count: number;
+}>;
+
+// Item types for the flat list
+type ContinuousListItem =
+  | {type: 'surah_header'; surahNumber: number; showBismillah: boolean}
+  | {type: 'verse'; verse: EnhancedVerse; surahNumber: number};
+
+// Build the flat list once at module scope
+let cachedItems: ContinuousListItem[] | null = null;
+
+function buildContinuousListItems(): ContinuousListItem[] {
+  if (cachedItems) return cachedItems;
+
+  const items: ContinuousListItem[] = [];
+  for (const surah of surahData) {
+    items.push({
+      type: 'surah_header',
+      surahNumber: surah.id,
+      showBismillah: surah.bismillah_pre,
+    });
+
+    const verses = enhancedVersesBySurah[surah.id];
+    if (verses) {
+      for (const verse of verses) {
+        items.push({type: 'verse', verse, surahNumber: surah.id});
+      }
+    }
+  }
+
+  cachedItems = items;
+  return items;
+}
+
+// Precomputed lookup: surahNumber → index in flat list
+let surahIndexMap: Map<number, number> | null = null;
+// Precomputed lookup: verseKey → index in flat list
+let verseIndexMap: Map<string, number> | null = null;
+
+function getSurahIndex(surahNumber: number): number {
+  if (!surahIndexMap) {
+    surahIndexMap = new Map();
+    const items = buildContinuousListItems();
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (
+        item.type === 'surah_header' &&
+        !surahIndexMap.has(item.surahNumber)
+      ) {
+        surahIndexMap.set(item.surahNumber, i);
+      }
+    }
+  }
+  return surahIndexMap.get(surahNumber) ?? 0;
+}
+
+function getVerseIndex(verseKey: string): number {
+  if (!verseIndexMap) {
+    verseIndexMap = new Map();
+    const items = buildContinuousListItems();
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.type === 'verse') {
+        verseIndexMap.set(item.verse.verse_key, i);
+      }
+    }
+  }
+  return verseIndexMap.get(verseKey) ?? 0;
+}
+
+// Reverse lookup: verseKey → page number (built lazily from all 604 pages)
+let verseToPageMap: Map<string, number> | null = null;
+
+function getPageForVerse(verseKey: string): number | null {
+  if (!verseToPageMap) {
+    if (!digitalKhattDataService.initialized) return null;
+    verseToPageMap = new Map();
+    for (let page = 1; page <= 604; page++) {
+      const keys = mushafVerseMapService.getOrderedVerseKeysForPage(page);
+      for (const key of keys) {
+        // First occurrence wins — a verse spanning two pages maps to its start page
+        if (!verseToPageMap.has(key)) {
+          verseToPageMap.set(key, page);
+        }
+      }
+    }
+  }
+  return verseToPageMap.get(verseKey) ?? null;
+}
+
+// Map page number → first verse key on that page for scroll-to-page support
+function getFirstVerseKeyForPage(pageNumber: number): string | null {
+  if (!digitalKhattDataService.initialized) return null;
+  const verseKeys =
+    mushafVerseMapService.getOrderedVerseKeysForPage(pageNumber);
+  return verseKeys.length > 0 ? verseKeys[0] : null;
+}
+
+// Public handle for imperative navigation from MushafViewer
+export interface ContinuousListViewHandle {
+  scrollToPage: (page: number, animated?: boolean) => void;
+  scrollToSurah: (surahId: number, animated?: boolean) => void;
+  scrollToVerse: (verseKey: string, animated?: boolean) => void;
+}
+
+interface ContinuousListViewProps {
+  textColor: string;
+  labelColor: string;
+  borderColor: string;
+  onTap?: () => void;
+  initialPage: number;
+  onCurrentSurahChange?: (surahId: number) => void;
+  onCurrentPageChange?: (page: number) => void;
+}
+
+const ContinuousListView = forwardRef<
+  ContinuousListViewHandle,
+  ContinuousListViewProps
+>(
+  (
+    {
+      textColor,
+      labelColor,
+      borderColor,
+      onTap,
+      initialPage,
+      onCurrentSurahChange,
+      onCurrentPageChange,
+    },
+    ref,
+  ) => {
+    const insets = useSafeAreaInsets();
+    const flashListRef = useRef<FlashListRef<ContinuousListItem>>(null);
+
+    // Expose navigation methods to parent
+    useImperativeHandle(ref, () => ({
+      scrollToPage: (page: number, animated = false) => {
+        const verseKey = getFirstVerseKeyForPage(page);
+        if (verseKey) {
+          const index = getVerseIndex(verseKey);
+          flashListRef.current?.scrollToIndex({index, animated});
+        }
+      },
+      scrollToSurah: (surahId: number, animated = false) => {
+        const index = getSurahIndex(surahId);
+        flashListRef.current?.scrollToIndex({index, animated});
+      },
+      scrollToVerse: (verseKey: string, animated = false) => {
+        const index = getVerseIndex(verseKey);
+        flashListRef.current?.scrollToIndex({index, animated});
+      },
+    }));
+
+    // Settings subscriptions
+    const showTranslation = useMushafSettingsStore(s => s.showTranslation);
+    const showTransliteration = useMushafSettingsStore(
+      s => s.showTransliteration,
+    );
+    const showTajweed = useMushafSettingsStore(s => s.showTajweed);
+    const showWBW = useMushafSettingsStore(s => s.showWBW);
+    const wbwShowTranslation = useMushafSettingsStore(
+      s => s.wbwShowTranslation,
+    );
+    const wbwShowTransliteration = useMushafSettingsStore(
+      s => s.wbwShowTransliteration,
+    );
+    const arabicFontSize = useMushafSettingsStore(s => s.arabicFontSize);
+    const translationFontSize = useMushafSettingsStore(
+      s => s.translationFontSize,
+    );
+    const transliterationFontSize = useMushafSettingsStore(
+      s => s.transliterationFontSize,
+    );
+    const mushafRenderer = useMushafSettingsStore(s => s.mushafRenderer);
+    const selectedTranslationId = useMushafSettingsStore(
+      s => s.selectedTranslationId,
+    );
+    const translationName = getTranslationName(selectedTranslationId);
+
+    const dkFontFamily =
+      mushafRenderer === 'dk_indopak'
+        ? 'DigitalKhattIndoPak'
+        : mushafRenderer === 'dk_v1'
+          ? 'DigitalKhattV1'
+          : 'DigitalKhattV2';
+    const isDK =
+      (mushafRenderer === 'dk_v1' ||
+        mushafRenderer === 'dk_v2' ||
+        mushafRenderer === 'dk_indopak') &&
+      mushafPreloadService.initialized &&
+      digitalKhattDataService.initialized;
+    const fontMgr = isDK ? mushafPreloadService.fontMgr : null;
+    const indexedTajweedData = useTajweedStore(s => s.indexedTajweedData);
+
+    const items = useMemo(() => buildContinuousListItems(), []);
+
+    const contentWidth = SCREEN_WIDTH - moderateScale(24);
+
+    // Load annotations for visible surahs
+    const loadAnnotationsForSurah = useVerseAnnotationsStore(
+      s => s.loadAnnotationsForSurah,
+    );
+
+    const handleVersePress = useCallback(() => {
+      onTap?.();
+    }, [onTap]);
+
+    // Compute initial scroll index from page number
+    const initialScrollIndex = useMemo(() => {
+      const verseKey = getFirstVerseKeyForPage(initialPage);
+      if (verseKey) return getVerseIndex(verseKey);
+      return 0;
+    }, [initialPage]);
+
+    // Track viewable items for surah/page updates
+    const onViewableItemsChanged = useCallback(
+      ({viewableItems}: {viewableItems: Array<{item: ContinuousListItem}>}) => {
+        if (viewableItems.length === 0) return;
+        const firstItem = viewableItems[0].item;
+        if (firstItem.type === 'surah_header') {
+          onCurrentSurahChange?.(firstItem.surahNumber);
+          loadAnnotationsForSurah(firstItem.surahNumber);
+        } else if (firstItem.type === 'verse') {
+          onCurrentSurahChange?.(firstItem.surahNumber);
+          loadAnnotationsForSurah(firstItem.surahNumber);
+          // Report accurate page number from verse-to-page mapping
+          const page = getPageForVerse(firstItem.verse.verse_key);
+          if (page) onCurrentPageChange?.(page);
+        }
+      },
+      [onCurrentSurahChange, onCurrentPageChange, loadAnnotationsForSurah],
+    );
+
+    const renderItem = useCallback(
+      ({item}: {item: ContinuousListItem}) => {
+        if (item.type === 'surah_header') {
+          return (
+            <View>
+              <SurahDivider
+                width={contentWidth}
+                surahNumber={item.surahNumber}
+                textColor={labelColor}
+                nameColor={textColor}
+              />
+              <BasmalaHeader
+                visible={item.showBismillah}
+                width={contentWidth}
+                textColor={textColor}
+                showTajweed={showTajweed}
+                fontMgr={fontMgr}
+                dkFontFamily={dkFontFamily}
+                indexedTajweedData={indexedTajweedData}
+              />
+            </View>
+          );
+        }
+
+        return (
+          <VerseItem
+            verse={item.verse}
+            onVersePress={handleVersePress}
+            textColor={textColor}
+            borderColor={borderColor}
+            showTranslation={showTranslation}
+            showTransliteration={showTransliteration}
+            showTajweed={showTajweed}
+            arabicFontFamily="Uthmani"
+            transliterationFontSize={transliterationFontSize}
+            translationFontSize={translationFontSize}
+            arabicFontSize={arabicFontSize}
+            fontMgr={fontMgr}
+            dkFontFamily={dkFontFamily}
+            indexedTajweedData={indexedTajweedData}
+            source="mushaf"
+            translationName={translationName}
+            translationId={selectedTranslationId}
+            showWBW={showWBW}
+            wbwShowTranslation={wbwShowTranslation}
+            wbwShowTransliteration={wbwShowTransliteration}
+          />
+        );
+      },
+      [
+        contentWidth,
+        textColor,
+        labelColor,
+        borderColor,
+        showTranslation,
+        showTransliteration,
+        showTajweed,
+        arabicFontSize,
+        translationFontSize,
+        transliterationFontSize,
+        fontMgr,
+        dkFontFamily,
+        indexedTajweedData,
+        handleVersePress,
+        translationName,
+        selectedTranslationId,
+        showWBW,
+        wbwShowTranslation,
+        wbwShowTransliteration,
+      ],
+    );
+
+    const getItemType = useCallback(
+      (item: ContinuousListItem) => item.type,
+      [],
+    );
+
+    const keyExtractor = useCallback(
+      (item: ContinuousListItem, _index: number) => {
+        if (item.type === 'surah_header') return `header-${item.surahNumber}`;
+        return item.verse.verse_key;
+      },
+      [],
+    );
+
+    return (
+      <FlashList
+        ref={flashListRef}
+        data={items}
+        renderItem={renderItem}
+        getItemType={getItemType}
+        keyExtractor={keyExtractor}
+        initialScrollIndex={initialScrollIndex}
+        contentContainerStyle={{
+          paddingTop: insets.top + verticalScale(60),
+          paddingBottom: insets.bottom + verticalScale(80),
+          paddingHorizontal: moderateScale(12),
+        }}
+        showsVerticalScrollIndicator={false}
+        onViewableItemsChanged={onViewableItemsChanged}
+        viewabilityConfig={{itemVisiblePercentThreshold: 50}}
+      />
+    );
+  },
+);
+
+export default React.memo(ContinuousListView);
+
+// Re-export navigation helpers for use by MushafViewer
+export {getSurahIndex, getVerseIndex, getFirstVerseKeyForPage};

--- a/components/mushaf/skia/ContinuousMushafView.tsx
+++ b/components/mushaf/skia/ContinuousMushafView.tsx
@@ -1,0 +1,688 @@
+import React, {
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+  useImperativeHandle,
+  forwardRef,
+} from 'react';
+import {View, Platform} from 'react-native';
+import {FlashList, type FlashListRef} from '@shopify/flash-list';
+import {
+  Canvas,
+  Skia,
+  useFonts,
+  type SkFont,
+  type SkParagraph,
+  type SkTypefaceFontProvider,
+} from '@shopify/react-native-skia';
+import {Gesture, GestureDetector} from 'react-native-gesture-handler';
+import {runOnJS} from 'react-native-worklets';
+import * as Haptics from 'expo-haptics';
+import {SheetManager} from 'react-native-actions-sheet';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {verticalScale} from 'react-native-size-matters';
+import Color from 'color';
+import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
+import {useTajweedStore} from '@/store/tajweedStore';
+import {useMushafVerseSelectionStore} from '@/store/mushafVerseSelectionStore';
+import {useMushafPlayerStore} from '@/store/mushafPlayerStore';
+import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
+import {HIGHLIGHT_COLORS} from '@/types/verse-annotations';
+import {useTheme} from '@/hooks/useTheme';
+import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
+import {JustService} from '@/services/mushaf/JustificationService';
+import {mushafLayoutCacheService} from '@/services/mushaf/MushafLayoutCacheService';
+import {
+  quranTextService,
+  PAGE_WIDTH,
+  MARGIN,
+  FONTSIZE,
+} from '@/services/mushaf/QuranTextService';
+import {getLineTajweedMap} from '@/services/mushaf/TajweedMappingService';
+import {mushafVerseMapService} from '@/services/mushaf/MushafVerseMapService';
+import type {IndexedTajweedData} from '@/utils/tajweedLoader';
+import SkiaLine from './SkiaLine';
+import SkiaSurahHeader from './SkiaSurahHeader';
+import {SCREEN_WIDTH, CONTENT_WIDTH, BASE_LINE_HEIGHT} from '../constants';
+
+// Pre-compute rendering constants (derived from screen dimensions, never change)
+const renderScale = CONTENT_WIDTH / PAGE_WIDTH;
+const skiaMargin = MARGIN * renderScale;
+const lineWidth = CONTENT_WIDTH - 2 * skiaMargin;
+const skiaFontSize = FONTSIZE * renderScale * 0.9;
+const fontSizeLineWidthRatio = skiaFontSize / lineWidth;
+const canvasMarginX = (SCREEN_WIDTH - CONTENT_WIDTH) / 2;
+
+const TOTAL_PAGES = 604;
+const pages = Array.from({length: TOTAL_PAGES}, (_, i) => i + 1);
+
+// Reverse lookup: verseKey → page number (built lazily)
+let verseToPageMap: Map<string, number> | null = null;
+
+function getPageForVerse(verseKey: string): number | null {
+  if (!verseToPageMap) {
+    if (!digitalKhattDataService.initialized) return null;
+    verseToPageMap = new Map();
+    for (let page = 1; page <= 604; page++) {
+      const keys = mushafVerseMapService.getOrderedVerseKeysForPage(page);
+      for (const key of keys) {
+        if (!verseToPageMap.has(key)) {
+          verseToPageMap.set(key, page);
+        }
+      }
+    }
+  }
+  return verseToPageMap.get(verseKey) ?? null;
+}
+
+interface ParagraphInfo {
+  paragraph: SkParagraph;
+  xPos: number;
+}
+
+// Public handle (same interface as ContinuousListView)
+export interface ContinuousMushafViewHandle {
+  scrollToPage: (page: number, animated?: boolean) => void;
+  scrollToSurah: (surahId: number, animated?: boolean) => void;
+  scrollToVerse: (verseKey: string, animated?: boolean) => void;
+}
+
+interface ContinuousMushafViewProps {
+  textColor: string;
+  dividerColor: string;
+  onTap?: () => void;
+  initialPage: number;
+  onCurrentPageChange?: (page: number) => void;
+}
+
+// ── Per-page content with gestures + highlights ──────────
+
+interface MushafPageContentProps {
+  pageNumber: number;
+  fontMgr: SkTypefaceFontProvider;
+  textColor: string;
+  dividerColor: string;
+  showTajweed: boolean;
+  indexedTajweedData: IndexedTajweedData | null;
+  fontFamily: string;
+  dividerFont: SkFont | null;
+  nameFontSize: number;
+  onTap?: () => void;
+}
+
+const EMPTY_BG_MAP = new Map<
+  number,
+  Array<{start: number; end: number; color: string}>
+>();
+
+const MushafPageContent: React.FC<MushafPageContentProps> = React.memo(
+  ({
+    pageNumber,
+    fontMgr,
+    textColor,
+    dividerColor,
+    showTajweed,
+    indexedTajweedData,
+    fontFamily,
+    dividerFont,
+    nameFontSize,
+    onTap,
+  }) => {
+    const {isDarkMode} = useTheme();
+
+    // ── Page data ──────────────────────────────────────────
+    const pageLines = useMemo(
+      () => digitalKhattDataService.getPageLines(pageNumber),
+      [pageNumber],
+    );
+
+    const justResults = useMemo(() => {
+      const cached = JustService.getCachedPageLayout(
+        fontSizeLineWidthRatio,
+        pageNumber,
+        fontFamily,
+      );
+      if (cached) return cached;
+      const result = JustService.getPageLayout(
+        pageNumber,
+        fontSizeLineWidthRatio,
+        fontMgr,
+        fontFamily,
+      );
+      if (result.length > 0) {
+        mushafLayoutCacheService.setPageLayout(pageNumber, fontFamily, result);
+      }
+      return result;
+    }, [pageNumber, fontMgr, fontFamily]);
+
+    const lineTajweedMaps = useMemo(() => {
+      if (!showTajweed || !indexedTajweedData) return null;
+      return pageLines.map((_, i) =>
+        getLineTajweedMap(pageNumber, i, indexedTajweedData),
+      );
+    }, [showTajweed, indexedTajweedData, pageNumber, pageLines]);
+
+    const canvasHeight = pageLines.length * BASE_LINE_HEIGHT;
+
+    // ── Paragraph refs for hit testing ─────────────────────
+    const paragraphMapRef = useRef<Map<number, ParagraphInfo>>(new Map());
+
+    useEffect(() => {
+      paragraphMapRef.current.clear();
+    }, [pageNumber]);
+
+    const handleParagraphReady = useCallback(
+      (lineIndex: number, paragraph: SkParagraph, xPos: number) => {
+        paragraphMapRef.current.set(lineIndex, {paragraph, xPos});
+      },
+      [],
+    );
+
+    // ── Verse selection store ──────────────────────────────
+    const selectedVerseKeys = useMushafVerseSelectionStore(
+      s => s.selectedVerseKeys,
+    );
+    const selectedPageNumber = useMushafVerseSelectionStore(
+      s => s.selectedPageNumber,
+    );
+    const selectVerse = useMushafVerseSelectionStore(s => s.selectVerse);
+    const selectVerseRange = useMushafVerseSelectionStore(
+      s => s.selectVerseRange,
+    );
+
+    // ── Playback + annotation highlights ───────────────────
+    const persistentHighlights = useVerseAnnotationsStore(s => s.highlights);
+    const playbackVerseKey = useMushafPlayerStore(s => {
+      if (!s.currentVerseKey || s.playbackState === 'idle') return null;
+      return s.currentVerseKey;
+    });
+
+    // ── Hit testing ────────────────────────────────────────
+    const orderedVerseKeys = useMemo(
+      () => mushafVerseMapService.getOrderedVerseKeysForPage(pageNumber),
+      [pageNumber],
+    );
+
+    const hitTestVerse = useCallback(
+      (eventX: number, eventY: number) => {
+        const canvasX = eventX - canvasMarginX;
+        const canvasY = eventY;
+
+        if (
+          canvasX < 0 ||
+          canvasX > CONTENT_WIDTH ||
+          canvasY < 0 ||
+          canvasY > canvasHeight
+        ) {
+          return null;
+        }
+
+        const lineIndex = Math.floor(canvasY / BASE_LINE_HEIGHT);
+        if (lineIndex < 0 || lineIndex >= pageLines.length) return null;
+
+        const line = pageLines[lineIndex];
+        if (!line || line.line_type === 'surah_name') return null;
+
+        const paragraphInfo = paragraphMapRef.current.get(lineIndex);
+        if (!paragraphInfo) return null;
+
+        const paragraphX = canvasX - paragraphInfo.xPos;
+        const paragraphY = canvasY - lineIndex * BASE_LINE_HEIGHT;
+
+        const charIndex = paragraphInfo.paragraph.getGlyphPositionAtCoordinate(
+          paragraphX,
+          paragraphY,
+        );
+
+        return mushafVerseMapService.findVerseAtCharIndex(
+          pageNumber,
+          lineIndex,
+          charIndex,
+        );
+      },
+      [pageNumber, pageLines, canvasHeight],
+    );
+
+    // ── Drag gesture handlers ──────────────────────────────
+    const dragStartVerseKeyRef = useRef<string | null>(null);
+    const dragCurrentVerseKeyRef = useRef<string | null>(null);
+    const orderedVerseKeysRef = useRef<string[]>(orderedVerseKeys);
+    orderedVerseKeysRef.current = orderedVerseKeys;
+
+    const handleDragStart = useCallback(
+      (eventX: number, eventY: number) => {
+        const segment = hitTestVerse(eventX, eventY);
+        if (!segment) {
+          dragStartVerseKeyRef.current = null;
+          return;
+        }
+        dragStartVerseKeyRef.current = segment.verseKey;
+        dragCurrentVerseKeyRef.current = segment.verseKey;
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+        selectVerse(segment.verseKey, pageNumber);
+      },
+      [hitTestVerse, selectVerse, pageNumber],
+    );
+
+    const handleDragUpdate = useCallback(
+      (eventX: number, eventY: number) => {
+        if (Platform.OS === 'android') return;
+        const startKey = dragStartVerseKeyRef.current;
+        if (!startKey) return;
+
+        const segment = hitTestVerse(eventX, eventY);
+        if (!segment) return;
+
+        const currentKey = segment.verseKey;
+        if (currentKey === dragCurrentVerseKeyRef.current) return;
+
+        const ordered = orderedVerseKeysRef.current;
+        const startIdx = ordered.indexOf(startKey);
+        const currentIdx = ordered.indexOf(currentKey);
+        if (startIdx === -1 || currentIdx === -1) return;
+
+        if (currentIdx < startIdx) {
+          if (dragCurrentVerseKeyRef.current !== startKey) {
+            dragCurrentVerseKeyRef.current = startKey;
+            selectVerse(startKey, pageNumber);
+          }
+          return;
+        }
+
+        dragCurrentVerseKeyRef.current = currentKey;
+        const range = ordered.slice(startIdx, currentIdx + 1);
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+
+        if (range.length === 1) {
+          selectVerse(range[0], pageNumber);
+        } else {
+          selectVerseRange(range, pageNumber);
+        }
+      },
+      [hitTestVerse, selectVerse, selectVerseRange, pageNumber],
+    );
+
+    const handleDragEnd = useCallback(() => {
+      const startKey = dragStartVerseKeyRef.current;
+      if (!startKey) return;
+
+      const store = useMushafVerseSelectionStore.getState();
+      const keys = store.selectedVerseKeys;
+      if (keys.length === 0) return;
+
+      const firstKey = keys[0];
+      const [surahStr, ayahStr] = firstKey.split(':');
+      const surahNumber = parseInt(surahStr, 10);
+      const ayahNumber = parseInt(ayahStr, 10);
+
+      SheetManager.show('verse-actions', {
+        payload: {
+          verseKey: firstKey,
+          surahNumber,
+          ayahNumber,
+          verseKeys: keys.length > 1 ? keys : undefined,
+          source: 'mushaf',
+        },
+      });
+
+      dragStartVerseKeyRef.current = null;
+      dragCurrentVerseKeyRef.current = null;
+    }, []);
+
+    // ── Gestures ───────────────────────────────────────────
+    const longPressDragGesture = useMemo(
+      () =>
+        Platform.OS === 'android'
+          ? Gesture.LongPress()
+              .minDuration(400)
+              .maxDistance(20)
+              .onStart(event => {
+                'worklet';
+                runOnJS(handleDragStart)(event.x, event.y);
+              })
+              .onEnd(() => {
+                'worklet';
+                runOnJS(handleDragEnd)();
+              })
+          : Gesture.Pan()
+              .activateAfterLongPress(400)
+              .minDistance(0)
+              .onStart(event => {
+                'worklet';
+                runOnJS(handleDragStart)(event.x, event.y);
+              })
+              .onUpdate(event => {
+                'worklet';
+                runOnJS(handleDragUpdate)(event.x, event.y);
+              })
+              .onEnd(() => {
+                'worklet';
+                runOnJS(handleDragEnd)();
+              }),
+      [handleDragStart, handleDragUpdate, handleDragEnd],
+    );
+
+    const tapGesture = useMemo(
+      () =>
+        Gesture.Tap().onEnd(() => {
+          'worklet';
+          if (onTap) runOnJS(onTap)();
+        }),
+      [onTap],
+    );
+
+    const composedGesture = useMemo(
+      () => Gesture.Exclusive(longPressDragGesture, tapGesture),
+      [longPressDragGesture, tapGesture],
+    );
+
+    // ── Background highlights ──────────────────────────────
+    const playbackBgColor = useMemo(
+      () =>
+        Color(textColor)
+          .alpha(isDarkMode ? 0.1 : 0.12)
+          .toString(),
+      [textColor, isDarkMode],
+    );
+
+    const selectionBgColor = useMemo(
+      () =>
+        Color(textColor)
+          .alpha(isDarkMode ? 0.15 : 0.18)
+          .toString(),
+      [textColor, isDarkMode],
+    );
+
+    const lineBackgroundHighlightsMap = useMemo<
+      Map<number, Array<{start: number; end: number; color: string}>>
+    >(() => {
+      const hasAnnotations = Object.keys(persistentHighlights).length > 0;
+      const hasPlayback = !!playbackVerseKey;
+      const selectedSet =
+        selectedVerseKeys.length > 0 && selectedPageNumber === pageNumber
+          ? new Set(selectedVerseKeys)
+          : null;
+
+      if (!hasAnnotations && !hasPlayback && !selectedSet) return EMPTY_BG_MAP;
+
+      const map = new Map<
+        number,
+        Array<{start: number; end: number; color: string}>
+      >();
+
+      const addVerseHighlight = (vk: string, color: string) => {
+        const verseLines = mushafVerseMapService.getVerseSegmentsForPage(
+          pageNumber,
+          vk,
+        );
+        for (const {lineIndex, segment} of verseLines) {
+          let arr = map.get(lineIndex);
+          if (!arr) {
+            arr = [];
+            map.set(lineIndex, arr);
+          }
+          arr.push({
+            start: segment.startCharIndex,
+            end: segment.endCharIndex,
+            color,
+          });
+        }
+      };
+
+      // Layer 1: Persistent annotation highlights (lowest priority)
+      for (const [verseKey, colorName] of Object.entries(
+        persistentHighlights,
+      )) {
+        if (selectedSet?.has(verseKey)) continue;
+        if (playbackVerseKey === verseKey) continue;
+        const color = HIGHLIGHT_COLORS[colorName];
+        if (!color) continue;
+        addVerseHighlight(verseKey, color);
+      }
+
+      // Layer 2: Playback highlight (skip if selected)
+      if (playbackVerseKey && !selectedSet?.has(playbackVerseKey)) {
+        addVerseHighlight(playbackVerseKey, playbackBgColor);
+      }
+
+      // Layer 3: Selection highlight (highest priority)
+      if (selectedSet) {
+        for (const vk of selectedVerseKeys) {
+          addVerseHighlight(vk, selectionBgColor);
+        }
+      }
+
+      return map;
+    }, [
+      persistentHighlights,
+      playbackVerseKey,
+      playbackBgColor,
+      selectedVerseKeys,
+      selectedPageNumber,
+      pageNumber,
+      selectionBgColor,
+    ]);
+
+    // ── Render ─────────────────────────────────────────────
+    const content = (
+      <View style={{width: SCREEN_WIDTH, height: canvasHeight}}>
+        <Canvas
+          style={{
+            width: CONTENT_WIDTH,
+            height: canvasHeight,
+            marginHorizontal: canvasMarginX,
+          }}>
+          {pageLines.map((line, lineIndex) => {
+            const yPos = lineIndex * BASE_LINE_HEIGHT;
+
+            if (line.line_type === 'surah_name') {
+              if (!dividerFont) return null;
+              return (
+                <SkiaSurahHeader
+                  key={`header-${pageNumber}-${lineIndex}`}
+                  dividerFont={dividerFont}
+                  fontMgr={fontMgr}
+                  nameFontSize={nameFontSize}
+                  surahNumber={line.surah_number}
+                  yPos={yPos}
+                  pageWidth={lineWidth}
+                  xOffset={skiaMargin}
+                  dividerColor={dividerColor}
+                  nameColor={textColor}
+                  lineHeight={BASE_LINE_HEIGHT}
+                />
+              );
+            }
+
+            if (!justResults[lineIndex]) return null;
+
+            const lineInfo = quranTextService.getLineInfo(
+              pageNumber,
+              lineIndex,
+            );
+            let lineMargin = skiaMargin;
+            if (lineInfo.lineWidthRatio !== 1) {
+              const newLineWidth = lineWidth * lineInfo.lineWidthRatio;
+              lineMargin += (lineWidth - newLineWidth) / 2;
+            }
+
+            return (
+              <SkiaLine
+                key={`${pageNumber}-${lineIndex}`}
+                pageNumber={pageNumber}
+                lineIndex={lineIndex}
+                fontMgr={fontMgr}
+                justResult={justResults[lineIndex]}
+                pageWidth={CONTENT_WIDTH}
+                fontSize={skiaFontSize}
+                margin={lineMargin}
+                yPos={yPos}
+                textColor={textColor}
+                charToRule={lineTajweedMaps?.[lineIndex] ?? undefined}
+                fontFamily={fontFamily}
+                lineHeight={BASE_LINE_HEIGHT}
+                onParagraphReady={handleParagraphReady}
+                backgroundHighlights={lineBackgroundHighlightsMap.get(
+                  lineIndex,
+                )}
+              />
+            );
+          })}
+        </Canvas>
+      </View>
+    );
+
+    return (
+      <GestureDetector gesture={composedGesture}>{content}</GestureDetector>
+    );
+  },
+);
+
+// ── Main component ───────────────────────────────────────
+
+const ContinuousMushafView = forwardRef<
+  ContinuousMushafViewHandle,
+  ContinuousMushafViewProps
+>(({textColor, dividerColor, onTap, initialPage, onCurrentPageChange}, ref) => {
+  const insets = useSafeAreaInsets();
+  const flashListRef = useRef<FlashListRef<number>>(null);
+
+  // Font loading (fallback — prefer preloaded fontMgr)
+  const hookFontMgr = useFonts({
+    DigitalKhattV1: [require('@/data/mushaf/legacy/DigitalKhattQuranicV1.otf')],
+    DigitalKhattV2: [
+      require('@/data/mushaf/digitalkhatt/DigitalKhattFont.otf'),
+    ],
+    DigitalKhattIndoPak: [
+      require('@/data/mushaf/indopak/DigitalKhattIndoPak.otf'),
+    ],
+    QuranCommon: [require('@/data/mushaf/quran-common.ttf')],
+    SurahNameV4: [require('@/data/mushaf/surah-name-v4.ttf')],
+  });
+  const fontMgr = mushafPreloadService.fontMgr || hookFontMgr;
+
+  // Surah header fonts (computed once from quranCommon typeface)
+  const surahHeaderFonts = useMemo(() => {
+    const qcTypeface = mushafPreloadService.quranCommonTypeface;
+    if (!qcTypeface) return {dividerFont: null, nameFontSize: 0};
+    const refFont = Skia.Font(qcTypeface, 100);
+    const ids = refFont.getGlyphIDs('\uE000');
+    const widths = refFont.getGlyphWidths(ids);
+    const measuredW = widths[0] || 1;
+    const scaledSize = (lineWidth / measuredW) * 100;
+    return {
+      dividerFont: Skia.Font(qcTypeface, scaledSize),
+      nameFontSize: scaledSize * 0.4,
+    };
+  }, []);
+
+  // Settings subscriptions
+  const showTajweed = useMushafSettingsStore(s => s.showTajweed);
+  const mushafRenderer = useMushafSettingsStore(s => s.mushafRenderer);
+  const indexedTajweedData = useTajweedStore(s => s.indexedTajweedData);
+
+  const fontFamily =
+    mushafRenderer === 'dk_indopak'
+      ? 'DigitalKhattIndoPak'
+      : mushafRenderer === 'dk_v1'
+        ? 'DigitalKhattV1'
+        : 'DigitalKhattV2';
+
+  // Navigation
+  const surahStartPages = digitalKhattDataService.initialized
+    ? digitalKhattDataService.getSurahStartPages()
+    : {};
+
+  useImperativeHandle(ref, () => ({
+    scrollToPage: (page: number, animated = false) => {
+      flashListRef.current?.scrollToIndex({index: page - 1, animated});
+    },
+    scrollToSurah: (surahId: number, animated = false) => {
+      const targetPage = surahStartPages[surahId];
+      if (targetPage) {
+        flashListRef.current?.scrollToIndex({
+          index: targetPage - 1,
+          animated,
+        });
+      }
+    },
+    scrollToVerse: (verseKey: string, animated = false) => {
+      const page = getPageForVerse(verseKey);
+      if (page) {
+        flashListRef.current?.scrollToIndex({index: page - 1, animated});
+      }
+    },
+  }));
+
+  // Load annotations for visible surahs
+  const loadAnnotationsForSurah = useVerseAnnotationsStore(
+    s => s.loadAnnotationsForSurah,
+  );
+  const pageToSurah = digitalKhattDataService.initialized
+    ? digitalKhattDataService.getPageToSurah()
+    : {};
+
+  const onViewableItemsChanged = useCallback(
+    ({viewableItems}: {viewableItems: Array<{item: number}>}) => {
+      if (viewableItems.length === 0) return;
+      const page = viewableItems[0].item;
+      onCurrentPageChange?.(page);
+      const surahId = pageToSurah[page];
+      if (surahId) loadAnnotationsForSurah(surahId);
+    },
+    [onCurrentPageChange, pageToSurah, loadAnnotationsForSurah],
+  );
+
+  const renderItem = useCallback(
+    ({item}: {item: number}) => {
+      if (!fontMgr) return null;
+      return (
+        <MushafPageContent
+          pageNumber={item}
+          fontMgr={fontMgr}
+          textColor={textColor}
+          dividerColor={dividerColor}
+          showTajweed={showTajweed}
+          indexedTajweedData={indexedTajweedData}
+          fontFamily={fontFamily}
+          dividerFont={surahHeaderFonts.dividerFont}
+          nameFontSize={surahHeaderFonts.nameFontSize}
+          onTap={onTap}
+        />
+      );
+    },
+    [
+      fontMgr,
+      textColor,
+      dividerColor,
+      showTajweed,
+      indexedTajweedData,
+      fontFamily,
+      surahHeaderFonts,
+      onTap,
+    ],
+  );
+
+  const keyExtractor = useCallback((item: number) => `page-${item}`, []);
+
+  return (
+    <FlashList
+      ref={flashListRef}
+      data={pages}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      initialScrollIndex={initialPage - 1}
+      contentContainerStyle={{
+        paddingTop: insets.top + verticalScale(60),
+        paddingBottom: insets.bottom + verticalScale(80),
+      }}
+      showsVerticalScrollIndicator={false}
+      onViewableItemsChanged={onViewableItemsChanged}
+      viewabilityConfig={{itemVisiblePercentThreshold: 50}}
+    />
+  );
+});
+
+export default React.memo(ContinuousMushafView);

--- a/store/mushafSettingsStore.ts
+++ b/store/mushafSettingsStore.ts
@@ -22,7 +22,8 @@ export const getDisplayValue = (actualFontSize: number): number => {
 
 export type MushafRenderer = 'dk_v1' | 'dk_v2' | 'dk_indopak';
 export type MushafPageLayout = 'fullscreen' | 'book';
-export type MushafViewMode = 'mushaf' | 'reading';
+export type MushafViewMode = 'mushaf' | 'list';
+export type MushafScrollDirection = 'horizontal' | 'vertical';
 
 export interface RecentRead {
   surahId: number;
@@ -56,8 +57,11 @@ interface MushafSettingsState {
   // Mushaf renderer selection
   mushafRenderer: MushafRenderer;
 
-  // View mode (mushaf pages vs reading view)
+  // View mode (mushaf pages vs list view)
   viewMode: MushafViewMode;
+
+  // Scroll direction (horizontal paging vs vertical continuous scroll)
+  scrollDirection: MushafScrollDirection;
 
   // Recently read positions (last 10, chain-based — not deduplicated by surahId)
   recentPages: RecentRead[];
@@ -80,6 +84,7 @@ interface MushafSettingsState {
   setMushafRenderer: (renderer: MushafRenderer) => void;
   setPageLayout: (layout: MushafPageLayout) => void;
   setViewMode: (mode: MushafViewMode) => void;
+  setScrollDirection: (direction: MushafScrollDirection) => void;
   updateActiveChain: (surahId: number, page: number) => void;
   startNewChain: (surahId: number, page: number) => void;
   resumeChain: (index: number) => void;
@@ -104,6 +109,7 @@ export const useMushafSettingsStore = create<MushafSettingsState>()(
       uthmaniFont: 'v1', // Default to V1
       mushafRenderer: 'dk_v1' as MushafRenderer, // Default to DK V1 (Madani 1405)
       viewMode: 'mushaf' as MushafViewMode,
+      scrollDirection: 'horizontal' as MushafScrollDirection,
       pageLayout: 'book' as MushafPageLayout, // Default to book page view
       recentPages: [],
       selectedTranslationId: 'saheeh',
@@ -134,11 +140,13 @@ export const useMushafSettingsStore = create<MushafSettingsState>()(
             renderer === 'dk_v1'
               ? 'v1'
               : renderer === 'dk_indopak'
-              ? 'v2'
-              : 'v2',
+                ? 'v2'
+                : 'v2',
         }),
       setPageLayout: (layout: MushafPageLayout) => set({pageLayout: layout}),
       setViewMode: (mode: MushafViewMode) => set({viewMode: mode}),
+      setScrollDirection: (direction: MushafScrollDirection) =>
+        set({scrollDirection: direction}),
       updateActiveChain: (surahId: number, page: number) =>
         set(state => {
           const updated = [...state.recentPages];
@@ -171,7 +179,7 @@ export const useMushafSettingsStore = create<MushafSettingsState>()(
     {
       name: 'mushaf-settings',
       storage: createJSONStorage(() => AsyncStorage),
-      version: 8,
+      version: 9,
       migrate: (persistedState: unknown, version: number) => {
         const state = persistedState as Record<string, unknown>;
         if (version === 0) {
@@ -213,6 +221,13 @@ export const useMushafSettingsStore = create<MushafSettingsState>()(
           state.showWBW = false;
           state.wbwShowTranslation = true;
           state.wbwShowTransliteration = false;
+        }
+        if (version < 9) {
+          // Migrate viewMode: 'reading' → 'list', add scrollDirection
+          if (state.viewMode === 'reading') {
+            state.viewMode = 'list';
+          }
+          state.scrollDirection = 'horizontal';
         }
         return state as unknown as MushafSettingsState;
       },


### PR DESCRIPTION
## Summary
- Add **View Type** (Mushaf/List) × **Scroll Direction** (Horizontal/Vertical) settings creating a 2×2 matrix of reading modes
- New **ContinuousMushafView** — Skia Canvas per page rendered in a FlashList for vertical mushaf scrolling with full gesture support (tap, long-press verse selection, drag-to-select)
- New **ContinuousListView** — FlashList of VerseItems with surah dividers for vertical list scrolling
- 3-layer highlight system (annotations → playback → selection) ported to vertical modes
- Position preservation when switching between view modes
- Redesigned settings icons: mushaf icon shows last-page-style layout with surah dividers, distinct horizontal/vertical scroll icons, custom list view icon

## Test plan
- [ ] Toggle between all 4 view mode combinations and verify correct rendering
- [ ] Verify verse tap toggles immersive mode in all modes
- [ ] Verify long-press verse selection and drag-to-select in mushaf vertical
- [ ] Verify playback highlights track correctly in vertical modes
- [ ] Verify position is preserved when switching between modes
- [ ] Verify settings icons render correctly in both light and dark mode
- [ ] Verify scroll-to-page, scroll-to-surah, scroll-to-verse navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)