### PR TITLE
fix: mushaf list view 'Play from Here' using wrong player

### DIFF
--- a/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
+++ b/components/player/v2/PlayerContent/QuranView/VerseItem.tsx
@@ -222,10 +222,10 @@ export const VerseItem = memo<VerseItemProps>(
           arabicText: verse.text,
           translation: verse.translation || '',
           transliteration: verse.transliteration || '',
-          source: 'player',
+          source: source ?? 'player',
         },
       });
-    }, [verseKey, verse, selectVerse]);
+    }, [verseKey, verse, selectVerse, source]);
 
     // Options button → same as long press
     const handleOptionsPress = useCallback(() => {
@@ -238,10 +238,10 @@ export const VerseItem = memo<VerseItemProps>(
           arabicText: verse.text,
           translation: verse.translation || '',
           transliteration: verse.transliteration || '',
-          source: 'player',
+          source: source ?? 'player',
         },
       });
-    }, [verseKey, verse, selectVerse]);
+    }, [verseKey, verse, selectVerse, source]);
 
     const handleWordPress = useCallback(
       (position: number) => {


### PR DESCRIPTION
## Summary
- **VerseItem** hardcoded `source: 'player'` when opening the verse-actions sheet, ignoring its `source` prop
- This caused "Play from Here" in the mushaf list view to seek within the main player instead of initiating mushaf-specific playback via `mushafPlayerStore`
- Now uses `source ?? 'player'` so mushaf contexts correctly route through `handlePlaySelection` → `startPlaybackForSelection`

## Test plan
- [ ] Open mushaf list view, long-press a verse, tap "Play from Here" — should start mushaf player (not seek in main player)
- [ ] Open main player's verse list, long-press a verse, tap "Play from Here" — should still seek within main player as before
- [ ] Repeat both for "Repeat" action

🤖 Generated with [Claude Code](https://claude.com/claude-code)