### PR TITLE
fix: reading theme not applied in settings, player, and mushaf divider

### DIFF
--- a/app/(tabs)/(d.settings)/_layout.tsx
+++ b/app/(tabs)/(d.settings)/_layout.tsx
@@ -38,15 +38,13 @@ export default function SettingsLayout() {
         name="default-reciter"
         options={{title: 'Default Reciter'}}
       />
-      <Stack.Screen
-        name="reciter-choice"
-        options={{title: 'Reciter Choice'}}
-      />
+      <Stack.Screen name="reciter-choice" options={{title: 'Reciter Choice'}} />
       <Stack.Screen name="account" options={{title: 'Account'}} />
       <Stack.Screen
         name="translations"
         options={{title: 'Translations & Tafaseer'}}
       />
+      <Stack.Screen name="reading-theme" options={{title: 'Reading Theme'}} />
       <Stack.Screen name="whats-new" options={{title: "What's New"}} />
     </Stack>
   );

--- a/app/(tabs)/(d.settings)/mushaf-settings.tsx
+++ b/app/(tabs)/(d.settings)/mushaf-settings.tsx
@@ -1,11 +1,17 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 import {View, StyleSheet, ScrollView} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {MushafSettingsContent} from '@/components/MushafSettingsContent';
 import {verticalScale} from 'react-native-size-matters';
+import {useRouter} from 'expo-router';
 
 export default function MushafSettingsScreen() {
   const {theme} = useTheme();
+  const router = useRouter();
+
+  const handleOpenThemePicker = useCallback(() => {
+    router.push('/(tabs)/(d.settings)/reading-theme');
+  }, [router]);
 
   return (
     <View
@@ -19,7 +25,10 @@ export default function MushafSettingsScreen() {
         contentContainerStyle={styles.scrollContent}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}>
-        <MushafSettingsContent showTitle={false} />
+        <MushafSettingsContent
+          showTitle={false}
+          onOpenThemePicker={handleOpenThemePicker}
+        />
       </ScrollView>
     </View>
   );

--- a/app/(tabs)/(d.settings)/reading-theme.tsx
+++ b/app/(tabs)/(d.settings)/reading-theme.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {View, StyleSheet} from 'react-native';
+import {useTheme} from '@/hooks/useTheme';
+import {ReadingThemeContent} from '@/components/ReadingThemeContent';
+import {useRouter} from 'expo-router';
+
+export default function ReadingThemeScreen() {
+  const {theme} = useTheme();
+  const router = useRouter();
+
+  return (
+    <View
+      style={[styles.container, {backgroundColor: theme.colors.background}]}>
+      <ReadingThemeContent onBack={() => router.back()} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/components/mushaf/main.tsx
+++ b/components/mushaf/main.tsx
@@ -176,6 +176,7 @@ const DKPageView: React.FC<{
       <SkiaPage
         pageNumber={pageNumber}
         textColor={textColor}
+        dividerColor={labelColor}
         contentMarginLeft={effectiveMarginLeft}
         onReady={() => setPageReady(true)}
         onTap={onTap}

--- a/components/mushaf/skia/SkiaPage.tsx
+++ b/components/mushaf/skia/SkiaPage.tsx
@@ -58,6 +58,7 @@ interface ParagraphInfo {
 interface SkiaPageProps {
   pageNumber: number;
   textColor: string;
+  dividerColor: string;
   contentMarginLeft?: number;
   onReady?: () => void;
   onTap?: () => void;
@@ -66,6 +67,7 @@ interface SkiaPageProps {
 const SkiaPage: React.FC<SkiaPageProps> = ({
   pageNumber,
   textColor,
+  dividerColor,
   contentMarginLeft,
   onReady,
   onTap,
@@ -613,7 +615,7 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
                 yPos={lineYPositions[lineIndex]}
                 pageWidth={lineWidth}
                 xOffset={margin}
-                dividerColor={theme.colors.textSecondary}
+                dividerColor={dividerColor}
                 nameColor={textColor}
                 lineHeight={
                   lineIndex < lineYPositions.length - 1

--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -25,6 +25,7 @@ import {usePlayerActions} from '@/hooks/usePlayerActions';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {useVerseSelectionStore} from '@/store/verseSelectionStore';
 import {useTheme} from '@/hooks/useTheme';
+import {useReadingThemeColors} from '@/hooks/useReadingThemeColors';
 import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import Color from 'color';
@@ -56,6 +57,7 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
   onFollowAlongPress,
 }) => {
   const {theme} = useTheme();
+  const readingColors = useReadingThemeColors();
   const glassColorScheme = useGlassColorScheme();
   const [showQueue, setShowQueue] = useState(false);
   const {
@@ -245,7 +247,10 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
     <View style={styles.container}>
       {/* QuranView / QueueList fills the entire area */}
       <View
-        style={[StyleSheet.absoluteFill, {backgroundColor: theme.colors.card}]}>
+        style={[
+          StyleSheet.absoluteFill,
+          {backgroundColor: readingColors.background},
+        ]}>
         {showQueue ? (
           <View style={styles.fullArea}>
             <QueueList


### PR DESCRIPTION
## Summary
- **Settings screen:** "Reading Theme" row in Mushaf Settings was a dead tap — `onOpenThemePicker` was never passed. Created a `reading-theme.tsx` stack screen using the existing `ReadingThemeContent` component and wired up navigation.
- **Player view:** Background used `theme.colors.card` instead of `readingColors.background`, so verse items and surah dividers appeared against the wrong background color regardless of the selected reading theme.
- **Mushaf SkiaPage:** Surah divider ornament was hardcoded to `theme.colors.textSecondary` instead of using the reading theme's `textSecondary`. Added a `dividerColor` prop and passed `readingColors.textSecondary` from `main.tsx`.

## Test plan
- [ ] Settings > Mushaf Settings > tap "Reading Theme" → should navigate to the theme picker screen
- [ ] Change reading theme (e.g., to Parchment or Midnight) → player view background should update to match
- [ ] Surah divider in player view should use reading theme colors
- [ ] Surah divider in mushaf page view (horizontal scroll) should use reading theme colors
- [ ] Mushaf list and continuous views should be unaffected (already working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)