### PR TITLE
feat: bundle Ibn Kathir English tafseer

### DIFF
--- a/services/AppInitializer.ts
+++ b/services/AppInitializer.ts
@@ -7,6 +7,7 @@ import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
 import {qulDataService} from '@/services/mushaf/QulDataService';
 import {translationDbService} from '@/services/translation/TranslationDbService';
 import {tafseerDbService} from '@/services/tafseer/TafseerDbService';
+import {useTafseerStore} from '@/store/tafseerStore';
 import {wbwDataService} from '@/services/wbw/WBWDataService';
 import {warmBookmarkCache} from '@/components/mushaf/BookmarkChips';
 import {timestampService} from '@/services/timestamps/TimestampService';
@@ -402,6 +403,8 @@ appInitializer.registerService({
   critical: false,
   initialize: async () => {
     await tafseerDbService.initialize();
+    await tafseerDbService.importBundledIbnKathir();
+    await useTafseerStore.getState().loadDownloadedMeta();
   },
 });
 

--- a/services/tafseer/TafseerDbService.ts
+++ b/services/tafseer/TafseerDbService.ts
@@ -312,6 +312,65 @@ class TafseerDbService {
     );
     return row != null;
   }
+
+  /**
+   * Import the bundled Ibn Kathir (Abridged) tafseer into SQLite.
+   * The compact JSON stores only group leaders (1,895 entries instead of 6,231)
+   * to minimize bundle size. This method expands groups into per-verse rows.
+   * Runs once on first launch — subsequent calls are no-ops.
+   */
+  async importBundledIbnKathir(): Promise<void> {
+    const already = await this.isDownloaded('169');
+    if (already) return;
+
+    const db = await this.ensureReady();
+    const compactData =
+      require('@/data/ibn-kathir-tafseer-compact.json') as Array<{
+        s: number;
+        f: number;
+        t: number;
+        text: string;
+      }>;
+
+    // Expand compact entries into per-verse rows
+    const verses: Array<{
+      verseKey: string;
+      surahNumber: number;
+      ayahNumber: number;
+      text: string;
+      groupVerseKey: string;
+      fromAyah: number;
+      toAyah: number;
+    }> = [];
+
+    for (const entry of compactData) {
+      const groupVerseKey = `${entry.s}:${entry.f}`;
+      for (let ayah = entry.f; ayah <= entry.t; ayah++) {
+        verses.push({
+          verseKey: `${entry.s}:${ayah}`,
+          surahNumber: entry.s,
+          ayahNumber: ayah,
+          text: entry.text,
+          groupVerseKey,
+          fromAyah: entry.f,
+          toAyah: entry.t,
+        });
+      }
+    }
+
+    await this.saveTafseer(
+      '169',
+      'Ibn Kathir (Abridged)',
+      'Ibn Kathir (Abridged)',
+      'English',
+      'ltr',
+      verses,
+    );
+
+    console.log(
+      `[TafseerDbService] Bundled Ibn Kathir imported (${verses.length} verses)`,
+    );
+  }
 }
 
 export const tafseerDbService = new TafseerDbService();

--- a/store/tafseerStore.ts
+++ b/store/tafseerStore.ts
@@ -25,7 +25,7 @@ export const useTafseerStore = create<TafseerStoreState>()(
   persist(
     (set, get) => ({
       downloadedMeta: [],
-      selectedTafseerId: null,
+      selectedTafseerId: '169',
       downloadingId: null,
       downloadProgress: 0,
 


### PR DESCRIPTION
## Summary
- Bundles Ibn Kathir (Abridged) English tafseer as a compact JSON file (10.6MB) so users get tafseer out-of-the-box without downloading
- On first launch, auto-imports into SQLite via existing `saveTafseer` pipeline — subsequent launches are no-ops
- Defaults new users to Ibn Kathir as their selected tafseer

## Details
The compact JSON stores only 1,895 group-leader entries (vs 6,231 per-verse rows), cutting bundle size by 74% from the naive 41MB format. During import, groups are expanded into per-verse rows with proper `from_ayah`/`to_ayah` range metadata.

**Files changed:**
- `data/ibn-kathir-tafseer-compact.json` — bundled tafseer data
- `services/tafseer/TafseerDbService.ts` — `importBundledIbnKathir()` method
- `services/AppInitializer.ts` — registers import after Tafseer DB init
- `store/tafseerStore.ts` — defaults `selectedTafseerId` to `'169'`

## Test plan
- [ ] Fresh install: verify Ibn Kathir appears as downloaded tafseer without user action
- [ ] Fresh install: open verse actions → tafseer tab → verify commentary loads
- [ ] Existing user (already has tafaseer): verify no duplicate import, existing selection preserved
- [ ] Existing user (no tafaseer downloaded): verify Ibn Kathir auto-imports on upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)