### PR TITLE
fix: migrate existing users to bundled Ibn Kathir tafseer

### DIFF
--- a/store/tafseerStore.ts
+++ b/store/tafseerStore.ts
@@ -100,11 +100,22 @@ export const useTafseerStore = create<TafseerStoreState>()(
     {
       name: 'tafseer-store',
       storage: createJSONStorage(() => AsyncStorage),
-      version: 2,
+      version: 3,
       // Only persist selected tafseer
       partialize: state => ({
         selectedTafseerId: state.selectedTafseerId,
       }),
+      migrate: (persistedState: unknown, version: number) => {
+        const state = persistedState as {selectedTafseerId?: string | null};
+        if (version < 3) {
+          // Existing users had null — default to bundled Ibn Kathir
+          return {
+            ...state,
+            selectedTafseerId: state.selectedTafseerId || '169',
+          };
+        }
+        return state;
+      },
     },
   ),
 );


### PR DESCRIPTION
## Summary
- Fixes "Tafseer not available for this verse" for existing users after bundled Ibn Kathir was added
- Bumps tafseer store version to 3 with migration that converts persisted `null` → `'169'`

## Root cause
Existing users had `selectedTafseerId: null` persisted in AsyncStorage. Zustand hydration overwrote the new `'169'` default, so the tafseer query never ran despite the data being imported.

## Test plan
- [ ] Existing user: restart app → tafseer content loads immediately
- [ ] New user: fresh install → tafseer works out of the box

🤖 Generated with [Claude Code](https://claude.com/claude-code)