### PR TITLE
feat: 2.1 onboarding pages, custom icons & changelog

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1993,3 +1993,30 @@ export const QuranBookIcon: React.FC<IconProps> = ({color, size}) => (
     />
   </Svg>
 );
+
+export const TasbihIcon: React.FC<IconProps> = ({color, size}) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    {/* Beads forming an oval loop */}
+    <Circle cx={12} cy={2} r={1.4} fill={color} />
+    <Circle cx={7.5} cy={3.8} r={1.4} fill={color} />
+    <Circle cx={16.5} cy={3.8} r={1.4} fill={color} />
+    <Circle cx={5} cy={7} r={1.4} fill={color} />
+    <Circle cx={19} cy={7} r={1.4} fill={color} />
+    <Circle cx={5} cy={10.5} r={1.4} fill={color} />
+    <Circle cx={19} cy={10.5} r={1.4} fill={color} />
+    <Circle cx={7.5} cy={13.2} r={1.4} fill={color} />
+    <Circle cx={16.5} cy={13.2} r={1.4} fill={color} />
+    {/* Imam bead (larger) */}
+    <Circle cx={12} cy={15} r={1.9} fill={color} />
+    {/* Tassel */}
+    <Line
+      x1={12}
+      y1={17}
+      x2={12}
+      y2={22}
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+    />
+  </Svg>
+);

--- a/components/modals/WhatsNewOnboarding/OnboardingPage.tsx
+++ b/components/modals/WhatsNewOnboarding/OnboardingPage.tsx
@@ -10,6 +10,11 @@ import {
   RepeatIcon,
   DownloadIcon,
   PlaylistIcon,
+  BreakdownIcon,
+  AmbientIcon,
+  StackedVolumesIcon,
+  GroupedLinesIcon,
+  TasbihIcon,
 } from '@/components/Icons';
 
 const CUSTOM_ICONS: Record<
@@ -20,6 +25,11 @@ const CUSTOM_ICONS: Record<
   memorize: {component: RepeatIcon, size: moderateScale(64)},
   downloads: {component: DownloadIcon, size: moderateScale(56)},
   playlists: {component: PlaylistIcon, size: moderateScale(56)},
+  wbw: {component: BreakdownIcon, size: moderateScale(56)},
+  ambient: {component: AmbientIcon, size: moderateScale(56)},
+  adhkar: {component: TasbihIcon, size: moderateScale(56)},
+  translations: {component: StackedVolumesIcon, size: moderateScale(56)},
+  themes: {component: GroupedLinesIcon, size: moderateScale(56)},
 };
 
 function renderIcon(page: OnboardingPageType) {

--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,5 +1,32 @@
 [
   {
+    "version": "2.1",
+    "releaseDate": "2026-03-11",
+    "title": "Deeper Understanding",
+    "highlights": [
+      {
+        "title": "Word by Word",
+        "description": "Tap any word to see its meaning, transliteration, and grammar — right in the mushaf or player",
+        "icon": "text-outline"
+      },
+      {
+        "title": "Translations & Tafseer",
+        "description": "Browse dozens of translations and scholarly commentaries in multiple languages, all downloadable for offline use",
+        "icon": "language-outline"
+      },
+      {
+        "title": "Thematic Highlighting",
+        "description": "Verses are color-coded by theme so you can see the structure and topics of each surah at a glance",
+        "icon": "color-palette-outline"
+      },
+      {
+        "title": "IndoPak Script",
+        "description": "Switch to the IndoPak Nastaliq script in the mushaf for the style used across South Asia",
+        "icon": "globe-outline"
+      }
+    ]
+  },
+  {
     "version": "2.0",
     "releaseDate": "2026-02-18",
     "title": "A New Chapter",

--- a/data/onboardingPages.ts
+++ b/data/onboardingPages.ts
@@ -12,10 +12,10 @@ export const ONBOARDING_PAGES: OnboardingPage[] = [
   {
     id: 'welcome',
     icon: 'app-icon',
-    title: 'Welcome to Bayaan 2.0',
+    title: 'Welcome to Bayaan',
     subtitle: 'A New Chapter',
     description:
-      'A major update with a beautiful Mushaf, ayah highlighting, adhkar, ambient sounds, and so much more.',
+      'A beautiful Mushaf, ayah highlighting, word-by-word translation, adhkar, ambient sounds, and so much more.',
   },
   {
     id: 'mushaf',
@@ -54,6 +54,7 @@ export const ONBOARDING_PAGES: OnboardingPage[] = [
   {
     id: 'ambient',
     icon: 'leaf-outline',
+    isCustomIcon: true,
     gradientColors: ['#10B981', '#059669'],
     title: 'Ambient Sounds',
     description:
@@ -70,10 +71,46 @@ export const ONBOARDING_PAGES: OnboardingPage[] = [
   {
     id: 'adhkar',
     icon: 'flower-outline',
+    isCustomIcon: true,
     gradientColors: ['#EC4899', '#DB2777'],
     title: 'Adhkar (Remembrance)',
     description:
       'The complete Hisnul Muslim collection with audio playback, Play All mode, and saved favorites.',
+  },
+  {
+    id: 'wbw',
+    icon: 'text-outline',
+    isCustomIcon: true,
+    gradientColors: ['#0EA5E9', '#0284C7'],
+    title: 'Word by Word',
+    description:
+      'Tap any word to see its meaning, transliteration, and grammar — right in the mushaf or player.',
+  },
+  {
+    id: 'translations',
+    icon: 'language-outline',
+    isCustomIcon: true,
+    gradientColors: ['#A855F7', '#7C3AED'],
+    title: 'Translations & Tafseer',
+    description:
+      'Browse dozens of translations and scholarly commentaries in multiple languages, all downloadable for offline use.',
+  },
+  {
+    id: 'themes',
+    icon: 'color-palette-outline',
+    isCustomIcon: true,
+    gradientColors: ['#F43F5E', '#E11D48'],
+    title: 'Thematic Highlighting',
+    description:
+      'Verses are color-coded by theme so you can see the structure and topics of each surah at a glance.',
+  },
+  {
+    id: 'indopak',
+    icon: 'globe-outline',
+    gradientColors: ['#22D3EE', '#06B6D4'],
+    title: 'IndoPak Script',
+    description:
+      'Switch to the IndoPak Nastaliq script in the mushaf for the style used across South Asia.',
   },
   {
     id: 'downloads',


### PR DESCRIPTION
## Summary
- Add 4 new onboarding pages: Word by Word, Translations & Tafseer, Thematic Highlighting, IndoPak Script
- Create `TasbihIcon` SVG (prayer beads) for adhkar page
- Wire up 5 custom icon mappings in the onboarding carousel (BreakdownIcon, AmbientIcon, TasbihIcon, StackedVolumesIcon, GroupedLinesIcon)
- Update welcome page title to "Welcome to Bayaan" and refresh description
- Add 2.1 changelog entry with 4 highlights

## Files changed
- `data/onboardingPages.ts` — new pages + `isCustomIcon` flags
- `data/changelog.json` — 2.1 entry
- `components/Icons.tsx` — TasbihIcon
- `components/modals/WhatsNewOnboarding/OnboardingPage.tsx` — custom icon imports + mappings

## Test plan
- [ ] Open What's New modal — all pages render with correct custom icons
- [ ] Swipe through carousel — WBW, Translations, Themes, IndoPak pages appear
- [ ] Adhkar page shows TasbihIcon (prayer beads), not Ionicon
- [ ] Settings > What's New — changelog shows 2.1 entry
- [ ] Welcome page shows updated title/description

🤖 Generated with [Claude Code](https://claude.com/claude-code)