### PR TITLE
feat: redesign player with floating glass UI

### DIFF
--- a/components/player/v2/PlayerContent/ControlButtons/index.tsx
+++ b/components/player/v2/PlayerContent/ControlButtons/index.tsx
@@ -7,6 +7,7 @@ import {
   ViewStyle,
   TextStyle,
 } from 'react-native';
+import {GlassView} from 'expo-glass-effect';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {usePlayerActions} from '@/hooks/usePlayerActions';
@@ -37,6 +38,8 @@ interface ControlButtonsProps {
 interface Styles {
   wrapper: ViewStyle;
   button: ViewStyle;
+  glassButton: ViewStyle;
+  glassButtonInner: ViewStyle;
   speedButtonText: TextStyle;
 }
 
@@ -78,19 +81,26 @@ export const ControlButtons: React.FC<ControlButtonsProps> = ({
     settings.sleepTimerEnd !== null && settings.sleepTimerEnd > Date.now();
 
   const activeBackgroundColor = Color(theme.colors.text).alpha(0.08).toString();
-  const defaultIconColor = Color(theme.colors.text).alpha(0.7).toString();
+  const defaultIconColor = theme.colors.text;
   const activeIconColor = theme.colors.text;
 
   return (
     <View style={styles.wrapper}>
       {onMushafLayoutPress && (
-        <Pressable onPress={handleMushafLayoutPress} style={styles.button}>
-          <Ionicons
-            name="options-outline"
-            size={moderateScale(20)}
-            color={defaultIconColor}
-          />
-        </Pressable>
+        <GlassView
+          style={styles.glassButton}
+          glassEffectStyle="regular"
+          isInteractive>
+          <Pressable
+            onPress={handleMushafLayoutPress}
+            style={styles.glassButtonInner}>
+            <Ionicons
+              name="options-outline"
+              size={moderateScale(20)}
+              color={defaultIconColor}
+            />
+          </Pressable>
+        </GlassView>
       )}
 
       <Pressable
@@ -177,17 +187,17 @@ export const ControlButtons: React.FC<ControlButtonsProps> = ({
         />
       </Pressable>
 
-      <Pressable
-        onPress={onQueuePress}
-        style={[
-          styles.button,
-          showQueue && {backgroundColor: activeBackgroundColor},
-        ]}>
-        <QueueIcon
-          size={moderateScale(20)}
-          color={showQueue ? activeIconColor : defaultIconColor}
-        />
-      </Pressable>
+      <GlassView
+        style={styles.glassButton}
+        glassEffectStyle="regular"
+        isInteractive>
+        <Pressable onPress={onQueuePress} style={styles.glassButtonInner}>
+          <QueueIcon
+            size={moderateScale(20)}
+            color={showQueue ? activeIconColor : defaultIconColor}
+          />
+        </Pressable>
+      </GlassView>
     </View>
   );
 };
@@ -198,14 +208,23 @@ const styles = StyleSheet.create<Styles>({
     justifyContent: 'space-evenly',
     alignItems: 'center',
     paddingVertical: moderateScale(10),
-    paddingHorizontal: moderateScale(16),
     width: '100%',
   },
   button: {
-    width: moderateScale(38),
-    height: moderateScale(38),
-    borderRadius: moderateScale(12),
+    width: moderateScale(44),
+    height: moderateScale(44),
+    borderRadius: moderateScale(14),
     backgroundColor: 'transparent',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  glassButton: {
+    width: moderateScale(44),
+    height: moderateScale(44),
+    borderRadius: moderateScale(22),
+  },
+  glassButtonInner: {
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/components/player/v2/PlayerContent/Header.tsx
+++ b/components/player/v2/PlayerContent/Header.tsx
@@ -1,7 +1,8 @@
 import React, {useMemo} from 'react';
 import {View, Text, Pressable, StyleSheet} from 'react-native';
+import {GlassView} from 'expo-glass-effect';
 import {moderateScale} from 'react-native-size-matters';
-import {Entypo, Feather} from '@expo/vector-icons';
+import {SymbolView} from 'expo-symbols';
 import {
   Canvas,
   Paragraph,
@@ -112,23 +113,35 @@ export const Header: React.FC<HeaderProps> = ({onOptionsPress}) => {
 
   return (
     <View style={styles.header}>
-      <Pressable style={styles.closeButton} onPress={handleClose}>
-        <Entypo
-          name="chevron-thin-down"
-          size={moderateScale(22)}
-          color={theme.colors.text}
-        />
-      </Pressable>
+      <GlassView
+        style={styles.closeButton}
+        glassEffectStyle="regular"
+        isInteractive>
+        <Pressable style={styles.glassButtonInner} onPress={handleClose}>
+          <SymbolView
+            name="xmark"
+            size={moderateScale(18)}
+            tintColor={theme.colors.text}
+            weight="medium"
+          />
+        </Pressable>
+      </GlassView>
 
       {renderSurahName()}
 
-      <Pressable style={styles.optionsButton} onPress={onOptionsPress}>
-        <Feather
-          name="more-horizontal"
-          size={moderateScale(22)}
-          color={theme.colors.text}
-        />
-      </Pressable>
+      <GlassView
+        style={styles.optionsButton}
+        glassEffectStyle="regular"
+        isInteractive>
+        <Pressable style={styles.glassButtonInner} onPress={onOptionsPress}>
+          <SymbolView
+            name="ellipsis"
+            size={moderateScale(18)}
+            tintColor={theme.colors.text}
+            weight="medium"
+          />
+        </Pressable>
+      </GlassView>
     </View>
   );
 };
@@ -138,27 +151,28 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    paddingVertical: moderateScale(10),
+    paddingVertical: moderateScale(4),
     paddingHorizontal: moderateScale(16),
     width: '100%',
   },
   closeButton: {
     position: 'absolute',
-    left: moderateScale(15),
+    left: moderateScale(10),
     zIndex: 1,
-    padding: moderateScale(10),
     width: moderateScale(44),
     height: moderateScale(44),
-    justifyContent: 'center',
-    alignItems: 'center',
+    borderRadius: moderateScale(22),
   },
   optionsButton: {
     position: 'absolute',
-    right: moderateScale(15),
+    right: moderateScale(10),
     zIndex: 1,
-    padding: moderateScale(10),
     width: moderateScale(44),
     height: moderateScale(44),
+    borderRadius: moderateScale(22),
+  },
+  glassButtonInner: {
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/components/player/v2/PlayerContent/TrackInfo.tsx
+++ b/components/player/v2/PlayerContent/TrackInfo.tsx
@@ -1,5 +1,7 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
+import {GlassView} from 'expo-glass-effect';
+import {SymbolView} from 'expo-symbols';
 import {Pressable} from 'react-native-gesture-handler';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
@@ -10,12 +12,7 @@ import {ReciterImage} from '@/components/ReciterImage';
 import {getReciterById} from '@/services/dataService';
 import {Reciter, Rewayat} from '@/data/reciterData';
 import {useLoved} from '@/hooks/useLoved';
-import {HeartIcon, MicrophoneIcon} from '@/components/Icons';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from 'react-native-reanimated';
+import {MicrophoneIcon} from '@/components/Icons';
 
 export const TrackInfo = () => {
   const {theme} = useTheme();
@@ -26,7 +23,6 @@ export const TrackInfo = () => {
   const [, setReciter] = useState<Reciter | null>(null);
   const [rewayat, setRewayat] = useState<Rewayat | null>(null);
   const {isTrackLoved, toggleTrackLoved} = useLoved();
-  const scale = useSharedValue(1);
 
   useEffect(() => {
     setRewayat(null);
@@ -78,20 +74,11 @@ export const TrackInfo = () => {
 
   const handleToggleLoved = useCallback(() => {
     if (currentTrack) {
-      // Animate the heart
-      scale.value = withSpring(1.2, {}, () => {
-        scale.value = withSpring(1);
-      });
-
       toggleTrackLoved(currentTrack);
     }
-  }, [currentTrack, scale, toggleTrackLoved]);
+  }, [currentTrack, toggleTrackLoved]);
 
   const isLoved = currentTrack ? isTrackLoved(currentTrack) : false;
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: scale.value}],
-  }));
 
   return (
     <View style={styles.container}>
@@ -145,20 +132,24 @@ export const TrackInfo = () => {
           </View>
         </Pressable>
 
-        <Pressable
-          style={({pressed}) => [
-            styles.loveButton,
-            {opacity: pressed ? 0.7 : 1},
-          ]}
-          onPress={handleToggleLoved}>
-          <Animated.View style={animatedStyle}>
-            <HeartIcon
-              size={moderateScale(32)}
-              color={isLoved ? 'red' : theme.colors.text}
-              filled={isLoved}
+        <GlassView
+          style={styles.loveButton}
+          glassEffectStyle="regular"
+          isInteractive>
+          <Pressable
+            style={({pressed}) => [
+              styles.loveButtonInner,
+              {opacity: pressed ? 0.7 : 1},
+            ]}
+            onPress={handleToggleLoved}>
+            <SymbolView
+              name={isLoved ? 'heart.fill' : 'heart'}
+              size={moderateScale(22)}
+              tintColor={isLoved ? 'red' : theme.colors.text}
+              weight="medium"
             />
-          </Animated.View>
-        </Pressable>
+          </Pressable>
+        </GlassView>
       </View>
     </View>
   );
@@ -173,7 +164,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     width: '100%',
-    paddingHorizontal: moderateScale(8),
   },
   trackInfoTouchable: {
     flexDirection: 'row',
@@ -186,7 +176,7 @@ const styles = StyleSheet.create({
   reciterImage: {
     width: moderateScale(50),
     height: moderateScale(50),
-    borderRadius: moderateScale(6),
+    borderRadius: moderateScale(25),
   },
   uploadArtwork: {
     justifyContent: 'center',
@@ -214,7 +204,13 @@ const styles = StyleSheet.create({
     opacity: 0.7,
   },
   loveButton: {
-    paddingLeft: moderateScale(8),
+    marginLeft: moderateScale(8),
+    width: moderateScale(50),
+    height: moderateScale(50),
+    borderRadius: moderateScale(25),
+  },
+  loveButtonInner: {
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -1,5 +1,6 @@
 import React, {useState, useCallback, useEffect, useMemo} from 'react';
 import {View, StyleSheet, LayoutChangeEvent} from 'react-native';
+import {GlassView} from 'expo-glass-effect';
 import Animated, {
   runOnJS,
   useSharedValue,
@@ -263,7 +264,7 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
                 transliterationFontSize={transliterationFontSize}
                 translationFontSize={translationFontSize}
                 arabicFontSize={arabicFontSize}
-                contentPaddingTop={headerHeight}
+                contentPaddingTop={insets.top + moderateScale(4) + headerHeight}
                 contentPaddingBottom={controlsHeight}
               />
             )}
@@ -271,48 +272,45 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
         )}
       </View>
 
-      {/* Header overlay — absolute positioned at top */}
+      {/* Header overlay — floating glass card */}
       <GestureDetector gesture={sheetDragGesture}>
         <Animated.View
           style={[
             styles.headerOverlay,
             overlayAnimatedStyle,
             {
-              backgroundColor: theme.colors.background,
-              paddingTop: insets.top + moderateScale(12),
+              top: insets.top + moderateScale(4),
+              borderColor: Color(theme.colors.text).alpha(0.1).toString(),
             },
           ]}
           pointerEvents={isImmersive ? 'none' : 'auto'}
           onLayout={handleHeaderLayout}>
-          <View style={styles.handleContainer}>
-            <View
-              style={[
-                styles.handle,
-                {
-                  backgroundColor: Color(theme.colors.text)
-                    .alpha(0.2)
-                    .toString(),
-                },
-              ]}
-            />
-          </View>
+          {/* Glass background */}
+          <GlassView
+            style={StyleSheet.absoluteFill}
+            glassEffectStyle="regular"
+          />
           <Header onOptionsPress={onOptionsPress} />
         </Animated.View>
       </GestureDetector>
 
-      {/* Controls overlay — absolute positioned at bottom */}
+      {/* Controls overlay — floating glass card */}
       <GestureDetector gesture={sheetDragGesture}>
         <Animated.View
           style={[
             styles.controlsOverlay,
             overlayAnimatedStyle,
             {
-              backgroundColor: theme.colors.background,
-              paddingBottom: insets.bottom || moderateScale(20),
+              borderColor: Color(theme.colors.text).alpha(0.1).toString(),
             },
           ]}
           pointerEvents={isImmersive ? 'none' : 'auto'}
           onLayout={handleControlsLayout}>
+          {/* Glass background */}
+          <GlassView
+            style={StyleSheet.absoluteFill}
+            glassEffectStyle="regular"
+          />
           <TrackInfo />
           <PlaybackControls />
           <ControlButtons
@@ -330,20 +328,6 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
           />
         </Animated.View>
       </GestureDetector>
-
-      {/* Rounded TV frame between header and controls */}
-      <Animated.View
-        style={[
-          styles.tvFrame,
-          overlayAnimatedStyle,
-          {
-            top: headerHeight,
-            bottom: controlsHeight,
-            borderColor: Color(theme.colors.text).alpha(0.08).toString(),
-          },
-        ]}
-        pointerEvents="none"
-      />
     </View>
   );
 };
@@ -355,39 +339,30 @@ const styles = StyleSheet.create({
   },
   fullArea: {
     flex: 1,
-    paddingHorizontal: moderateScale(20),
+    paddingHorizontal: moderateScale(8),
   },
   headerOverlay: {
     position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
+    top: moderateScale(20),
+    left: moderateScale(16),
+    right: moderateScale(16),
     alignItems: 'center',
-    paddingTop: 0,
-  },
-  handleContainer: {
-    alignItems: 'center',
-    width: '100%',
-  },
-  handle: {
-    width: 40,
-    height: 5,
-    borderRadius: 3,
-  },
-  tvFrame: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderRadius: moderateScale(38),
+    borderCurve: 'continuous',
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
   },
   controlsOverlay: {
     position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    paddingHorizontal: moderateScale(20),
-    paddingTop: moderateScale(10),
+    bottom: moderateScale(20),
+    left: moderateScale(16),
+    right: moderateScale(16),
+    borderRadius: moderateScale(38),
+    borderCurve: 'continuous',
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+    paddingHorizontal: moderateScale(14),
+    paddingTop: moderateScale(14),
   },
 });
 

--- a/components/player/v2/PlayerSheet.tsx
+++ b/components/player/v2/PlayerSheet.tsx
@@ -295,7 +295,7 @@ export const PlayerSheet = () => {
         style={styles.sheet}
         backgroundStyle={[
           styles.background,
-          {backgroundColor: theme.colors.background},
+          {backgroundColor: 'transparent'},
         ]}>
         <PlayerContent
           onSpeedPress={handleShowSpeedSheet}
@@ -316,7 +316,7 @@ const styles = StyleSheet.create({
     elevation: 20,
   },
   background: {
-    borderTopLeftRadius: 45,
-    borderTopRightRadius: 45,
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
   },
 });


### PR DESCRIPTION
## Summary
- Replace solid header/controls overlays with floating rounded glass cards (`expo-glass-effect`)
- Use SF Symbols (`expo-symbols`) for close, options, and heart icons instead of vector icon packs
- Make reciter artwork circular and love button a glass circle
- Remove TV frame divider and sheet drag handle for cleaner look
- Reduce verse area `paddingHorizontal` from `ms(20)` → `ms(8)` for more reading space
- Transparent sheet background so glass effect shows through

## Files changed
- `PlayerSheet.tsx` — transparent bg, no rounded corners
- `PlayerContent/index.tsx` — floating glass header/controls, removed TV frame
- `PlayerContent/Header.tsx` — GlassView buttons, SF Symbols
- `PlayerContent/TrackInfo.tsx` — circular artwork, glass love button
- `PlayerContent/ControlButtons/index.tsx` — glass queue/options buttons

## Test plan
- [ ] Open player sheet — verify floating glass header and controls
- [ ] Tap close (X), options (…), heart, queue buttons — all respond
- [ ] Scroll verses — header/controls fade with immersive mode
- [ ] Check on both iOS and Android (glass falls back gracefully)
- [ ] Verify no layout regressions in landscape

🤖 Generated with [Claude Code](https://claude.com/claude-code)