### PR TITLE
feat: restore theme selector and sync liquid glass with user theme

### DIFF
--- a/app/(tabs)/(a.home)/index.tsx
+++ b/app/(tabs)/(a.home)/index.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useCallback, useLayoutEffect, useMemo} from 'react';
-import {View, Pressable, StyleSheet, Platform} from 'react-native';
+import {View, Pressable, StyleSheet} from 'react-native';
 import {useRouter, useNavigation} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {createStyles} from './_styles';
@@ -19,9 +19,8 @@ import {QuranIcon} from '@/components/Icons';
 import Color from 'color';
 import {mushafSessionStore} from '@/services/mushaf/MushafSessionStore';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
 type ViewOption = 'Reciters' | 'Surahs' | 'Adhkar';
 
@@ -29,6 +28,7 @@ function HomeScreen() {
   const router = useRouter();
   const navigation = useNavigation();
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const styles = createStyles(theme);
   const [activeView, setActiveView] = useState<ViewOption>('Reciters');
   const insets = useSafeAreaInsets();
@@ -207,6 +207,7 @@ function HomeScreen() {
             <GlassView
               style={headerStyles.mushafGlass}
               glassEffectStyle="regular"
+              colorScheme={glassColorScheme}
               isInteractive>
               <Pressable
                 onPress={handleMushafPress}

--- a/app/(tabs)/(d.settings)/index.tsx
+++ b/app/(tabs)/(d.settings)/index.tsx
@@ -26,6 +26,7 @@ import {
   ShieldLockIcon,
 } from '@/components/Icons';
 import {useDevSettingsStore} from '@/store/devSettingsStore';
+import {ThemePicker} from '@/components/settings/ThemePicker';
 
 const isExternalLink = (type: string): boolean => {
   return ['support', 'featureRequest', 'terms', 'privacy', 'rateApp'].includes(
@@ -270,9 +271,18 @@ export default function SettingsScreen() {
       <ScrollView
         contentContainerStyle={[
           styles.scrollContent,
-          {paddingTop: insets.top + moderateScale(16), paddingBottom: bottomInset},
+          {
+            paddingTop: insets.top + moderateScale(16),
+            paddingBottom: bottomInset,
+          },
         ]}
         showsVerticalScrollIndicator={false}>
+        {/* Appearance */}
+        <View style={styles.section}>
+          <Text style={styles.sectionHeader}>APPEARANCE</Text>
+          <ThemePicker />
+        </View>
+
         {/* Settings Sections */}
         {settingsItems.map(section => (
           <View key={section.section} style={styles.section}>

--- a/components/BottomTabBar.tsx
+++ b/components/BottomTabBar.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
-import {View, Pressable, Text, StyleSheet, Platform} from 'react-native';
+import {View, Pressable, Text, StyleSheet} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {moderateScale} from 'react-native-size-matters';
 import {
@@ -17,9 +17,8 @@ import {
   FLOATING_UI_HORIZONTAL_MARGIN,
   FLOATING_TAB_BAR_BOTTOM_MARGIN,
 } from '@/utils/constants';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
 function getIcon(
   routeName: string,
@@ -92,6 +91,7 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({
   navigation,
 }) => {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const insets = useSafeAreaInsets();
   const iconSize = moderateScale(24, 0.2);
 
@@ -103,7 +103,10 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({
       right: FLOATING_UI_HORIZONTAL_MARGIN,
       backgroundColor: USE_GLASS
         ? 'transparent'
-        : Color(theme.colors.background).mix(Color(theme.colors.text), 0.08).alpha(0.92).toString(),
+        : Color(theme.colors.background)
+            .mix(Color(theme.colors.text), 0.08)
+            .alpha(0.92)
+            .toString(),
       borderRadius: moderateScale(24),
       borderWidth: USE_GLASS ? 0 : 1,
       borderColor: USE_GLASS
@@ -142,7 +145,7 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({
     <Container
       style={containerStyle}
       {...(USE_GLASS
-        ? {glassEffectStyle: 'regular' as const}
+        ? {glassEffectStyle: 'regular' as const, colorScheme: glassColorScheme}
         : {})}>
       <View style={styles.content}>
         {state.routes.map((route, index) => {

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -2020,3 +2020,105 @@ export const TasbihIcon: React.FC<IconProps> = ({color, size}) => (
     />
   </Svg>
 );
+
+export const SunIcon: React.FC<IconProps> = ({color, size}) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <Circle cx={12} cy={12} r={4.5} stroke={color} strokeWidth={1.5} />
+    <Line
+      x1={12}
+      y1={2.5}
+      x2={12}
+      y2={5}
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+    />
+    <Line
+      x1={12}
+      y1={19}
+      x2={12}
+      y2={21.5}
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+    />
+    <Line
+      x1={2.5}
+      y1={12}
+      x2={5}
+      y2={12}
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+    />
+    <Line
+      x1={19}
+      y1={12}
+      x2={21.5}
+      y2={12}
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+    />
+    <Line
+      x1={5.28}
+      y1={5.28}
+      x2={7.05}
+      y2={7.05}
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+    />
+    <Line
+      x1={16.95}
+      y1={16.95}
+      x2={18.72}
+      y2={18.72}
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+    />
+    <Line
+      x1={5.28}
+      y1={18.72}
+      x2={7.05}
+      y2={16.95}
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+    />
+    <Line
+      x1={16.95}
+      y1={7.05}
+      x2={18.72}
+      y2={5.28}
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+    />
+  </Svg>
+);
+
+export const MoonIcon: React.FC<IconProps> = ({color, size}) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <Path
+      d="M20.5 12.5c-.67 4.44-4.64 7.5-9.11 7.5C6.48 20 2.5 16.48 2.5 11.5c0-4.47 3.06-8.44 7.5-9.11a8 8 0 0010.5 10.11z"
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
+export const AutoThemeIcon: React.FC<IconProps> = ({color, size}) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    {/* Circle split in half — left light, right dark */}
+    <Circle cx={12} cy={12} r={8.5} stroke={color} strokeWidth={1.5} />
+    {/* Right half filled (dark side) */}
+    <Path d="M12 3.5a8.5 8.5 0 010 17V3.5z" fill={color} opacity={0.85} />
+    {/* Small star on the dark side */}
+    <Circle cx={14.5} cy={10} r={1} fill="white" opacity={0.9} />
+    <Circle cx={16} cy={13.5} r={0.6} fill="white" opacity={0.7} />
+  </Svg>
+);

--- a/components/adhkar/AdhkarBentoCard.tsx
+++ b/components/adhkar/AdhkarBentoCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, Pressable, Platform, StyleSheet} from 'react-native';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {LinearGradient} from 'expo-linear-gradient';
 import {Image} from 'expo-image';
 import {moderateScale} from 'react-native-size-matters';
@@ -8,9 +8,8 @@ import {useTheme} from '@/hooks/useTheme';
 import {SuperCategory} from '@/types/adhkar';
 import {ADHKAR_CATEGORY_IMAGES} from '@/constants/adhkarImages';
 import {Link} from 'expo-router';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
 const TEXT_POSITION: Record<string, 'top' | 'bottom' | 'center'> = {
   // Main adhkar
@@ -60,6 +59,7 @@ export const AdhkarBentoCard = React.memo(function AdhkarBentoCard({
   height,
 }: AdhkarBentoCardProps) {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const isDarkMode = theme.isDarkMode;
 
   // Subtle gradient incorporating the category's color (same pattern as ExploreView)
@@ -144,7 +144,10 @@ export const AdhkarBentoCard = React.memo(function AdhkarBentoCard({
       <Link {...linkProps}>
         <Pressable style={StyleSheet.flatten([styles.glassWrapper])}>
           <Link.AppleZoom>
-            <GlassView style={styles.glassInner} glassEffectStyle="regular">
+            <GlassView
+              style={styles.glassInner}
+              glassEffectStyle="regular"
+              colorScheme={glassColorScheme}>
               {cardContent}
             </GlassView>
           </Link.AppleZoom>

--- a/components/browse/BrowseReciterCard.tsx
+++ b/components/browse/BrowseReciterCard.tsx
@@ -1,14 +1,13 @@
 import React, {useMemo} from 'react';
-import {View, Text, Pressable, StyleSheet, Platform} from 'react-native';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {Reciter} from '@/data/reciterData';
 import {Theme} from '@/utils/themeUtils';
 import {ReciterImage} from '@/components/ReciterImage';
 import Color from 'color';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
+import {GlassView} from 'expo-glass-effect';
 import {Link} from 'expo-router';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
 interface BrowseReciterCardProps {
   reciter: Reciter;
@@ -79,6 +78,7 @@ const BrowseReciterCard = React.memo(
     height,
     theme,
   }: BrowseReciterCardProps) => {
+    const glassColorScheme = useGlassColorScheme();
     const styles = useMemo(
       () => createStyles(theme, width, height),
       [theme, width, height],
@@ -128,7 +128,8 @@ const BrowseReciterCard = React.memo(
                   styles.container,
                   styles.glassContainer,
                 ])}
-                glassEffectStyle="regular">
+                glassEffectStyle="regular"
+                colorScheme={glassColorScheme}>
                 {content}
               </GlassView>
             </Link.AppleZoom>

--- a/components/browse/BrowseSurahs.tsx
+++ b/components/browse/BrowseSurahs.tsx
@@ -1,11 +1,5 @@
 import React, {useState, useMemo, useCallback, useLayoutEffect} from 'react';
-import {
-  View,
-  FlatList,
-  Text,
-  Platform,
-  Pressable,
-} from 'react-native';
+import {View, FlatList, Text, Platform, Pressable} from 'react-native';
 import {useRouter, useNavigation} from 'expo-router';
 import {
   moderateScale,
@@ -28,10 +22,10 @@ import {useReciterSelection} from '@/hooks/useReciterSelection';
 import {Theme} from '@/utils/themeUtils';
 import {getJuzForSurah, getJuzName} from '@/data/juzData';
 import {useHeaderHeight} from '@react-navigation/elements';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
 const isIOS = Platform.OS === 'ios';
-const USE_GLASS = isIOS && isLiquidGlassAvailable();
 
 // Define types for clarity, matching the ones in useSettings
 type ViewMode = 'card' | 'list';
@@ -164,6 +158,7 @@ interface BrowseSurahsProps {
 export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
   const router = useRouter();
   const navigation = useNavigation();
+  const glassColorScheme = useGlassColorScheme();
   const insets = useSafeAreaInsets();
   const iosHeaderHeight = isIOS ? useHeaderHeight() : 0;
   const {askEveryTime, defaultReciterSelection} = useSettings();
@@ -446,7 +441,9 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
     if (USE_GLASS) {
       return (
         <View style={styles.glassWrapper}>
-          <GlassView style={styles.glassInner}>{controlsContent}</GlassView>
+          <GlassView style={styles.glassInner} colorScheme={glassColorScheme}>
+            {controlsContent}
+          </GlassView>
         </View>
       );
     }

--- a/components/cards/RecentReciterCard.tsx
+++ b/components/cards/RecentReciterCard.tsx
@@ -1,12 +1,13 @@
 import React, {useCallback, useMemo} from 'react';
-import {View, Text, Pressable, StyleSheet, Platform} from 'react-native';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {ReciterImage} from '@/components/ReciterImage';
 import {PlayIcon} from '@/components/Icons';
 import Color from 'color';
 import {LinearGradient} from 'expo-linear-gradient';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 import {Slider} from '@miblanchard/react-native-slider';
 import {
   getReciterById,
@@ -242,16 +243,18 @@ export const RecentReciterCard = ({
   ]);
 
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const glassColorScheme = useGlassColorScheme();
 
-  const useGlass = Platform.OS === 'ios' && isLiquidGlassAvailable();
-  const CardWrapper = useGlass ? GlassView : View;
+  const CardWrapper = USE_GLASS ? GlassView : View;
 
   return (
     <CardWrapper
-      style={[styles.container, useGlass && styles.glassContainer]}
-      {...(useGlass ? {glassEffectStyle: 'regular'} : {})}>
+      style={[styles.container, USE_GLASS && styles.glassContainer]}
+      {...(USE_GLASS
+        ? {glassEffectStyle: 'regular', colorScheme: glassColorScheme}
+        : {})}>
       {/* Background layers (fallback for non-glass) */}
-      {!useGlass && (
+      {!USE_GLASS && (
         <>
           <View
             style={[
@@ -301,7 +304,6 @@ export const RecentReciterCard = ({
       <Text style={styles.reciterName} numberOfLines={1}>
         {reciterName}
       </Text>
-
 
       {/* Bottom zone: Playback controls — resumes audio */}
       <Pressable

--- a/components/cards/RewayatCard.tsx
+++ b/components/cards/RewayatCard.tsx
@@ -1,13 +1,12 @@
 import React, {useMemo} from 'react';
-import {Pressable, Text, View, StyleSheet, Platform} from 'react-native';
+import {Pressable, Text, View, StyleSheet} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {RewayatInfo} from '@/data/rewayatCollections';
 import {useTheme} from '@/hooks/useTheme';
 import Color from 'color';
 import {Link} from 'expo-router';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
 interface RewayatCardProps {
   rewayat: RewayatInfo;
@@ -23,6 +22,7 @@ function RewayatCard({
   height = moderateScale(92),
 }: RewayatCardProps) {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const styles = useMemo(
     () => createStyles(theme, width, height),
     [theme, width, height],
@@ -63,7 +63,8 @@ function RewayatCard({
                 styles.container,
                 styles.glassContainer,
               ])}
-              glassEffectStyle="regular">
+              glassEffectStyle="regular"
+              colorScheme={glassColorScheme}>
               {content}
             </GlassView>
           </Link.AppleZoom>

--- a/components/cards/SurahCard.tsx
+++ b/components/cards/SurahCard.tsx
@@ -8,7 +8,6 @@ import {
   StyleProp,
   ViewStyle,
   GestureResponderEvent,
-  Platform,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
@@ -25,9 +24,8 @@ import Animated, {
 import * as Haptics from 'expo-haptics';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {Link} from 'expo-router';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
 import {NowPlayingIndicator} from '@/components/NowPlayingIndicator';
 import {GradientText} from '@/components/GradientText';
@@ -79,6 +77,7 @@ export const SurahCard: React.FC<SurahCardProps> = ({
   mushafLink = false,
 }) => {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
 
   // Get download state
   const isDownloadedBase = useIsDownloaded(
@@ -442,7 +441,8 @@ export const SurahCard: React.FC<SurahCardProps> = ({
           <Link.AppleZoom>
             <GlassView
               style={styles.glassInner}
-              glassEffectStyle="regular">
+              glassEffectStyle="regular"
+              colorScheme={glassColorScheme}>
               {cardContent}
             </GlassView>
           </Link.AppleZoom>
@@ -482,7 +482,8 @@ export const SurahCard: React.FC<SurahCardProps> = ({
         style={StyleSheet.flatten([styles.glassWrapper, style])}>
         <GlassView
           style={styles.glassInner}
-          glassEffectStyle="regular">
+          glassEffectStyle="regular"
+          colorScheme={glassColorScheme}>
           {cardContent}
         </GlassView>
       </Pressable>

--- a/components/hero/SavedAdhkarHero.tsx
+++ b/components/hero/SavedAdhkarHero.tsx
@@ -1,12 +1,5 @@
 import React, {useMemo} from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  Pressable,
-  Platform,
-  ViewStyle,
-} from 'react-native';
+import {View, Text, StyleSheet, Pressable, ViewStyle} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {LinearGradient} from 'expo-linear-gradient';
 import {Ionicons} from '@expo/vector-icons';
@@ -14,11 +7,10 @@ import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
 import {HeroSection} from './HeroSection';
 import {Link} from 'expo-router';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 import Svg, {Circle, Path, Defs, RadialGradient, Stop} from 'react-native-svg';
 import {pickHeroTheme, HeroColorTheme} from '@/components/hero/heroThemes';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
 
 // Match SurahsHero height
 const SECTION_HEIGHT = moderateScale(150);
@@ -141,6 +133,7 @@ interface SavedAdhkarCardProps {
  */
 const SavedAdhkarCard = ({savedCount, style}: SavedAdhkarCardProps) => {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const heroTheme = useMemo(() => pickHeroTheme(), []);
   const styles = useMemo(
     () => createStyles(theme, heroTheme),
@@ -193,7 +186,10 @@ const SavedAdhkarCard = ({savedCount, style}: SavedAdhkarCardProps) => {
       <Link href="/(tabs)/(a.home)/adhkar/saved" asChild>
         <Pressable style={StyleSheet.flatten([styles.glassWrapper, style])}>
           <Link.AppleZoom>
-            <GlassView style={styles.glassInner} glassEffectStyle="regular">
+            <GlassView
+              style={styles.glassInner}
+              glassEffectStyle="regular"
+              colorScheme={glassColorScheme}>
               {cardContent}
             </GlassView>
           </Link.AppleZoom>

--- a/components/hero/ScrollingReciters.tsx
+++ b/components/hero/ScrollingReciters.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   StyleSheet,
   Pressable,
-  Platform,
   TouchableOpacity,
   InteractionManager,
 } from 'react-native';
@@ -27,9 +26,8 @@ import Color from 'color';
 import {Link} from 'expo-router';
 import {LinearGradient} from 'expo-linear-gradient';
 import {getRandomColors} from '@/utils/gradientColors';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
 // Error Boundary for ScrollingHero
 class ScrollingHeroErrorBoundary extends React.Component<{
@@ -426,6 +424,7 @@ function createStyles(theme: Theme) {
 export const ScrollingHero = React.memo(
   () => {
     const {theme} = useTheme();
+    const glassColorScheme = useGlassColorScheme();
     const styles = useMemo(() => createStyles(theme), [theme]);
 
     const distributedReciters = useDistributedReciters(RECITERS);
@@ -442,23 +441,16 @@ export const ScrollingHero = React.memo(
       <>
         <View style={styles.columnsContainer}>
           {columnConfigs.map((config, index) => (
-            <Column
-              key={index}
-              config={config}
-              styles={styles}
-              theme={theme}
-            />
+            <Column key={index} config={config} styles={styles} theme={theme} />
           ))}
         </View>
         <Overlay isRevealed={false} theme={theme} styles={styles} />
         <View style={styles.contentOverlay} pointerEvents="none">
           {USE_GLASS ? (
             <GlassView
-              style={[
-                styles.browseButton,
-                {borderRadius: moderateScale(25)},
-              ]}
-              glassEffectStyle="regular">
+              style={[styles.browseButton, {borderRadius: moderateScale(25)}]}
+              glassEffectStyle="regular"
+              colorScheme={glassColorScheme}>
               <Text style={styles.buttonText}>Browse All</Text>
               <Feather
                 name="arrow-right"
@@ -476,9 +468,7 @@ export const ScrollingHero = React.memo(
                     .alpha(0.95)
                     .toString(),
                   borderWidth: 1,
-                  borderColor: Color(theme.colors.border)
-                    .alpha(0.2)
-                    .toString(),
+                  borderColor: Color(theme.colors.border).alpha(0.2).toString(),
                   borderRadius: moderateScale(25),
                 },
               ]}>
@@ -501,7 +491,10 @@ export const ScrollingHero = React.memo(
           <Link href="/(tabs)/(a.home)/browse-all" asChild>
             <Pressable style={StyleSheet.flatten([styles.glassWrapper])}>
               <Link.AppleZoom>
-                <GlassView style={styles.glassInner} glassEffectStyle="regular">
+                <GlassView
+                  style={styles.glassInner}
+                  glassEffectStyle="regular"
+                  colorScheme={glassColorScheme}>
                   {scrollingContent}
                 </GlassView>
               </Link.AppleZoom>

--- a/components/hero/SurahsHero.tsx
+++ b/components/hero/SurahsHero.tsx
@@ -1,12 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
-import {
-  StyleSheet,
-  Text,
-  View,
-  Pressable,
-  Platform,
-  ViewStyle,
-} from 'react-native';
+import {StyleSheet, Text, View, Pressable, ViewStyle} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -16,7 +9,8 @@ import {MakkahIcon, MadinahIcon} from '@/components/Icons';
 import {HeroSection} from './HeroSection';
 import {SurahOfTheDay} from './SurahOfTheDay';
 import {Link} from 'expo-router';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 import Svg, {
   Defs,
   RadialGradient as SvgRadialGradient,
@@ -24,8 +18,6 @@ import Svg, {
   Rect,
 } from 'react-native-svg';
 import {SESSION_SEED, pickHeroTheme} from '@/components/hero/heroThemes';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
 
 // Same SECTION_HEIGHT as ScrollingHero for consistency
 const SECTION_HEIGHT = moderateScale(150);
@@ -64,6 +56,7 @@ export const SurahHeroSection = ({
   style,
 }: SurahHeroSectionProps) => {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const heroTheme = useMemo(() => pickHeroTheme(), []);
   const handleLongPress = useCallback(() => {
     onLongPress?.(surah);
@@ -187,7 +180,10 @@ export const SurahHeroSection = ({
           {...pressableProps}
           style={StyleSheet.flatten([styles.glassWrapper, style])}>
           <Link.AppleZoom>
-            <GlassView style={styles.glassInner} glassEffectStyle="regular">
+            <GlassView
+              style={styles.glassInner}
+              glassEffectStyle="regular"
+              colorScheme={glassColorScheme}>
               {cardContent}
             </GlassView>
           </Link.AppleZoom>

--- a/components/mushaf/main.tsx
+++ b/components/mushaf/main.tsx
@@ -21,6 +21,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {Ionicons} from '@expo/vector-icons';
 import {SheetManager} from 'react-native-actions-sheet';
 import {GlassView} from 'expo-glass-effect';
+import {useGlassColorScheme} from '@/hooks/useGlassProps';
 import {BackButton} from '@/components/BackButton';
 import MushafSearchView from './MushafSearchView';
 import {moderateScale} from 'react-native-size-matters';
@@ -271,6 +272,7 @@ export default function MushafViewer({
   }, [storeSearchMode]);
 
   const {theme, isDarkMode} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const pageLayout = useMushafSettingsStore(s => s.pageLayout);
   const viewMode = useMushafSettingsStore(s => s.viewMode);
   const scrollDirection = useMushafSettingsStore(s => s.scrollDirection);
@@ -344,7 +346,7 @@ export default function MushafViewer({
       headerTitle: () => (
         <GlassView
           glassEffectStyle="regular"
-          colorScheme={isDarkMode ? 'dark' : 'light'}
+          colorScheme={glassColorScheme}
           tintColor={isDarkMode ? 'rgba(0,0,0,0.5)' : undefined}
           style={{
             borderRadius: moderateScale(14),
@@ -611,8 +613,8 @@ export default function MushafViewer({
           backgroundColor: isVertical
             ? theme.colors.background
             : isBookLayout
-            ? edgeBg
-            : theme.colors.card,
+              ? edgeBg
+              : theme.colors.card,
         },
       ]}>
       {/* Content area: horizontal FlatList or vertical continuous view */}

--- a/components/player/v2/FloatingPlayer/index.tsx
+++ b/components/player/v2/FloatingPlayer/index.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo, useRef} from 'react';
-import {View, Text, Pressable, StyleSheet, Platform} from 'react-native';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {usePathname} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {moderateScale} from 'react-native-size-matters';
@@ -15,12 +15,12 @@ import {
   getFloatingPlayerBottomPosition,
   FLOATING_UI_HORIZONTAL_MARGIN,
 } from '@/utils/constants';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
 export const FloatingPlayer: React.FC = React.memo(function FloatingPlayer() {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const {play, pause} = usePlayerActions();
   const playbackState = usePlayerStore(state => state.playback.state);
   const queueTracks = usePlayerStore(state => state.queue.tracks);
@@ -97,7 +97,9 @@ export const FloatingPlayer: React.FC = React.memo(function FloatingPlayer() {
   return (
     <Container
       style={containerStyle}
-      {...(USE_GLASS ? {glassEffectStyle: 'regular' as const} : {})}>
+      {...(USE_GLASS
+        ? {glassEffectStyle: 'regular' as const, colorScheme: glassColorScheme}
+        : {})}>
       <Pressable
         onPress={handlePress}
         style={styles.content}

--- a/components/player/v2/PlayerContent/ControlButtons/index.tsx
+++ b/components/player/v2/PlayerContent/ControlButtons/index.tsx
@@ -8,6 +8,7 @@ import {
   TextStyle,
 } from 'react-native';
 import {GlassView} from 'expo-glass-effect';
+import {useGlassColorScheme} from '@/hooks/useGlassProps';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {usePlayerActions} from '@/hooks/usePlayerActions';
@@ -55,6 +56,7 @@ export const ControlButtons: React.FC<ControlButtonsProps> = ({
   followAlongAvailable,
 }) => {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const {updateSettings} = usePlayerActions();
   const playbackRate = usePlayerStore(s => s.playback.rate);
   const settings = usePlayerStore(s => s.settings);
@@ -90,6 +92,7 @@ export const ControlButtons: React.FC<ControlButtonsProps> = ({
         <GlassView
           style={styles.glassButton}
           glassEffectStyle="regular"
+          colorScheme={glassColorScheme}
           isInteractive>
           <Pressable
             onPress={handleMushafLayoutPress}
@@ -190,6 +193,7 @@ export const ControlButtons: React.FC<ControlButtonsProps> = ({
       <GlassView
         style={styles.glassButton}
         glassEffectStyle="regular"
+        colorScheme={glassColorScheme}
         isInteractive>
         <Pressable onPress={onQueuePress} style={styles.glassButtonInner}>
           <QueueIcon

--- a/components/player/v2/PlayerContent/Header.tsx
+++ b/components/player/v2/PlayerContent/Header.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react';
 import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {GlassView} from 'expo-glass-effect';
+import {useGlassColorScheme} from '@/hooks/useGlassProps';
 import {moderateScale} from 'react-native-size-matters';
 import {SymbolView} from 'expo-symbols';
 import {
@@ -32,6 +33,7 @@ interface HeaderProps {
 
 export const Header: React.FC<HeaderProps> = ({onOptionsPress}) => {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const {setSheetMode} = usePlayerActions();
   const queue = usePlayerStore(s => s.queue);
 
@@ -116,6 +118,7 @@ export const Header: React.FC<HeaderProps> = ({onOptionsPress}) => {
       <GlassView
         style={styles.closeButton}
         glassEffectStyle="regular"
+        colorScheme={glassColorScheme}
         isInteractive>
         <Pressable style={styles.glassButtonInner} onPress={handleClose}>
           <SymbolView
@@ -132,6 +135,7 @@ export const Header: React.FC<HeaderProps> = ({onOptionsPress}) => {
       <GlassView
         style={styles.optionsButton}
         glassEffectStyle="regular"
+        colorScheme={glassColorScheme}
         isInteractive>
         <Pressable style={styles.glassButtonInner} onPress={onOptionsPress}>
           <SymbolView

--- a/components/player/v2/PlayerContent/TrackInfo.tsx
+++ b/components/player/v2/PlayerContent/TrackInfo.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import {GlassView} from 'expo-glass-effect';
+import {useGlassColorScheme} from '@/hooks/useGlassProps';
 import {SymbolView} from 'expo-symbols';
 import {Pressable} from 'react-native-gesture-handler';
 import {moderateScale} from 'react-native-size-matters';
@@ -16,6 +17,7 @@ import {MicrophoneIcon} from '@/components/Icons';
 
 export const TrackInfo = () => {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const {setSheetMode} = usePlayerActions();
   const queue = usePlayerStore(s => s.queue);
   const {navigateToReciterProfile} = useReciterNavigation();
@@ -135,6 +137,7 @@ export const TrackInfo = () => {
         <GlassView
           style={styles.loveButton}
           glassEffectStyle="regular"
+          colorScheme={glassColorScheme}
           isInteractive>
           <Pressable
             style={({pressed}) => [

--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useCallback, useEffect, useMemo} from 'react';
 import {View, StyleSheet, LayoutChangeEvent} from 'react-native';
 import {GlassView} from 'expo-glass-effect';
+import {useGlassColorScheme} from '@/hooks/useGlassProps';
 import Animated, {
   runOnJS,
   useSharedValue,
@@ -55,6 +56,7 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
   onFollowAlongPress,
 }) => {
   const {theme} = useTheme();
+  const glassColorScheme = useGlassColorScheme();
   const [showQueue, setShowQueue] = useState(false);
   const {
     updateQueue,
@@ -289,6 +291,7 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
           <GlassView
             style={StyleSheet.absoluteFill}
             glassEffectStyle="regular"
+            colorScheme={glassColorScheme}
           />
           <Header onOptionsPress={onOptionsPress} />
         </Animated.View>
@@ -310,6 +313,7 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
           <GlassView
             style={StyleSheet.absoluteFill}
             glassEffectStyle="regular"
+            colorScheme={glassColorScheme}
           />
           <TrackInfo />
           <PlaybackControls />

--- a/components/search/ExploreView.tsx
+++ b/components/search/ExploreView.tsx
@@ -16,9 +16,8 @@ import {useWindowDimensions} from 'react-native';
 import {LinearGradient} from 'expo-linear-gradient';
 import {getAllSystemPlaylists, SystemPlaylist} from '@/data/systemPlaylists';
 import {useBottomInset} from '@/hooks/useBottomInset';
-import {GlassView, isLiquidGlassAvailable} from 'expo-glass-effect';
-
-const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
+import {GlassView} from 'expo-glass-effect';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
 // CONFIGURABLE ROW HEIGHT MULTIPLIER - This is the 'x' variable you can adjust
 const ROW_HEIGHT_UNIT = 80; // Base unit 'x' in points - adjust this value to change all card heights proportionally
@@ -119,6 +118,7 @@ const BentoTileComponent = React.memo(
     dimensions: {width: number; height: number};
   }) => {
     const {theme} = useTheme();
+    const glassColorScheme = useGlassColorScheme();
 
     // Subtle gradient incorporating the tile's unique color
     const baseColor = Color(tile.backgroundColor);
@@ -183,7 +183,8 @@ const BentoTileComponent = React.memo(
             <Link.AppleZoom>
               <GlassView
                 style={tileInnerStyles.glassInner}
-                glassEffectStyle="regular">
+                glassEffectStyle="regular"
+                colorScheme={glassColorScheme}>
                 {tileContent}
               </GlassView>
             </Link.AppleZoom>
@@ -317,7 +318,10 @@ export const ExploreView = React.memo(
           contentContainerStyle={[
             styles.scrollContent,
             {
-              paddingTop: Platform.OS === 'ios' ? insets.top + moderateScale(16) : moderateScale(16),
+              paddingTop:
+                Platform.OS === 'ios'
+                  ? insets.top + moderateScale(16)
+                  : moderateScale(16),
               paddingHorizontal: horizontalPadding,
               paddingBottom: bottomInset,
             },

--- a/components/settings/ThemePicker.tsx
+++ b/components/settings/ThemePicker.tsx
@@ -1,0 +1,101 @@
+import React, {useMemo, useCallback} from 'react';
+import {View, Text, Pressable} from 'react-native';
+import {ScaledSheet, moderateScale} from 'react-native-size-matters';
+import {useTheme} from '@/hooks/useTheme';
+import {ThemeMode, Theme} from '@/utils/themeUtils';
+import Color from 'color';
+import {SunIcon, MoonIcon, AutoThemeIcon} from '@/components/Icons';
+import * as Haptics from 'expo-haptics';
+
+const THEME_OPTIONS: {
+  mode: ThemeMode;
+  label: string;
+  icon: 'sun' | 'moon' | 'auto';
+}[] = [
+  {mode: 'light', label: 'Light', icon: 'sun'},
+  {mode: 'dark', label: 'Dark', icon: 'moon'},
+  {mode: 'system', label: 'Auto', icon: 'auto'},
+];
+
+const IconMap = {
+  sun: SunIcon,
+  moon: MoonIcon,
+  auto: AutoThemeIcon,
+};
+
+export const ThemePicker: React.FC = () => {
+  const {theme, themeMode, setThemeMode} = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const handleSelect = useCallback(
+    (mode: ThemeMode) => {
+      if (mode === themeMode) return;
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      setThemeMode(mode);
+    },
+    [themeMode, setThemeMode],
+  );
+
+  return (
+    <View style={styles.container}>
+      {THEME_OPTIONS.map(option => {
+        const isActive = themeMode === option.mode;
+        const Icon = IconMap[option.icon];
+        const iconColor = isActive
+          ? theme.colors.text
+          : Color(theme.colors.text).alpha(0.35).toString();
+
+        return (
+          <Pressable
+            key={option.mode}
+            style={({pressed}) => [
+              styles.option,
+              isActive && styles.optionActive,
+              pressed && !isActive && styles.optionPressed,
+            ]}
+            onPress={() => handleSelect(option.mode)}>
+            <Icon size={moderateScale(20)} color={iconColor} />
+            <Text style={[styles.label, isActive && styles.labelActive]}>
+              {option.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  ScaledSheet.create({
+    container: {
+      flexDirection: 'row',
+      gap: moderateScale(8),
+    },
+    option: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: moderateScale(12),
+      borderRadius: moderateScale(12),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      gap: moderateScale(6),
+    },
+    optionActive: {
+      backgroundColor: Color(theme.colors.text).alpha(0.1).toString(),
+      borderColor: Color(theme.colors.text).alpha(0.15).toString(),
+    },
+    optionPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+    },
+    label: {
+      fontSize: moderateScale(11.5),
+      fontFamily: 'Manrope-Medium',
+      color: Color(theme.colors.text).alpha(0.35).toString(),
+    },
+    labelActive: {
+      color: Color(theme.colors.text).alpha(0.85).toString(),
+      fontFamily: 'Manrope-SemiBold',
+    },
+  });

--- a/hooks/useGlassProps.ts
+++ b/hooks/useGlassProps.ts
@@ -1,0 +1,23 @@
+import {Platform} from 'react-native';
+import {isLiquidGlassAvailable} from 'expo-glass-effect';
+import {useThemeStore} from '@/store/themeStore';
+
+/** Whether the current device supports liquid glass (iOS 26+). */
+export const USE_GLASS = Platform.OS === 'ios' && isLiquidGlassAvailable();
+
+/**
+ * Returns the `colorScheme` prop value that should be passed to every
+ * `<GlassView>` so it matches the user's chosen theme instead of always
+ * following the system appearance.
+ *
+ * Usage:
+ * ```tsx
+ * const glassColorScheme = useGlassColorScheme();
+ * <GlassView colorScheme={glassColorScheme} glassEffectStyle="regular" />
+ * ```
+ */
+export function useGlassColorScheme(): 'auto' | 'light' | 'dark' {
+  const themeMode = useThemeStore(s => s.themeMode);
+  if (themeMode === 'system') return 'auto';
+  return themeMode; // 'light' | 'dark'
+}

--- a/store/themeStore.ts
+++ b/store/themeStore.ts
@@ -43,12 +43,17 @@ export const useThemeStore = create<ThemeState>()(
       primaryColor: 'Blue',
       theme: getEffectiveTheme('system', 'Blue'),
 
-      setThemeMode: _mode =>
+      setThemeMode: mode =>
         set(state => {
-          // Always follow system appearance
-          const newTheme = getEffectiveTheme('system', state.primaryColor);
+          const newTheme = getEffectiveTheme(mode, state.primaryColor);
+          // Sync native UI (keyboard, alerts, liquid glass chrome) with the choice
+          if (mode === 'system') {
+            Appearance.setColorScheme(null as any); // revert to system
+          } else {
+            Appearance.setColorScheme(mode);
+          }
           return {
-            themeMode: 'system' as ThemeMode,
+            themeMode: mode,
             theme: newTheme,
           };
         }),
@@ -71,11 +76,15 @@ export const useThemeStore = create<ThemeState>()(
       }),
       onRehydrateStorage: () => state => {
         if (state) {
-          // Always force system theme
-          const theme = getEffectiveTheme('system', state.primaryColor);
+          const theme = getEffectiveTheme(state.themeMode, state.primaryColor);
+          // Sync native UI with the persisted preference on app launch
+          if (state.themeMode === 'system') {
+            Appearance.setColorScheme(null as any);
+          } else {
+            Appearance.setColorScheme(state.themeMode);
+          }
           useThemeStore.setState({
             ...state,
-            themeMode: 'system',
             theme,
           });
         }


### PR DESCRIPTION
## Summary
- Restores the Light/Dark/Auto theme picker to Settings with custom SVG icons and haptic feedback
- Fixes `themeStore` to actually persist and apply the user's theme choice (was hardcoded to `'system'`)
- Syncs native UI (keyboard, alerts, liquid glass chrome) via `Appearance.setColorScheme()` on both theme change and app startup
- Adds centralized `useGlassColorScheme()` hook and applies `colorScheme` prop to all 24 `GlassView` instances across 18 files

## Test plan
- [ ] Open Settings → verify Light/Dark/Auto picker appears at top under "APPEARANCE"
- [ ] Select Light → verify entire app switches to light, including liquid glass elements
- [ ] Select Dark → verify entire app switches to dark, including liquid glass elements
- [ ] Select Auto → verify app follows system appearance
- [ ] Force-quit and relaunch → verify chosen theme persists
- [ ] Test on iOS 26+ device → verify liquid glass respects chosen theme (not just system)
- [ ] Test on older iOS / Android → verify app works normally without liquid glass

🤖 Generated with [Claude Code](https://claude.com/claude-code)