### PR TITLE
fix: reduce mushaf list view horizontal padding

### DIFF
--- a/components/mushaf/reading/ContinuousListView.tsx
+++ b/components/mushaf/reading/ContinuousListView.tsx
@@ -232,7 +232,7 @@ const ContinuousListView = forwardRef<
 
     const items = useMemo(() => buildContinuousListItems(), []);
 
-    const contentWidth = SCREEN_WIDTH - moderateScale(24);
+    const contentWidth = SCREEN_WIDTH - moderateScale(16);
 
     // Load annotations for visible surahs
     const loadAnnotationsForSurah = useVerseAnnotationsStore(
@@ -369,7 +369,7 @@ const ContinuousListView = forwardRef<
         contentContainerStyle={{
           paddingTop: insets.top + verticalScale(60),
           paddingBottom: insets.bottom + verticalScale(80),
-          paddingHorizontal: moderateScale(12),
+          paddingHorizontal: moderateScale(8),
         }}
         showsVerticalScrollIndicator={false}
         onViewableItemsChanged={onViewableItemsChanged}


### PR DESCRIPTION
## Summary
- Reduce `ContinuousListView` FlashList `paddingHorizontal` from `ms(12)` → `ms(8)`
- Update `contentWidth` calculation from `SCREEN_WIDTH - ms(24)` → `SCREEN_WIDTH - ms(16)` to stay in sync
- Gives verses more horizontal space, consistent with player padding reduction

## Test plan
- [ ] Open mushaf continuous reading mode — verses have slightly more width
- [ ] Digital Khatt justified text still fills correctly (no overflow/gap)
- [ ] Scroll through multiple pages — no layout shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)