### PR TITLE
fix: iOS 26 backward compatibility for non-glass devices

### DIFF
--- a/app/(tabs)/(a.home)/_layout.tsx
+++ b/app/(tabs)/(a.home)/_layout.tsx
@@ -1,5 +1,5 @@
 import {Stack} from 'expo-router';
-import {Platform} from 'react-native';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 export default function HomeLayout() {
   return (
@@ -20,15 +20,15 @@ export default function HomeLayout() {
         name="reciter/[id]"
         options={{
           title: '',
-          // Android uses custom NavigationButtons; hide native header to avoid clash
-          headerShown: Platform.OS === 'ios',
+          // Non-glass devices use custom NavigationButtons; hide native header to avoid clash
+          headerShown: USE_GLASS,
         }}
       />
       <Stack.Screen
         name="reciter/browse"
         options={{
-          // Android uses custom Header component inside BrowseReciters
-          headerShown: Platform.OS === 'ios',
+          // Non-glass devices use custom Header component inside BrowseReciters
+          headerShown: USE_GLASS,
         }}
       />
       <Stack.Screen name="playlist/[id]" options={{title: ''}} />
@@ -49,8 +49,8 @@ export default function HomeLayout() {
         name="browse-all"
         options={{
           title: 'Browse All',
-          // Android uses custom Header component; hide native header to avoid clash
-          headerShown: Platform.OS === 'ios',
+          // Non-glass devices use custom Header component; hide native header to avoid clash
+          headerShown: USE_GLASS,
         }}
       />
     </Stack>

--- a/app/(tabs)/(a.home)/adhkar/[superId]/index.tsx
+++ b/app/(tabs)/(a.home)/adhkar/[superId]/index.tsx
@@ -11,7 +11,6 @@ import {
   SectionList,
   FlatList,
   Text,
-  Platform,
   ViewToken,
   Pressable,
   StyleSheet,
@@ -24,6 +23,7 @@ import {
 } from 'expo-router';
 import {Ionicons} from '@expo/vector-icons';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import {useAdhkar} from '@/hooks/useAdhkar';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -300,9 +300,13 @@ const SuperCategoryListScreen: React.FC = () => {
         }}
         asChild>
         <Pressable style={StyleSheet.flatten([{flex: 1}])}>
-          <Link.AppleZoom>
+          {USE_GLASS ? (
+            <Link.AppleZoom>
+              <DhikrListItem dhikr={item.dhikr} index={item.index} />
+            </Link.AppleZoom>
+          ) : (
             <DhikrListItem dhikr={item.dhikr} index={item.index} />
-          </Link.AppleZoom>
+          )}
         </Pressable>
       </Link>
     ),
@@ -366,15 +370,15 @@ const SuperCategoryListScreen: React.FC = () => {
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           contentContainerStyle={styles.listContent}
-          contentInset={Platform.OS === 'ios' ? {top: headerHeight} : undefined}
+          contentInset={USE_GLASS ? {top: headerHeight} : undefined}
           contentOffset={
-            Platform.OS === 'ios' ? {x: 0, y: -headerHeight} : undefined
+            USE_GLASS ? {x: 0, y: -headerHeight} : undefined
           }
           scrollIndicatorInsets={
-            Platform.OS === 'ios' ? {top: headerHeight} : undefined
+            USE_GLASS ? {top: headerHeight} : undefined
           }
           style={
-            Platform.OS === 'android' ? {marginTop: headerHeight} : undefined
+            !USE_GLASS ? {marginTop: headerHeight} : undefined
           }
           showsVerticalScrollIndicator={false}
           initialNumToRender={10}
@@ -391,15 +395,15 @@ const SuperCategoryListScreen: React.FC = () => {
           keyExtractor={keyExtractor}
           stickySectionHeadersEnabled={false}
           contentContainerStyle={styles.listContent}
-          contentInset={Platform.OS === 'ios' ? {top: headerHeight} : undefined}
+          contentInset={USE_GLASS ? {top: headerHeight} : undefined}
           contentOffset={
-            Platform.OS === 'ios' ? {x: 0, y: -headerHeight} : undefined
+            USE_GLASS ? {x: 0, y: -headerHeight} : undefined
           }
           scrollIndicatorInsets={
-            Platform.OS === 'ios' ? {top: headerHeight} : undefined
+            USE_GLASS ? {top: headerHeight} : undefined
           }
           style={
-            Platform.OS === 'android' ? {marginTop: headerHeight} : undefined
+            !USE_GLASS ? {marginTop: headerHeight} : undefined
           }
           showsVerticalScrollIndicator={false}
           initialNumToRender={20}

--- a/app/(tabs)/(a.home)/adhkar/saved/index.tsx
+++ b/app/(tabs)/(a.home)/adhkar/saved/index.tsx
@@ -1,5 +1,17 @@
-import React, {useEffect, useState, useCallback, useMemo, useLayoutEffect} from 'react';
-import {View, Text, FlatList, Platform, Pressable, StyleSheet} from 'react-native';
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  useLayoutEffect,
+} from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  StyleSheet,
+} from 'react-native';
 import {useRouter, useNavigation, Link} from 'expo-router';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {Ionicons} from '@expo/vector-icons';
@@ -14,6 +26,7 @@ import {useAdhkar} from '@/hooks/useAdhkar';
 import {useAdhkarPlayAllStore} from '@/store/adhkarPlayAllStore';
 import {useBottomInset} from '@/hooks/useBottomInset';
 import {useHeaderHeight} from '@react-navigation/elements';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 const SavedAdhkarScreen: React.FC = () => {
   const router = useRouter();
@@ -95,7 +108,7 @@ const SavedAdhkarScreen: React.FC = () => {
       headerTintColor: theme.colors.text,
       headerShadowVisible: false,
       headerTitleAlign: 'center',
-      ...(Platform.OS === 'ios'
+      ...(USE_GLASS
         ? {headerBackButtonDisplayMode: 'minimal', headerBackTitle: ' '}
         : {}),
       headerTitle: () => (
@@ -129,7 +142,14 @@ const SavedAdhkarScreen: React.FC = () => {
         </View>
       ),
     });
-  }, [navigation, adhkarList.length, handlePlayAll, isSavedPlaying, isLoading, theme]);
+  }, [
+    navigation,
+    adhkarList.length,
+    handlePlayAll,
+    isSavedPlaying,
+    isLoading,
+    theme,
+  ]);
 
   const renderItem = useCallback(
     ({item, index}: {item: Dhikr; index: number}) => (
@@ -143,9 +163,13 @@ const SavedAdhkarScreen: React.FC = () => {
         }}
         asChild>
         <Pressable style={StyleSheet.flatten([{flex: 1}])}>
-          <Link.AppleZoom>
+          {USE_GLASS ? (
+            <Link.AppleZoom>
+              <DhikrListItem dhikr={item} index={index} />
+            </Link.AppleZoom>
+          ) : (
             <DhikrListItem dhikr={item} index={index} />
-          </Link.AppleZoom>
+          )}
         </Pressable>
       </Link>
     ),
@@ -188,11 +212,20 @@ const SavedAdhkarScreen: React.FC = () => {
         data={adhkarList}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        contentContainerStyle={[styles.listContent, {paddingBottom: bottomInset}]}
-        contentInset={Platform.OS === 'ios' ? {top: headerHeight} : undefined}
-        contentOffset={Platform.OS === 'ios' ? {x: 0, y: -headerHeight} : undefined}
-        scrollIndicatorInsets={Platform.OS === 'ios' ? {top: headerHeight} : undefined}
-        style={Platform.OS === 'android' ? {marginTop: headerHeight} : undefined}
+        contentContainerStyle={[
+          styles.listContent,
+          {paddingBottom: bottomInset},
+        ]}
+        contentInset={USE_GLASS ? {top: headerHeight} : undefined}
+        contentOffset={
+          USE_GLASS ? {x: 0, y: -headerHeight} : undefined
+        }
+        scrollIndicatorInsets={
+          USE_GLASS ? {top: headerHeight} : undefined
+        }
+        style={
+          !USE_GLASS ? {marginTop: headerHeight} : undefined
+        }
         showsVerticalScrollIndicator={false}
         initialNumToRender={10}
         maxToRenderPerBatch={10}

--- a/app/(tabs)/(a.home)/reciter/browse.tsx
+++ b/app/(tabs)/(a.home)/reciter/browse.tsx
@@ -1,7 +1,7 @@
 import React, {useLayoutEffect} from 'react';
 import {useRouter, useLocalSearchParams, useNavigation} from 'expo-router';
-import {Platform} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import BrowseReciters from '@/components/browse/BrowseReciters';
 import {SURAHS} from '@/data/surahData';
 
@@ -29,7 +29,7 @@ export default function BrowseScreen() {
 
   // Set native header title on iOS
   useLayoutEffect(() => {
-    if (Platform.OS === 'ios') {
+    if (USE_GLASS) {
       navigation.setOptions({headerTitle: title});
     }
   }, [navigation, title]);

--- a/app/(tabs)/(b.search)/_layout.tsx
+++ b/app/(tabs)/(b.search)/_layout.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {Platform, View} from 'react-native';
+import {View} from 'react-native';
 import {Stack} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 const EmptyHeaderBackground = () => <View />;
 
@@ -17,7 +18,7 @@ export default function SearchLayout() {
       <Stack.Screen
         name="index"
         options={
-          Platform.OS === 'ios'
+          USE_GLASS
             ? {
                 headerShown: true,
                 headerTransparent: true,
@@ -32,7 +33,7 @@ export default function SearchLayout() {
       <Stack.Screen
         name="browse-all"
         options={{
-          ...(Platform.OS === 'ios'
+          ...(USE_GLASS
             ? {
                 headerShown: true,
                 headerLargeTitle: false,
@@ -51,7 +52,7 @@ export default function SearchLayout() {
       <Stack.Screen
         name="browse-all-surahs"
         options={{
-          ...(Platform.OS === 'ios'
+          ...(USE_GLASS
             ? {
                 headerShown: true,
                 headerTransparent: true,
@@ -69,7 +70,7 @@ export default function SearchLayout() {
       <Stack.Screen
         name="system-playlist/[id]"
         options={{
-          ...(Platform.OS === 'ios'
+          ...(USE_GLASS
             ? {
                 headerShown: true,
                 headerTransparent: true,
@@ -87,7 +88,7 @@ export default function SearchLayout() {
       <Stack.Screen
         name="reciter/[id]"
         options={{
-          ...(Platform.OS === 'ios'
+          ...(USE_GLASS
             ? {
                 headerShown: true,
                 headerTransparent: true,

--- a/app/(tabs)/(c.collection)/_layout.tsx
+++ b/app/(tabs)/(c.collection)/_layout.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import {Platform} from 'react-native';
 import {Stack} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 export default function CollectionLayout() {
   const {theme} = useTheme();
 
   const collectionScreenOptions =
-    Platform.OS === 'ios'
+    USE_GLASS
       ? {
           headerShown: true,
           headerTransparent: true,
@@ -29,7 +29,7 @@ export default function CollectionLayout() {
       <Stack.Screen
         name="index"
         options={
-          Platform.OS === 'ios'
+          USE_GLASS
             ? {title: '', headerBackTitle: ' '}
             : undefined
         }
@@ -37,7 +37,7 @@ export default function CollectionLayout() {
       <Stack.Screen
         name="reciter/[id]"
         options={{
-          ...(Platform.OS === 'ios'
+          ...(USE_GLASS
             ? {
                 headerShown: true,
                 headerTransparent: true,

--- a/app/(tabs)/(c.collection)/collection/bookmarks.tsx
+++ b/app/(tabs)/(c.collection)/collection/bookmarks.tsx
@@ -5,10 +5,10 @@ import {
   Pressable,
   StyleSheet,
   StatusBar,
-  Platform,
   Animated as RNAnimated,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {useFocusEffect} from '@react-navigation/native';
@@ -103,7 +103,7 @@ const BookmarksScreen = () => {
   const ListHeaderComponent = useCallback(() => {
     return (
       <View style={styles.headerContainer}>
-        <View style={{paddingTop: Platform.OS === 'ios' ? 0 : insets.top}} />
+        <View style={{paddingTop: USE_GLASS ? 0 : insets.top}} />
         <View style={styles.headerContent}>
           <View
             style={[styles.heroIconContainer, {backgroundColor: heroOuterBg}]}>
@@ -162,7 +162,7 @@ const BookmarksScreen = () => {
     return (
       <View
         style={[styles.container, {backgroundColor: theme.colors.background}]}>
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
             <Pressable
               style={styles.emptyHeaderBack}
@@ -194,7 +194,7 @@ const BookmarksScreen = () => {
     return (
       <View
         style={[styles.container, {backgroundColor: theme.colors.background}]}>
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
             <Pressable
               style={styles.emptyHeaderBack}
@@ -237,7 +237,7 @@ const BookmarksScreen = () => {
       style={[styles.container, {backgroundColor: theme.colors.background}]}>
       <StatusBar barStyle="default" />
 
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <RNAnimated.View
           style={[
             styles.fixedBackButton,
@@ -274,7 +274,7 @@ const BookmarksScreen = () => {
         showsVerticalScrollIndicator={false}
         contentInsetAdjustmentBehavior="automatic"
       />
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <CollectionStickyHeader title="Bookmarks" scrollY={scrollY} />
       )}
     </View>

--- a/app/(tabs)/(c.collection)/collection/downloads.tsx
+++ b/app/(tabs)/(c.collection)/collection/downloads.tsx
@@ -6,9 +6,9 @@ import {
   StyleSheet,
   ListRenderItem,
   Animated as RNAnimated,
-  Platform,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {TrackItem} from '@/components/TrackItem';
@@ -110,7 +110,7 @@ export default function DownloadsScreen() {
         contentArea: {
           width: '100%',
           alignItems: 'center',
-          paddingTop: Platform.OS === 'ios' ? moderateScale(16) : insets.top + moderateScale(40),
+          paddingTop: USE_GLASS ? moderateScale(16) : insets.top + moderateScale(40),
           paddingBottom: moderateScale(10),
           overflow: 'hidden',
           backgroundColor: theme.colors.background,
@@ -471,7 +471,7 @@ export default function DownloadsScreen() {
   if (downloads.length === 0) {
     return (
       <View style={styles.container}>
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
             <Pressable
               style={styles.emptyHeaderBack}
@@ -527,7 +527,7 @@ export default function DownloadsScreen() {
         </View>
 
         <View style={styles.actionButtons}>
-          {Platform.OS !== 'ios' && (
+          {!USE_GLASS && (
             <Pressable
               style={[
                 styles.circleButton,
@@ -607,7 +607,7 @@ export default function DownloadsScreen() {
 
   return (
     <View style={styles.container}>
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <RNAnimated.View
           style={[
             styles.fixedBackButton,
@@ -647,7 +647,7 @@ export default function DownloadsScreen() {
         showsVerticalScrollIndicator={false}
         contentInsetAdjustmentBehavior="automatic"
       />
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <CollectionStickyHeader title="Downloads" scrollY={scrollY} />
       )}
     </View>

--- a/app/(tabs)/(c.collection)/collection/favorite-reciters.tsx
+++ b/app/(tabs)/(c.collection)/collection/favorite-reciters.tsx
@@ -5,7 +5,6 @@ import {
   Pressable,
   StyleSheet,
   Animated as RNAnimated,
-  Platform,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -21,6 +20,7 @@ import Color from 'color';
 import {Reciter} from '@/data/reciterData';
 import {SheetManager} from 'react-native-actions-sheet';
 import {useCollectionNativeHeader} from '@/hooks/useCollectionNativeHeader';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 export default function FavoriteRecitersScreen() {
   const {theme} = useTheme();
@@ -79,7 +79,7 @@ export default function FavoriteRecitersScreen() {
         contentArea: {
           width: '100%',
           alignItems: 'center',
-          paddingTop: Platform.OS === 'ios' ? moderateScale(16) : insets.top + moderateScale(40),
+          paddingTop: USE_GLASS ? moderateScale(16) : insets.top + moderateScale(40),
           paddingBottom: moderateScale(30),
           overflow: 'hidden',
           backgroundColor: theme.colors.background,
@@ -272,7 +272,7 @@ export default function FavoriteRecitersScreen() {
   if (favoriteReciters.length === 0) {
     return (
       <View style={styles.container}>
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
             <Pressable
               style={styles.emptyHeaderBack}
@@ -371,7 +371,7 @@ export default function FavoriteRecitersScreen() {
 
   return (
     <View style={styles.container}>
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <RNAnimated.View
           style={[
             styles.fixedBackButton,
@@ -393,7 +393,7 @@ export default function FavoriteRecitersScreen() {
         </RNAnimated.View>
       )}
 
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <RNAnimated.View
           style={[
             styles.fixedSearchToggle,
@@ -434,7 +434,7 @@ export default function FavoriteRecitersScreen() {
         showsVerticalScrollIndicator={false}
         contentInsetAdjustmentBehavior="automatic"
       />
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <CollectionStickyHeader title="Favorite Reciters" scrollY={scrollY} />
       )}
     </View>

--- a/app/(tabs)/(c.collection)/collection/loved.tsx
+++ b/app/(tabs)/(c.collection)/collection/loved.tsx
@@ -6,10 +6,10 @@ import {
   StyleSheet,
   Alert,
   StatusBar,
-  Platform,
   Animated as RNAnimated,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {TrackItem} from '@/components/TrackItem';
@@ -623,7 +623,7 @@ const LovedScreen = () => {
         }`}
         onPlayPress={handlePlayAll}
         onShufflePress={handleShuffle}
-        onOptionsPress={Platform.OS === 'ios' ? undefined : handleOptionsMenu}
+        onOptionsPress={USE_GLASS ? undefined : handleOptionsMenu}
         theme={theme}
       />
     );
@@ -666,7 +666,7 @@ const LovedScreen = () => {
   if (loading) {
     return (
       <View style={styles.container}>
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
             <Pressable
               style={styles.emptyHeaderBack}
@@ -692,7 +692,7 @@ const LovedScreen = () => {
   if (lovedData.length === 0) {
     return (
       <View style={styles.container}>
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
             <Pressable
               style={styles.emptyHeaderBack}
@@ -727,7 +727,7 @@ const LovedScreen = () => {
     <View style={styles.container}>
       <StatusBar barStyle="default" />
 
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <RNAnimated.View
           style={[
             styles.fixedBackButton,
@@ -763,7 +763,7 @@ const LovedScreen = () => {
         scrollEventThrottle={16}
         showsVerticalScrollIndicator={false}
       />
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <CollectionStickyHeader title="Loved" scrollY={scrollY} />
       )}
     </View>

--- a/app/(tabs)/(c.collection)/collection/notes.tsx
+++ b/app/(tabs)/(c.collection)/collection/notes.tsx
@@ -5,10 +5,10 @@ import {
   Pressable,
   StyleSheet,
   StatusBar,
-  Platform,
   Animated as RNAnimated,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {useFocusEffect} from '@react-navigation/native';
@@ -123,7 +123,7 @@ const NotesScreen = () => {
   const ListHeaderComponent = useCallback(() => {
     return (
       <View style={styles.headerContainer}>
-        <View style={{paddingTop: Platform.OS === 'ios' ? 0 : insets.top}} />
+        <View style={{paddingTop: USE_GLASS ? 0 : insets.top}} />
         <View style={styles.headerContent}>
           <View
             style={[styles.heroIconContainer, {backgroundColor: heroOuterBg}]}>
@@ -170,7 +170,7 @@ const NotesScreen = () => {
     return (
       <View
         style={[styles.container, {backgroundColor: theme.colors.background}]}>
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
             <Pressable
               style={styles.emptyHeaderBack}
@@ -202,7 +202,7 @@ const NotesScreen = () => {
     return (
       <View
         style={[styles.container, {backgroundColor: theme.colors.background}]}>
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
             <Pressable
               style={styles.emptyHeaderBack}
@@ -245,7 +245,7 @@ const NotesScreen = () => {
       style={[styles.container, {backgroundColor: theme.colors.background}]}>
       <StatusBar barStyle="default" />
 
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <RNAnimated.View
           style={[
             styles.fixedBackButton,
@@ -282,7 +282,7 @@ const NotesScreen = () => {
         showsVerticalScrollIndicator={false}
         contentInsetAdjustmentBehavior="automatic"
       />
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <CollectionStickyHeader title="Notes" scrollY={scrollY} />
       )}
     </View>

--- a/app/(tabs)/(c.collection)/collection/playlists.tsx
+++ b/app/(tabs)/(c.collection)/collection/playlists.tsx
@@ -5,9 +5,9 @@ import {
   Pressable,
   StyleSheet,
   Animated as RNAnimated,
-  Platform,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {PlaylistItem} from '@/components/PlaylistItem';
 import {useRouter} from 'expo-router';
@@ -54,7 +54,7 @@ export default function PlaylistsScreen() {
         contentArea: {
           width: '100%',
           alignItems: 'center',
-          paddingTop: Platform.OS === 'ios' ? moderateScale(16) : insets.top + moderateScale(40),
+          paddingTop: USE_GLASS ? moderateScale(16) : insets.top + moderateScale(40),
           paddingBottom: moderateScale(30),
           overflow: 'hidden',
           backgroundColor: theme.colors.background,
@@ -258,7 +258,7 @@ export default function PlaylistsScreen() {
   if (playlists.length === 0) {
     return (
       <View style={styles.container}>
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
             <Pressable
               style={styles.emptyHeaderBack}
@@ -335,7 +335,7 @@ export default function PlaylistsScreen() {
 
   return (
     <View style={styles.container}>
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <RNAnimated.View
           style={[
             styles.fixedBackButton,
@@ -371,7 +371,7 @@ export default function PlaylistsScreen() {
         showsVerticalScrollIndicator={false}
         contentInsetAdjustmentBehavior="automatic"
       />
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <CollectionStickyHeader title="Playlists" scrollY={scrollY} />
       )}
     </View>

--- a/app/(tabs)/(c.collection)/collection/uploads.tsx
+++ b/app/(tabs)/(c.collection)/collection/uploads.tsx
@@ -7,9 +7,9 @@ import {
   ListRenderItemInfo,
   ActivityIndicator,
   Animated as RNAnimated,
-  Platform,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {moderateScale} from 'react-native-size-matters';
@@ -376,7 +376,7 @@ export default function UploadsScreen() {
   if (!hasRecitations) {
     return (
       <View style={styles.container}>
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <View style={[styles.emptyHeader, {paddingTop: insets.top}]}>
             <Pressable
               style={styles.emptyHeaderBack}
@@ -434,7 +434,7 @@ export default function UploadsScreen() {
         <View
           style={[
             styles.contentArea,
-            {paddingTop: Platform.OS === 'ios' ? moderateScale(16) : insets.top + moderateScale(40)},
+            {paddingTop: USE_GLASS ? moderateScale(16) : insets.top + moderateScale(40)},
           ]}>
           {/* Hero Icon */}
           <View style={styles.contentCenter}>
@@ -455,7 +455,7 @@ export default function UploadsScreen() {
 
         {/* Action Buttons */}
         <View style={styles.actionButtons}>
-          {Platform.OS !== 'ios' && (
+          {!USE_GLASS && (
             <Pressable
               style={[
                 styles.circleButton,
@@ -523,7 +523,7 @@ export default function UploadsScreen() {
 
   return (
     <View style={styles.container}>
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <RNAnimated.View
           style={[
             styles.fixedBackButton,
@@ -562,7 +562,7 @@ export default function UploadsScreen() {
         scrollEventThrottle={16}
         contentInsetAdjustmentBehavior="automatic"
       />
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <CollectionStickyHeader title="Uploads" scrollY={scrollY} />
       )}
     </View>

--- a/app/(tabs)/(c.collection)/index.tsx
+++ b/app/(tabs)/(c.collection)/index.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {View, ScrollView, Text, Pressable, Platform} from 'react-native';
+import {View, ScrollView, Text, Pressable} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
@@ -24,6 +24,7 @@ import {useUploadsStore} from '@/store/uploadsStore';
 import {useFocusEffect} from '@react-navigation/native';
 import {verseAnnotationService} from '@/services/verse-annotations/VerseAnnotationService';
 import {useBottomInset} from '@/hooks/useBottomInset';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface CategoryItem {
   id: string;
@@ -148,12 +149,12 @@ export default function CollectionScreen() {
         scrollEventThrottle={16}
         showsVerticalScrollIndicator={false}
         contentInsetAdjustmentBehavior={
-          Platform.OS === 'ios' ? 'automatic' : 'never'
+          USE_GLASS ? 'automatic' : 'never'
         }
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={{
           paddingTop:
-            Platform.OS === 'ios'
+            USE_GLASS
               ? moderateScale(16)
               : insets.top + moderateScale(16),
         }}>

--- a/app/(tabs)/(d.settings)/_layout.tsx
+++ b/app/(tabs)/(d.settings)/_layout.tsx
@@ -1,6 +1,6 @@
-import {Platform} from 'react-native';
 import {Stack} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 export default function SettingsLayout() {
   const {theme} = useTheme();
@@ -11,7 +11,7 @@ export default function SettingsLayout() {
         headerShown: true,
         freezeOnBlur: true,
         headerTintColor: theme.colors.text,
-        ...(Platform.OS === 'ios'
+        ...(USE_GLASS
           ? {
               headerTransparent: true,
               headerStyle: {backgroundColor: 'transparent'},

--- a/app/(tabs)/(d.settings)/default-reciter.tsx
+++ b/app/(tabs)/(d.settings)/default-reciter.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useCallback, useMemo} from 'react';
-import {View, Text, FlatList, Platform} from 'react-native';
+import {View, Text, FlatList} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {
   ScaledSheet,
@@ -15,6 +15,7 @@ import {useReciterStore} from '@/store/reciterStore';
 import {useRouter} from 'expo-router';
 import {ReciterImage} from '@/components/ReciterImage';
 import {useHeaderHeight} from '@react-navigation/elements';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 export default function DefaultReciterScreen() {
   const [searchQuery, setSearchQuery] = useState('');
@@ -25,7 +26,7 @@ export default function DefaultReciterScreen() {
   const setDefaultReciter = useReciterStore(state => state.setDefaultReciter);
   const router = useRouter();
   const rawHeaderHeight = useHeaderHeight();
-  const headerHeight = Platform.OS === 'ios' ? rawHeaderHeight : 0;
+  const headerHeight = USE_GLASS ? rawHeaderHeight : 0;
 
   const hasCompleteQuran = useCallback((reciter: Reciter) => {
     return reciter.rewayat.some(

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -40,6 +40,7 @@ import {useUploadsStore} from '@/store/uploadsStore';
 import {SheetManager} from 'react-native-actions-sheet';
 import {showToast} from '@/utils/toastUtils';
 import {mushafSessionStore} from '@/services/mushaf/MushafSessionStore';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 // Configure Reanimated logger
 configureReanimatedLogger({
@@ -395,7 +396,7 @@ export default function RootLayout() {
                   <Stack.Screen
                     name="mushaf"
                     options={{
-                      headerShown: Platform.OS === 'ios',
+                      headerShown: USE_GLASS,
                       headerTransparent: true,
                       headerStyle: {backgroundColor: 'transparent'},
                       headerShadowVisible: false,

--- a/app/mushaf.tsx
+++ b/app/mushaf.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useMemo, useCallback} from 'react';
-import {View, ActivityIndicator, StyleSheet, Platform} from 'react-native';
+import {View, ActivityIndicator, StyleSheet} from 'react-native';
 import {Stack, useLocalSearchParams} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
@@ -10,6 +10,7 @@ import {mushafAudioService} from '@/services/audio/MushafAudioService';
 import {SheetManager} from 'react-native-actions-sheet';
 import {SURAHS} from '@/data/surahData';
 import MushafViewer from '@/components/mushaf/main';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 export type MushafScreenParams = {
   surah?: string;
@@ -87,7 +88,7 @@ export default function MushafScreen() {
   return (
     <View
       style={[styles.container, {backgroundColor: theme.colors.background}]}>
-      {Platform.OS === 'ios' && <MushafToolbar />}
+      {USE_GLASS && <MushafToolbar />}
       <MushafViewer pageNumber={pageNumber} initialVerseKey={initialVerseKey} />
     </View>
   );

--- a/components/BottomTabBar.tsx
+++ b/components/BottomTabBar.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/utils/constants';
 import {GlassView} from 'expo-glass-effect';
 import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
+import {FrostedView} from '@/components/FrostedView';
 
 function getIcon(
   routeName: string,
@@ -101,13 +102,8 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({
       bottom: insets.bottom + FLOATING_TAB_BAR_BOTTOM_MARGIN,
       left: FLOATING_UI_HORIZONTAL_MARGIN,
       right: FLOATING_UI_HORIZONTAL_MARGIN,
-      backgroundColor: USE_GLASS
-        ? 'transparent'
-        : Color(theme.colors.background)
-            .mix(Color(theme.colors.text), 0.08)
-            .alpha(0.92)
-            .toString(),
       borderRadius: moderateScale(24),
+      overflow: 'hidden' as const,
       borderWidth: USE_GLASS ? 0 : 1,
       borderColor: USE_GLASS
         ? undefined
@@ -139,7 +135,7 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({
     [state.index, navigation],
   );
 
-  const Container = USE_GLASS ? GlassView : View;
+  const Container = USE_GLASS ? GlassView : FrostedView;
 
   return (
     <Container

--- a/components/FrostedView.tsx
+++ b/components/FrostedView.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {Platform, View, ViewProps, StyleSheet} from 'react-native';
+import {BlurView} from 'expo-blur';
+import {useTheme} from '@/hooks/useTheme';
+
+type FrostedViewProps = ViewProps & {
+  children?: React.ReactNode;
+};
+
+/**
+ * Frosted glass fallback for non-liquid-glass devices.
+ * iOS: BlurView with frosted effect.
+ * Android: solid View with theme card background.
+ */
+export function FrostedView({style, children, ...rest}: FrostedViewProps) {
+  const {theme} = useTheme();
+
+  if (Platform.OS === 'ios') {
+    return (
+      <BlurView
+        style={style}
+        intensity={80}
+        tint={theme.isDarkMode ? 'dark' : 'light'}
+        {...rest}>
+        {children}
+      </BlurView>
+    );
+  }
+
+  return (
+    <View
+      style={StyleSheet.flatten([{backgroundColor: theme.colors.card}, style])}
+      {...rest}>
+      {children}
+    </View>
+  );
+}

--- a/components/browse/BrowseReciterCard.tsx
+++ b/components/browse/BrowseReciterCard.tsx
@@ -141,9 +141,7 @@ const BrowseReciterCard = React.memo(
     return (
       <Link href={linkHref} asChild>
         <Pressable onLongPress={onLongPress} style={styles.container}>
-          <Link.AppleZoom>
-            <View style={{flex: 1}}>{content}</View>
-          </Link.AppleZoom>
+          {content}
         </Pressable>
       </Link>
     );

--- a/components/browse/BrowseReciters.tsx
+++ b/components/browse/BrowseReciters.tsx
@@ -7,7 +7,6 @@ import {
   ScrollView,
   Keyboard,
   TouchableWithoutFeedback,
-  Platform,
 } from 'react-native';
 import Animated, {
   FadeIn,
@@ -35,6 +34,7 @@ import {useSettings} from '@/hooks/useSettings';
 import {QIRAAT_TEACHERS, resolveRewayatName} from '@/data/rewayat';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useHeaderHeight} from '@react-navigation/elements';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface BrowseRecitersProps {
   theme: Theme;
@@ -116,7 +116,7 @@ export default function BrowseReciters({
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   // On iOS, the native Stack header handles the top area; on Android, use custom Header
-  const useNativeHeader = Platform.OS === 'ios';
+  const useNativeHeader = USE_GLASS;
   const iosHeaderHeight = useNativeHeader ? useHeaderHeight() : 0;
 
   const [selectedTeacher, setSelectedTeacher] = useState<string | null>(

--- a/components/browse/BrowseSurahs.tsx
+++ b/components/browse/BrowseSurahs.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useMemo, useCallback, useLayoutEffect} from 'react';
-import {View, FlatList, Text, Platform, Pressable} from 'react-native';
+import {View, FlatList, Text, Pressable} from 'react-native';
 import {useRouter, useNavigation} from 'expo-router';
 import {
   moderateScale,
@@ -25,7 +25,7 @@ import {useHeaderHeight} from '@react-navigation/elements';
 import {GlassView} from 'expo-glass-effect';
 import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 
-const isIOS = Platform.OS === 'ios';
+const isGlass = USE_GLASS;
 
 // Define types for clarity, matching the ones in useSettings
 type ViewMode = 'card' | 'list';
@@ -160,7 +160,7 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
   const navigation = useNavigation();
   const glassColorScheme = useGlassColorScheme();
   const insets = useSafeAreaInsets();
-  const iosHeaderHeight = isIOS ? useHeaderHeight() : 0;
+  const iosHeaderHeight = isGlass ? useHeaderHeight() : 0;
   const {askEveryTime, defaultReciterSelection} = useSettings();
   const defaultReciter = useReciterStore(state => state.defaultReciter);
   const {playWithReciter, playWithRandomReciter} = useReciterSelection();
@@ -176,7 +176,7 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
 
   // iOS: set native header title
   useLayoutEffect(() => {
-    if (!isIOS) return;
+    if (!isGlass) return;
     navigation.setOptions({
       headerTitle: 'All Surahs',
     });
@@ -469,18 +469,18 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
     <View
       style={[styles.container, {backgroundColor: theme.colors.background}]}>
       {/* Android: custom header | iOS: native header via layout */}
-      {!isIOS && <Header title="All Surahs" onBack={onBack} showBlur={true} />}
+      {!isGlass && <Header title="All Surahs" onBack={onBack} showBlur={true} />}
 
       <View
         style={[
           styles.content,
-          !isIOS && {marginTop: insets.top + moderateScale(56)},
+          !isGlass && {marginTop: insets.top + moderateScale(56)},
         ]}>
         {/* Android: inline options row (normal flow) */}
-        {!isIOS && renderOptionsRow()}
+        {!isGlass && renderOptionsRow()}
 
         {/* iOS: floating sticky options bar below native header */}
-        {isIOS && (
+        {isGlass && (
           <View style={[styles.stickyBarContainer, {top: iosHeaderHeight}]}>
             {renderOptionsRow()}
           </View>
@@ -499,11 +499,11 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
               data={displaySurahs}
               renderItem={renderCardItem}
               keyExtractor={item => `card-${item.id}`}
-              contentInsetAdjustmentBehavior={isIOS ? 'automatic' : 'never'}
+              contentInsetAdjustmentBehavior={isGlass ? 'automatic' : 'never'}
               contentContainerStyle={[
                 styles.listContent,
                 styles.scrollContent,
-                isIOS && {paddingTop: stickyBarTotalHeight},
+                isGlass && {paddingTop: stickyBarTotalHeight},
               ]}
               numColumns={2}
               columnWrapperStyle={styles.columnWrapper}
@@ -525,12 +525,12 @@ export default function BrowseSurahs({theme, onBack}: BrowseSurahsProps) {
                   ? `juz-${item.juzNumber}`
                   : `list-${item.surah.id}-${index}`
               }
-              contentInsetAdjustmentBehavior={isIOS ? 'automatic' : 'never'}
+              contentInsetAdjustmentBehavior={isGlass ? 'automatic' : 'never'}
               contentContainerStyle={[
                 styles.listContent,
                 styles.listViewContent,
                 styles.scrollContent,
-                isIOS && {paddingTop: stickyBarTotalHeight},
+                isGlass && {paddingTop: stickyBarTotalHeight},
               ]}
               numColumns={1}
               {...flatListProps}

--- a/components/cards/CircularReciterCard.tsx
+++ b/components/cards/CircularReciterCard.tsx
@@ -13,6 +13,7 @@ import {ReciterImage} from '@/components/ReciterImage';
 import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {Link} from 'expo-router';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface CircularReciterCardProps {
   imageUrl?: string;
@@ -162,6 +163,14 @@ export const CircularReciterCard: React.FC<CircularReciterCardProps> = ({
   );
 
   if (useZoom) {
+    const inner = USE_GLASS ? (
+      <Link.AppleZoom>
+        <View style={{flex: 1}}>{content}</View>
+      </Link.AppleZoom>
+    ) : (
+      content
+    );
+
     return (
       <Link
         href={{
@@ -170,9 +179,7 @@ export const CircularReciterCard: React.FC<CircularReciterCardProps> = ({
         }}
         asChild>
         <Pressable onLongPress={onLongPress} style={styles.container}>
-          <Link.AppleZoom>
-            <View style={{flex: 1}}>{content}</View>
-          </Link.AppleZoom>
+          {inner}
         </Pressable>
       </Link>
     );

--- a/components/cards/PlaylistCard.tsx
+++ b/components/cards/PlaylistCard.tsx
@@ -6,6 +6,7 @@ import {PlaylistIcon} from '@/components/Icons';
 import Color from 'color';
 import {Link} from 'expo-router';
 import {LinearGradient} from 'expo-linear-gradient';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface PlaylistCardProps {
   name: string;
@@ -120,7 +121,11 @@ export const PlaylistCard: React.FC<PlaylistCardProps> = ({
         }}
         asChild>
         <Pressable onLongPress={onLongPress}>
-          <Link.AppleZoom>{cardContent}</Link.AppleZoom>
+          {USE_GLASS ? (
+            <Link.AppleZoom>{cardContent}</Link.AppleZoom>
+          ) : (
+            cardContent
+          )}
         </Pressable>
       </Link>
     );

--- a/components/cards/RecentReciterCard.tsx
+++ b/components/cards/RecentReciterCard.tsx
@@ -288,14 +288,23 @@ export const RecentReciterCard = ({
           }}
           asChild>
           <Pressable onLongPress={handleLongPress}>
-            <Link.AppleZoom>
+            {USE_GLASS ? (
+              <Link.AppleZoom>
+                <ReciterImage
+                  imageUrl={imageUrl}
+                  reciterName={reciterName}
+                  style={styles.image}
+                  profileIconSize={moderateScale(40)}
+                />
+              </Link.AppleZoom>
+            ) : (
               <ReciterImage
                 imageUrl={imageUrl}
                 reciterName={reciterName}
                 style={styles.image}
                 profileIconSize={moderateScale(40)}
               />
-            </Link.AppleZoom>
+            )}
           </Pressable>
         </Link>
       </View>

--- a/components/cards/RewayatCard.tsx
+++ b/components/cards/RewayatCard.tsx
@@ -75,11 +75,7 @@ function RewayatCard({
 
   return (
     <Link href={linkHref} asChild>
-      <Pressable style={styles.container}>
-        <Link.AppleZoom>
-          <View style={{flex: 1}}>{content}</View>
-        </Link.AppleZoom>
-      </Pressable>
+      <Pressable style={styles.container}>{content}</Pressable>
     </Link>
   );
 }

--- a/components/mushaf/main.tsx
+++ b/components/mushaf/main.tsx
@@ -22,7 +22,8 @@ import {useReadingThemeColors} from '@/hooks/useReadingThemeColors';
 import {Ionicons} from '@expo/vector-icons';
 import {SheetManager} from 'react-native-actions-sheet';
 import {GlassView} from 'expo-glass-effect';
-import {useGlassColorScheme} from '@/hooks/useGlassProps';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
+import {FrostedView} from '@/components/FrostedView';
 import {BackButton} from '@/components/BackButton';
 import MushafSearchView from './MushafSearchView';
 import {moderateScale} from 'react-native-size-matters';
@@ -262,10 +263,10 @@ export default function MushafViewer({
     },
     [isSearchMode],
   );
-  // iOS: sync search mode from store (toolbar search button sets store directly)
+  // iOS 26: sync search mode from store (toolbar search button sets store directly)
   const storeSearchMode = useMushafPlayerStore(s => s.isSearchMode);
   useEffect(() => {
-    if (Platform.OS !== 'ios') return;
+    if (!USE_GLASS) return;
     if (storeSearchMode !== isSearchMode) {
       setIsSearchModeRaw(storeSearchMode);
       // Toolbar search button always means "search with focus"
@@ -328,9 +329,9 @@ export default function MushafViewer({
 
   const currentSurahId = pageToSurah[currentPage] || 1;
 
-  // iOS: configure Stack navigator header based on current mode
+  // iOS 26: configure Stack navigator header based on current mode
   useEffect(() => {
-    if (Platform.OS !== 'ios') return;
+    if (!USE_GLASS) return;
 
     if (isImmersive || isSearchMode) {
       // Hide native header — search overlay renders its own UI
@@ -341,20 +342,27 @@ export default function MushafViewer({
       return;
     }
 
-    // Normal mode: GlassView title + options button
+    // Normal mode: Glass/blur title + options button
+    const TitleWrapper = USE_GLASS ? GlassView : FrostedView;
+    const titleWrapperProps = USE_GLASS
+      ? {
+          glassEffectStyle: 'regular' as const,
+          colorScheme: glassColorScheme,
+          tintColor: isDarkMode ? 'rgba(0,0,0,0.5)' : undefined,
+        }
+      : {};
     navigation.setOptions({
       headerShown: true,
       headerBackVisible: true,
       headerSearchBarOptions: undefined,
       headerTitle: () => (
-        <GlassView
-          glassEffectStyle="regular"
-          colorScheme={glassColorScheme}
-          tintColor={isDarkMode ? 'rgba(0,0,0,0.5)' : undefined}
+        <TitleWrapper
+          {...titleWrapperProps}
           style={{
             borderRadius: moderateScale(14),
             paddingHorizontal: moderateScale(14),
             paddingVertical: moderateScale(6),
+            overflow: 'hidden' as const,
           }}>
           <Pressable
             onPress={() => setIsSearchMode(true)}
@@ -391,7 +399,7 @@ export default function MushafViewer({
               Page {currentPage} · Juz {getJuzForPage(currentPage)}
             </Text>
           </Pressable>
-        </GlassView>
+        </TitleWrapper>
       ),
       headerLeft: undefined,
       headerRight: () => (
@@ -691,8 +699,8 @@ export default function MushafViewer({
 
       {!isSearchMode && (
         <>
-          {/* Android: custom header (iOS uses Stack navigator header from _layout) */}
-          {Platform.OS === 'android' && (
+          {/* Non-glass: custom header (iOS 26 uses Stack navigator header) */}
+          {!USE_GLASS && (
             <Animated.View
               style={[
                 styles.header,
@@ -774,9 +782,9 @@ export default function MushafViewer({
           )}
 
           {/* ================================================================ */}
-          {/* Normal mode bottom bar — Android only (iOS uses Stack.Toolbar)  */}
+          {/* Normal mode bottom bar — non-glass (iOS 26 uses Stack.Toolbar)  */}
           {/* ================================================================ */}
-          {Platform.OS === 'android' && (
+          {!USE_GLASS && (
             <Animated.View
               style={[
                 styles.bottomBar,

--- a/components/player/v2/FloatingPlayer/index.tsx
+++ b/components/player/v2/FloatingPlayer/index.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/utils/constants';
 import {GlassView} from 'expo-glass-effect';
 import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
+import {FrostedView} from '@/components/FrostedView';
 
 export const FloatingPlayer: React.FC = React.memo(function FloatingPlayer() {
   const {theme} = useTheme();
@@ -65,13 +66,8 @@ export const FloatingPlayer: React.FC = React.memo(function FloatingPlayer() {
       bottom: getFloatingPlayerBottomPosition(insets.bottom),
       left: FLOATING_UI_HORIZONTAL_MARGIN,
       right: FLOATING_UI_HORIZONTAL_MARGIN,
-      backgroundColor: USE_GLASS
-        ? 'transparent'
-        : Color(theme.colors.background)
-            .mix(Color(theme.colors.text), 0.08)
-            .alpha(0.92)
-            .toString(),
       borderRadius: moderateScale(20),
+      overflow: 'hidden' as const,
       borderWidth: USE_GLASS ? 0 : 1,
       borderColor: USE_GLASS
         ? undefined
@@ -92,7 +88,7 @@ export const FloatingPlayer: React.FC = React.memo(function FloatingPlayer() {
     .alpha(0.45)
     .toString();
 
-  const Container = USE_GLASS ? GlassView : View;
+  const Container = USE_GLASS ? GlassView : FrostedView;
 
   return (
     <Container

--- a/components/player/v2/PlayerContent/ControlButtons/index.tsx
+++ b/components/player/v2/PlayerContent/ControlButtons/index.tsx
@@ -8,7 +8,8 @@ import {
   TextStyle,
 } from 'react-native';
 import {GlassView} from 'expo-glass-effect';
-import {useGlassColorScheme} from '@/hooks/useGlassProps';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
+import {FrostedView} from '@/components/FrostedView';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
 import {usePlayerActions} from '@/hooks/usePlayerActions';
@@ -86,14 +87,19 @@ export const ControlButtons: React.FC<ControlButtonsProps> = ({
   const defaultIconColor = theme.colors.text;
   const activeIconColor = theme.colors.text;
 
+  const PillWrapper = USE_GLASS ? GlassView : FrostedView;
+  const pillProps = USE_GLASS
+    ? {
+        glassEffectStyle: 'regular' as const,
+        colorScheme: glassColorScheme,
+        isInteractive: true,
+      }
+    : {};
+
   return (
     <View style={styles.wrapper}>
       {onMushafLayoutPress && (
-        <GlassView
-          style={styles.glassButton}
-          glassEffectStyle="regular"
-          colorScheme={glassColorScheme}
-          isInteractive>
+        <PillWrapper style={styles.glassButton} {...pillProps}>
           <Pressable
             onPress={handleMushafLayoutPress}
             style={styles.glassButtonInner}>
@@ -103,7 +109,7 @@ export const ControlButtons: React.FC<ControlButtonsProps> = ({
               color={defaultIconColor}
             />
           </Pressable>
-        </GlassView>
+        </PillWrapper>
       )}
 
       <Pressable
@@ -190,18 +196,14 @@ export const ControlButtons: React.FC<ControlButtonsProps> = ({
         />
       </Pressable>
 
-      <GlassView
-        style={styles.glassButton}
-        glassEffectStyle="regular"
-        colorScheme={glassColorScheme}
-        isInteractive>
+      <PillWrapper style={styles.glassButton} {...pillProps}>
         <Pressable onPress={onQueuePress} style={styles.glassButtonInner}>
           <QueueIcon
             size={moderateScale(20)}
             color={showQueue ? activeIconColor : defaultIconColor}
           />
         </Pressable>
-      </GlassView>
+      </PillWrapper>
     </View>
   );
 };
@@ -226,6 +228,7 @@ const styles = StyleSheet.create<Styles>({
     width: moderateScale(44),
     height: moderateScale(44),
     borderRadius: moderateScale(22),
+    overflow: 'hidden',
   },
   glassButtonInner: {
     flex: 1,

--- a/components/player/v2/PlayerContent/Header.tsx
+++ b/components/player/v2/PlayerContent/Header.tsx
@@ -1,9 +1,11 @@
 import React, {useMemo} from 'react';
 import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {GlassView} from 'expo-glass-effect';
-import {useGlassColorScheme} from '@/hooks/useGlassProps';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
+import {FrostedView} from '@/components/FrostedView';
 import {moderateScale} from 'react-native-size-matters';
 import {SymbolView} from 'expo-symbols';
+import {Entypo, Feather} from '@expo/vector-icons';
 import {
   Canvas,
   Paragraph,
@@ -113,39 +115,56 @@ export const Header: React.FC<HeaderProps> = ({onOptionsPress}) => {
     return null;
   };
 
+  const PillWrapper = USE_GLASS ? GlassView : FrostedView;
+  const pillProps = USE_GLASS
+    ? {
+        glassEffectStyle: 'regular' as const,
+        colorScheme: glassColorScheme,
+        isInteractive: true,
+      }
+    : {};
+
   return (
     <View style={styles.header}>
-      <GlassView
-        style={styles.closeButton}
-        glassEffectStyle="regular"
-        colorScheme={glassColorScheme}
-        isInteractive>
+      <PillWrapper style={styles.closeButton} {...pillProps}>
         <Pressable style={styles.glassButtonInner} onPress={handleClose}>
-          <SymbolView
-            name="xmark"
-            size={moderateScale(18)}
-            tintColor={theme.colors.text}
-            weight="medium"
-          />
+          {USE_GLASS ? (
+            <SymbolView
+              name="xmark"
+              size={moderateScale(18)}
+              tintColor={theme.colors.text}
+              weight="medium"
+            />
+          ) : (
+            <Entypo
+              name="chevron-thin-down"
+              size={moderateScale(18)}
+              color={theme.colors.text}
+            />
+          )}
         </Pressable>
-      </GlassView>
+      </PillWrapper>
 
       {renderSurahName()}
 
-      <GlassView
-        style={styles.optionsButton}
-        glassEffectStyle="regular"
-        colorScheme={glassColorScheme}
-        isInteractive>
+      <PillWrapper style={styles.optionsButton} {...pillProps}>
         <Pressable style={styles.glassButtonInner} onPress={onOptionsPress}>
-          <SymbolView
-            name="ellipsis"
-            size={moderateScale(18)}
-            tintColor={theme.colors.text}
-            weight="medium"
-          />
+          {USE_GLASS ? (
+            <SymbolView
+              name="ellipsis"
+              size={moderateScale(18)}
+              tintColor={theme.colors.text}
+              weight="medium"
+            />
+          ) : (
+            <Feather
+              name="more-horizontal"
+              size={moderateScale(18)}
+              color={theme.colors.text}
+            />
+          )}
         </Pressable>
-      </GlassView>
+      </PillWrapper>
     </View>
   );
 };
@@ -166,6 +185,7 @@ const styles = StyleSheet.create({
     width: moderateScale(44),
     height: moderateScale(44),
     borderRadius: moderateScale(22),
+    overflow: 'hidden',
   },
   optionsButton: {
     position: 'absolute',
@@ -174,6 +194,7 @@ const styles = StyleSheet.create({
     width: moderateScale(44),
     height: moderateScale(44),
     borderRadius: moderateScale(22),
+    overflow: 'hidden',
   },
   glassButtonInner: {
     flex: 1,

--- a/components/player/v2/PlayerContent/TrackInfo.tsx
+++ b/components/player/v2/PlayerContent/TrackInfo.tsx
@@ -1,7 +1,8 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import {GlassView} from 'expo-glass-effect';
-import {useGlassColorScheme} from '@/hooks/useGlassProps';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
+import {FrostedView} from '@/components/FrostedView';
 import {SymbolView} from 'expo-symbols';
 import {Pressable} from 'react-native-gesture-handler';
 import {moderateScale} from 'react-native-size-matters';
@@ -13,7 +14,12 @@ import {ReciterImage} from '@/components/ReciterImage';
 import {getReciterById} from '@/services/dataService';
 import {Reciter, Rewayat} from '@/data/reciterData';
 import {useLoved} from '@/hooks/useLoved';
-import {MicrophoneIcon} from '@/components/Icons';
+import {HeartIcon, MicrophoneIcon} from '@/components/Icons';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+} from 'react-native-reanimated';
 
 export const TrackInfo = () => {
   const {theme} = useTheme();
@@ -25,6 +31,10 @@ export const TrackInfo = () => {
   const [, setReciter] = useState<Reciter | null>(null);
   const [rewayat, setRewayat] = useState<Rewayat | null>(null);
   const {isTrackLoved, toggleTrackLoved} = useLoved();
+  const loveScale = useSharedValue(1);
+  const loveAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{scale: loveScale.value}],
+  }));
 
   useEffect(() => {
     setRewayat(null);
@@ -76,9 +86,14 @@ export const TrackInfo = () => {
 
   const handleToggleLoved = useCallback(() => {
     if (currentTrack) {
+      if (!USE_GLASS) {
+        loveScale.value = withSpring(1.2, {}, () => {
+          loveScale.value = withSpring(1);
+        });
+      }
       toggleTrackLoved(currentTrack);
     }
-  }, [currentTrack, toggleTrackLoved]);
+  }, [currentTrack, loveScale, toggleTrackLoved]);
 
   const isLoved = currentTrack ? isTrackLoved(currentTrack) : false;
 
@@ -134,25 +149,44 @@ export const TrackInfo = () => {
           </View>
         </Pressable>
 
-        <GlassView
-          style={styles.loveButton}
-          glassEffectStyle="regular"
-          colorScheme={glassColorScheme}
-          isInteractive>
-          <Pressable
-            style={({pressed}) => [
-              styles.loveButtonInner,
-              {opacity: pressed ? 0.7 : 1},
-            ]}
-            onPress={handleToggleLoved}>
-            <SymbolView
-              name={isLoved ? 'heart.fill' : 'heart'}
-              size={moderateScale(22)}
-              tintColor={isLoved ? 'red' : theme.colors.text}
-              weight="medium"
-            />
-          </Pressable>
-        </GlassView>
+        {USE_GLASS ? (
+          <GlassView
+            style={styles.loveButton}
+            glassEffectStyle="regular"
+            colorScheme={glassColorScheme}
+            isInteractive>
+            <Pressable
+              style={({pressed}) => [
+                styles.loveButtonInner,
+                {opacity: pressed ? 0.7 : 1},
+              ]}
+              onPress={handleToggleLoved}>
+              <SymbolView
+                name={isLoved ? 'heart.fill' : 'heart'}
+                size={moderateScale(22)}
+                tintColor={isLoved ? 'red' : theme.colors.text}
+                weight="medium"
+              />
+            </Pressable>
+          </GlassView>
+        ) : (
+          <FrostedView style={styles.loveButton}>
+            <Pressable
+              style={({pressed}) => [
+                styles.loveButtonInner,
+                {opacity: pressed ? 0.7 : 1},
+              ]}
+              onPress={handleToggleLoved}>
+              <Animated.View style={loveAnimatedStyle}>
+                <HeartIcon
+                  size={moderateScale(22)}
+                  color={isLoved ? 'red' : theme.colors.text}
+                  filled={isLoved}
+                />
+              </Animated.View>
+            </Pressable>
+          </FrostedView>
+        )}
       </View>
     </View>
   );
@@ -211,6 +245,7 @@ const styles = StyleSheet.create({
     width: moderateScale(50),
     height: moderateScale(50),
     borderRadius: moderateScale(25),
+    overflow: 'hidden',
   },
   loveButtonInner: {
     flex: 1,

--- a/components/player/v2/PlayerContent/index.tsx
+++ b/components/player/v2/PlayerContent/index.tsx
@@ -1,7 +1,8 @@
 import React, {useState, useCallback, useEffect, useMemo} from 'react';
 import {View, StyleSheet, LayoutChangeEvent} from 'react-native';
 import {GlassView} from 'expo-glass-effect';
-import {useGlassColorScheme} from '@/hooks/useGlassProps';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
+import {FrostedView} from '@/components/FrostedView';
 import Animated, {
   runOnJS,
   useSharedValue,
@@ -292,12 +293,16 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
           ]}
           pointerEvents={isImmersive ? 'none' : 'auto'}
           onLayout={handleHeaderLayout}>
-          {/* Glass background */}
-          <GlassView
-            style={StyleSheet.absoluteFill}
-            glassEffectStyle="regular"
-            colorScheme={glassColorScheme}
-          />
+          {/* Glass/blur background */}
+          {USE_GLASS ? (
+            <GlassView
+              style={StyleSheet.absoluteFill}
+              glassEffectStyle="regular"
+              colorScheme={glassColorScheme}
+            />
+          ) : (
+            <FrostedView style={StyleSheet.absoluteFill} />
+          )}
           <Header onOptionsPress={onOptionsPress} />
         </Animated.View>
       </GestureDetector>
@@ -314,12 +319,16 @@ const PlayerContent: React.FC<PlayerContentProps> = ({
           ]}
           pointerEvents={isImmersive ? 'none' : 'auto'}
           onLayout={handleControlsLayout}>
-          {/* Glass background */}
-          <GlassView
-            style={StyleSheet.absoluteFill}
-            glassEffectStyle="regular"
-            colorScheme={glassColorScheme}
-          />
+          {/* Glass/blur background */}
+          {USE_GLASS ? (
+            <GlassView
+              style={StyleSheet.absoluteFill}
+              glassEffectStyle="regular"
+              colorScheme={glassColorScheme}
+            />
+          ) : (
+            <FrostedView style={StyleSheet.absoluteFill} />
+          )}
           <TrackInfo />
           <PlaybackControls />
           <ControlButtons

--- a/components/playlist-detail/LovedHeader.tsx
+++ b/components/playlist-detail/LovedHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, Pressable, Platform} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
@@ -7,6 +7,7 @@ import {Theme} from '@/utils/themeUtils';
 import {PlayIcon, ShuffleIcon, HeartIcon} from '@/components/Icons';
 import {Feather} from '@expo/vector-icons';
 import Color from 'color';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface LovedHeaderProps {
   title: string;
@@ -54,7 +55,7 @@ export const LovedHeader: React.FC<LovedHeaderProps> = ({
 
       {/* Action Buttons */}
       <View style={styles.actionButtons}>
-        {Platform.OS !== 'ios' && onOptionsPress && (
+        {!USE_GLASS && onOptionsPress && (
           <Pressable style={styles.circleButton} onPress={onOptionsPress}>
             <Feather
               name="more-horizontal"
@@ -90,7 +91,7 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
     contentArea: {
       width: '100%',
       alignItems: 'center',
-      paddingTop: Platform.OS === 'ios' ? moderateScale(16) : insets.top + moderateScale(40),
+      paddingTop: USE_GLASS ? moderateScale(16) : insets.top + moderateScale(40),
       paddingBottom: moderateScale(10),
       overflow: 'hidden',
       backgroundColor: theme.colors.background,

--- a/components/playlist-detail/PlaylistDetail.tsx
+++ b/components/playlist-detail/PlaylistDetail.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   ListRenderItem,
   Animated as RNAnimated,
-  Platform,
   Pressable,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
@@ -26,6 +25,7 @@ import * as Haptics from 'expo-haptics';
 import {UserPlaylist} from '@/services/database/DatabaseService';
 import {CollectionStickyHeader} from '@/components/collection/CollectionStickyHeader';
 import {useCollectionNativeHeader} from '@/hooks/useCollectionNativeHeader';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface PlaylistTrack {
   id: string;
@@ -384,7 +384,7 @@ const PlaylistDetail: React.FC<PlaylistDetailProps> = ({id}) => {
         }`}
         onPlayPress={handlePlayAll}
         onShufflePress={handleShuffle}
-        onOptionsPress={Platform.OS === 'ios' ? undefined : handleOptionsPress}
+        onOptionsPress={USE_GLASS ? undefined : handleOptionsPress}
         theme={theme}
       />
     );
@@ -445,7 +445,7 @@ const PlaylistDetail: React.FC<PlaylistDetailProps> = ({id}) => {
         scrollEventThrottle={16}
         showsVerticalScrollIndicator={false}
       />
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <CollectionStickyHeader title={playlist.name} scrollY={scrollY} />
       )}
     </View>

--- a/components/playlist-detail/PlaylistHeader.tsx
+++ b/components/playlist-detail/PlaylistHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, Pressable, Platform} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {Feather} from '@expo/vector-icons';
@@ -8,6 +8,7 @@ import {useRouter} from 'expo-router';
 import {Theme} from '@/utils/themeUtils';
 import {PlaylistIcon, PlayIcon, ShuffleIcon} from '@/components/Icons';
 import Color from 'color';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface PlaylistHeaderProps {
   title: string;
@@ -34,7 +35,7 @@ export const PlaylistHeader: React.FC<PlaylistHeaderProps> = ({
     <View style={styles.headerContainer}>
       <View style={styles.contentArea}>
         {/* Back Button */}
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <Pressable
             style={styles.backButton}
             onPress={() => router.back()}
@@ -67,7 +68,7 @@ export const PlaylistHeader: React.FC<PlaylistHeaderProps> = ({
 
       {/* Action Buttons */}
       <View style={styles.actionButtons}>
-        {Platform.OS !== 'ios' && onOptionsPress && (
+        {!USE_GLASS && onOptionsPress && (
           <Pressable style={styles.circleButton} onPress={onOptionsPress}>
             <Feather
               name="more-horizontal"
@@ -103,14 +104,14 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
     contentArea: {
       width: '100%',
       alignItems: 'center',
-      paddingTop: Platform.OS === 'ios' ? moderateScale(16) : insets.top + moderateScale(40),
+      paddingTop: USE_GLASS ? moderateScale(16) : insets.top + moderateScale(40),
       paddingBottom: moderateScale(10),
       overflow: 'hidden',
       backgroundColor: theme.colors.background,
     },
     backButton: {
       position: 'absolute',
-      top: Platform.OS === 'ios' ? moderateScale(10) : insets.top + moderateScale(10),
+      top: USE_GLASS ? moderateScale(10) : insets.top + moderateScale(10),
       left: moderateScale(15),
       zIndex: 10,
       padding: moderateScale(8),

--- a/components/playlist-detail/ReciterDownloadsHeader.tsx
+++ b/components/playlist-detail/ReciterDownloadsHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, Pressable, Platform} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
@@ -9,6 +9,7 @@ import {Feather} from '@expo/vector-icons';
 import {PlayIcon, ShuffleIcon} from '@/components/Icons';
 import {ReciterImage} from '@/components/ReciterImage';
 import Color from 'color';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface ReciterDownloadsHeaderProps {
   reciterId: string;
@@ -43,7 +44,7 @@ export const ReciterDownloadsHeader: React.FC<ReciterDownloadsHeaderProps> = ({
     <View style={styles.headerContainer}>
       <View style={styles.contentArea}>
         {/* Back Button */}
-        {Platform.OS !== 'ios' && (
+        {!USE_GLASS && (
           <Pressable
             style={styles.backButton}
             onPress={() => router.back()}
@@ -79,7 +80,7 @@ export const ReciterDownloadsHeader: React.FC<ReciterDownloadsHeaderProps> = ({
 
       {/* Action Buttons */}
       <View style={styles.actionButtons}>
-        {Platform.OS !== 'ios' && onOptionsPress && (
+        {!USE_GLASS && onOptionsPress && (
           <Pressable style={styles.circleButton} onPress={onOptionsPress}>
             <Feather
               name="more-horizontal"
@@ -115,14 +116,14 @@ const createStyles = (theme: Theme, insets: EdgeInsets) =>
     contentArea: {
       width: '100%',
       alignItems: 'center',
-      paddingTop: Platform.OS === 'ios' ? moderateScale(16) : insets.top + moderateScale(40),
+      paddingTop: USE_GLASS ? moderateScale(16) : insets.top + moderateScale(40),
       paddingBottom: moderateScale(10),
       overflow: 'hidden',
       backgroundColor: theme.colors.background,
     },
     backButton: {
       position: 'absolute',
-      top: Platform.OS === 'ios' ? moderateScale(10) : insets.top + moderateScale(10),
+      top: USE_GLASS ? moderateScale(10) : insets.top + moderateScale(10),
       left: moderateScale(15),
       zIndex: 10,
       padding: moderateScale(8),

--- a/components/reciter-downloads/ReciterDownloadsList.tsx
+++ b/components/reciter-downloads/ReciterDownloadsList.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect, useCallback, useRef, useMemo} from 'react';
-import {View, Text, StyleSheet, Animated as RNAnimated, Platform, Pressable} from 'react-native';
+import {View, Text, StyleSheet, Animated as RNAnimated, Pressable} from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {SurahItem} from '@/components/SurahItem';
 import {getReciterById, getSurahById} from '@/services/dataService';
@@ -22,6 +22,7 @@ import {SheetManager} from 'react-native-actions-sheet';
 import {usePlayerActions} from '@/hooks/usePlayerActions';
 import {useCollectionNativeHeader} from '@/hooks/useCollectionNativeHeader';
 import {Feather} from '@expo/vector-icons';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface DownloadTrackData {
   download: DownloadedSurah;
@@ -390,7 +391,7 @@ export const ReciterDownloadsList: React.FC<ReciterDownloadsListProps> = ({
         } downloaded`}
         onPlayPress={handlePlayAll}
         onShufflePress={handleShuffle}
-        onOptionsPress={Platform.OS === 'ios' ? undefined : handleRemoveAllDownloads}
+        onOptionsPress={USE_GLASS ? undefined : handleRemoveAllDownloads}
         theme={theme}
       />
     );
@@ -457,7 +458,7 @@ export const ReciterDownloadsList: React.FC<ReciterDownloadsListProps> = ({
         scrollEventThrottle={16}
         showsVerticalScrollIndicator={false}
       />
-      {Platform.OS !== 'ios' && (
+      {!USE_GLASS && (
         <CollectionStickyHeader
           title={reciter?.name || 'Downloads'}
           scrollY={scrollY}

--- a/components/reciter-profile/ReciterProfile.tsx
+++ b/components/reciter-profile/ReciterProfile.tsx
@@ -62,6 +62,7 @@ import {useBottomInset} from '@/hooks/useBottomInset';
 import {HAFS_REWAYAT_NAME} from '@/data/rewayat';
 import {useNavigation} from 'expo-router';
 import {useHeaderHeight} from '@react-navigation/elements';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface ReciterProfileProps {
   id: string;
@@ -177,7 +178,9 @@ const SurahListSkeleton: React.FC<{theme: any}> = React.memo(({theme}) => {
   );
 });
 
-const isIOS = Platform.OS === 'ios';
+// Use USE_GLASS (iOS 26+) instead of Platform.OS so non-glass iOS
+// devices get the same custom header/nav buttons as Android.
+const isGlass = USE_GLASS;
 
 const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
   id: currentReciterId,
@@ -189,7 +192,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
   const bottomInset = useBottomInset();
   const {height: screenHeight, width: screenWidth} = useWindowDimensions();
   const navigation = useNavigation();
-  const headerHeight = isIOS ? useHeaderHeight() : 0;
+  const headerHeight = isGlass ? useHeaderHeight() : 0;
 
   // Synchronous reciter init — data available on first render, no deferred loading delay
   const initialReciter = useMemo(
@@ -221,7 +224,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
   // iOS native header: search icon in headerRight, hidden when search is active
   const headerTitleShownRef = useRef(false);
   useLayoutEffect(() => {
-    if (!isIOS) return;
+    if (!isGlass) return;
     headerTitleShownRef.current = false;
     navigation.setOptions({
       headerTitle: '',
@@ -270,7 +273,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
   const [stickyTitleHeight, setStickyTitleHeight] = useState(0);
 
   // iOS: offset below transparent native header; Android: below custom sticky title
-  const stickyPinOffset = isIOS ? headerHeight : stickyTitleHeight;
+  const stickyPinOffset = isGlass ? headerHeight : stickyTitleHeight;
   const {isLovedWithRewayat} = useLoved();
   const {isDownloaded} = useDownloadQueries();
   const {startNewChain} = useRecentlyPlayedStore();
@@ -792,7 +795,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
           <RNAnimated.ScrollView
             ref={outerScrollRef}
             stickyHeaderIndices={[1]}
-            contentInsetAdjustmentBehavior={isIOS ? 'automatic' : 'never'}
+            contentInsetAdjustmentBehavior={isGlass ? 'automatic' : 'never'}
             onScroll={RNAnimated.event(
               [{nativeEvent: {contentOffset: {y: scrollY}}}],
               {
@@ -801,7 +804,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                   const y = e.nativeEvent.contentOffset.y;
                   currentScrollYRef.current = y;
                   // iOS: show reciter name in native header when scrolled past header
-                  if (isIOS && reciter) {
+                  if (isGlass && reciter) {
                     const threshold = collapsePoint * 0.6;
                     const shouldShow = y >= threshold;
                     if (shouldShow !== headerTitleShownRef.current) {
@@ -1044,7 +1047,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
           </RNAnimated.ScrollView>
 
           {/* Sticky title bar — fades in as outer scroll collapses header (Android only) */}
-          {!isIOS && (
+          {!isGlass && (
             <RNAnimated.View
               pointerEvents="none"
               onLayout={e => setStickyTitleHeight(e.nativeEvent.layout.height)}
@@ -1072,7 +1075,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
               </Text>
             </RNAnimated.View>
           )}
-          {!isIOS && (
+          {!isGlass && (
             <NavigationButtons
               insets={insets}
               iconsOpacity={iconsOpacity}
@@ -1125,15 +1128,28 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
 
 // Lightweight wrapper — defers mounting the heavy content until the navigation
 // transition finishes so the screen push feels instant.
+// On Android, InteractionManager can hang indefinitely if an interaction never
+// completes, so we race it against a short timeout.
 const ReciterProfile: React.FC<ReciterProfileProps> = props => {
   const [ready, setReady] = useState(false);
   const {theme} = useTheme();
 
   useEffect(() => {
-    const handle = InteractionManager.runAfterInteractions(() => {
+    let settled = false;
+    const markReady = () => {
+      if (settled) return;
+      settled = true;
       setReady(true);
-    });
-    return () => handle.cancel();
+    };
+
+    const handle = InteractionManager.runAfterInteractions(markReady);
+    // Fallback: if interactions don't settle within 300ms, mount anyway
+    const timer = setTimeout(markReady, 300);
+
+    return () => {
+      handle.cancel();
+      clearTimeout(timer);
+    };
   }, []);
 
   if (!ready) {

--- a/components/reciter-profile/components/ReciterHeader/index.tsx
+++ b/components/reciter-profile/components/ReciterHeader/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, Platform} from 'react-native';
+import {View, Text} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {Theme} from '@/utils/themeUtils';
@@ -7,6 +7,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {ReciterImage} from '@/components/ReciterImage';
 import {ReciterHeaderProps} from '@/components/reciter-profile/types';
 import {Link} from 'expo-router';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 export const ReciterHeader: React.FC<ReciterHeaderProps> = ({
   reciter,
@@ -18,17 +19,24 @@ export const ReciterHeader: React.FC<ReciterHeaderProps> = ({
 
   const topPadding = showSearch
     ? moderateScale(15)
-    : Platform.OS === 'ios'
+    : USE_GLASS
       ? moderateScale(10)
       : insets.top + moderateScale(50);
 
   return (
-    <View
-      style={[
-        styles.container,
-        {paddingTop: topPadding},
-      ]}>
-      <Link.AppleZoomTarget>
+    <View style={[styles.container, {paddingTop: topPadding}]}>
+      {USE_GLASS ? (
+        <Link.AppleZoomTarget>
+          <View>
+            <ReciterImage
+              reciterName={reciter.name}
+              imageUrl={reciter.image_url || undefined}
+              style={styles.reciterImage}
+              profileIconSize={moderateScale(48)}
+            />
+          </View>
+        </Link.AppleZoomTarget>
+      ) : (
         <View>
           <ReciterImage
             reciterName={reciter.name}
@@ -37,7 +45,7 @@ export const ReciterHeader: React.FC<ReciterHeaderProps> = ({
             profileIconSize={moderateScale(48)}
           />
         </View>
-      </Link.AppleZoomTarget>
+      )}
       <Text style={styles.reciterName} numberOfLines={2}>
         {reciter.name}
       </Text>

--- a/components/reciter-profile/components/SearchView/index.tsx
+++ b/components/reciter-profile/components/SearchView/index.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   TouchableOpacity,
   FlatList,
-  Platform,
   Keyboard,
 } from 'react-native';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
@@ -17,7 +16,6 @@ import Animated, {FadeIn, FadeOut} from 'react-native-reanimated';
 import Color from 'color';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {SearchInput} from '@/components/SearchInput';
-import {BlurView} from '@react-native-community/blur';
 import {StyleSheet} from 'react-native';
 import {StatusBar} from 'expo-status-bar';
 import {SurahCard} from '@/components/cards/SurahCard';
@@ -164,33 +162,14 @@ export const SearchView: React.FC<SearchViewProps> = ({
       style={[styles.container, {backgroundColor: theme.colors.background}]}>
       <StatusBar style={isDarkMode ? 'light' : 'dark'} />
       <View style={[styles.headerContainer, {paddingTop: insets.top}]}>
-        {Platform.OS === 'ios' ? (
-          <BlurView
-            blurAmount={80}
-            blurType={theme.isDarkMode ? 'dark' : 'light'}
-            style={StyleSheet.absoluteFill}>
-            <View
-              style={[
-                StyleSheet.absoluteFill,
-                {
-                  backgroundColor: Color(theme.colors.card)
-                    .alpha(0.7)
-                    .toString(),
-                },
-              ]}
-            />
-          </BlurView>
-        ) : (
-          <View
-            style={[
-              StyleSheet.absoluteFill,
-              {
-                backgroundColor: theme.colors.card,
-                opacity: 0.95,
-              },
-            ]}
-          />
-        )}
+        <View
+          style={[
+            StyleSheet.absoluteFill,
+            {
+              backgroundColor: theme.colors.card,
+            },
+          ]}
+        />
         <Text style={[styles.reciterName, {color: theme.colors.text}]}>
           {reciterName}
         </Text>

--- a/components/reciter-profile/components/StickyHeader/index.tsx
+++ b/components/reciter-profile/components/StickyHeader/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import {Animated, StyleSheet, Text, Platform, View} from 'react-native';
+import {Animated, StyleSheet, Text, View} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {Theme} from '@/utils/themeUtils';
 import {useTheme} from '@/hooks/useTheme';
-import {BlurView} from '@react-native-community/blur';
 import {StickyHeaderProps} from '@/components/reciter-profile/types';
 
 /**
@@ -33,24 +32,14 @@ export const StickyHeader: React.FC<StickyHeaderProps> = ({
           paddingTop: insets.top,
         },
       ]}>
-      {Platform.OS === 'ios' ? (
-        <BlurView
-          blurAmount={100}
-          blurType={isDarkMode ? 'dark' : 'light'}
-          style={StyleSheet.absoluteFill}
-        />
-      ) : (
-        <View
-          style={[
-            StyleSheet.absoluteFill,
-            {
-              backgroundColor: isDarkMode
-                ? 'rgba(0,0,0,0.75)'
-                : 'rgba(255,255,255,0.85)',
-            },
-          ]}
-        />
-      )}
+      <View
+        style={[
+          StyleSheet.absoluteFill,
+          {
+            backgroundColor: theme.colors.background,
+          },
+        ]}
+      />
       <Text style={[styles.stickyHeaderTitle, {color: theme.colors.text}]}>
         {reciterName}
       </Text>

--- a/components/screens/TranslationsContent.tsx
+++ b/components/screens/TranslationsContent.tsx
@@ -12,7 +12,6 @@ import {
   ActivityIndicator,
   Alert,
   StyleSheet,
-  Platform,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
 import {ScaledSheet, moderateScale} from 'react-native-size-matters';
@@ -21,6 +20,7 @@ import Color from 'color';
 import {Feather} from '@expo/vector-icons';
 import {FlashList, type ListRenderItemInfo} from '@shopify/flash-list';
 import {useHeaderHeight} from '@react-navigation/elements';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import {useNavigation} from 'expo-router';
 import TabSelector from '@/components/TabSelector';
 import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
@@ -129,7 +129,7 @@ export default function TranslationsContent() {
   const navigation = useNavigation();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const rawHeaderHeight = useHeaderHeight();
-  const headerHeight = Platform.OS === 'ios' ? rawHeaderHeight : 0;
+  const headerHeight = USE_GLASS ? rawHeaderHeight : 0;
   const bottomInset = useBottomInset();
 
   const [activeTab, setActiveTab] = useState<ActiveTab>('Translations');

--- a/components/system-playlist/SystemPlaylistDetail.tsx
+++ b/components/system-playlist/SystemPlaylistDetail.tsx
@@ -15,9 +15,9 @@ import {
   Alert,
   NativeSyntheticEvent,
   NativeScrollEvent,
-  Platform,
 } from 'react-native';
 import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import {TrackItem} from '@/components/TrackItem';
 import {
   getReciterById,
@@ -126,7 +126,7 @@ function findBestRewayat(
   return reciter.rewayat[0]?.id;
 }
 
-const isIOS = Platform.OS === 'ios';
+const isGlass = USE_GLASS;
 
 const SystemPlaylistDetail: React.FC<SystemPlaylistDetailProps> = ({
   playlist,
@@ -135,14 +135,14 @@ const SystemPlaylistDetail: React.FC<SystemPlaylistDetailProps> = ({
   const {updateQueue, addToQueue, play} = usePlayerActions();
   const {startNewChain} = useRecentlyPlayedStore();
   const navigation = useNavigation();
-  const iosHeaderHeight = isIOS ? useHeaderHeight() : 0;
+  const iosHeaderHeight = isGlass ? useHeaderHeight() : 0;
 
   const scrollY = useRef(new RNAnimated.Value(0)).current;
 
   // iOS: reveal playlist title in native header on scroll
   const headerTitleShownRef = useRef(false);
   useLayoutEffect(() => {
-    if (!isIOS) return;
+    if (!isGlass) return;
     navigation.setOptions({
       headerTitle: '',
     });
@@ -669,7 +669,7 @@ const SystemPlaylistDetail: React.FC<SystemPlaylistDetailProps> = ({
         ListHeaderComponent={listHeaderComponent}
         contentContainerStyle={[
           styles.listContentContainer,
-          isIOS && {paddingTop: iosHeaderHeight},
+          isGlass && {paddingTop: iosHeaderHeight},
         ]}
         ListEmptyComponent={listEmptyComponent}
         onScroll={RNAnimated.event(
@@ -677,7 +677,7 @@ const SystemPlaylistDetail: React.FC<SystemPlaylistDetailProps> = ({
           {
             useNativeDriver: true,
             listener: (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-              if (!isIOS) return;
+              if (!isGlass) return;
               const y = e.nativeEvent.contentOffset.y;
               // Show title after scrolling past the header area
               const threshold = moderateScale(120);
@@ -694,7 +694,7 @@ const SystemPlaylistDetail: React.FC<SystemPlaylistDetailProps> = ({
         scrollEventThrottle={16}
         showsVerticalScrollIndicator={false}
       />
-      {!isIOS && (
+      {!isGlass && (
         <CollectionStickyHeader title={playlist.title} scrollY={scrollY} />
       )}
     </View>

--- a/components/system-playlist/SystemPlaylistHeader.tsx
+++ b/components/system-playlist/SystemPlaylistHeader.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import {View, Text, Pressable, Platform} from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {Feather} from '@expo/vector-icons';
 import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
 import {useRouter} from 'expo-router';
 import {Theme} from '@/utils/themeUtils';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 import {PlayIcon, ShuffleIcon} from '@/components/Icons';
 import Color from 'color';
 import Animated, {
@@ -15,7 +16,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
-const isIOS = Platform.OS === 'ios';
+const isGlass = USE_GLASS;
 
 interface SystemPlaylistHeaderProps {
   title: string;
@@ -78,9 +79,9 @@ export const SystemPlaylistHeader: React.FC<SystemPlaylistHeaderProps> = ({
 
   return (
     <View style={styles.headerContainer}>
-      <View style={[styles.contentArea, isIOS && styles.contentAreaIOS]}>
+      <View style={[styles.contentArea, isGlass && styles.contentAreaIOS]}>
         {/* Back Button — Android only, iOS uses native header */}
-        {!isIOS && (
+        {!isGlass && (
           <Pressable
             style={styles.backButton}
             onPress={() => router.back()}

--- a/hooks/useCollectionNativeHeader.tsx
+++ b/hooks/useCollectionNativeHeader.tsx
@@ -1,7 +1,8 @@
 import React, {useLayoutEffect} from 'react';
-import {Animated as RNAnimated, Platform} from 'react-native';
+import {Animated as RNAnimated} from 'react-native';
 import {useNavigation} from 'expo-router';
 import {useTheme} from './useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 interface UseCollectionNativeHeaderOptions {
   title: string;
@@ -22,7 +23,7 @@ export function useCollectionNativeHeader({
   const {theme} = useTheme();
 
   useLayoutEffect(() => {
-    if (Platform.OS !== 'ios') return;
+    if (!USE_GLASS) return;
 
     navigation.setOptions({
       headerTitle: hasContent


### PR DESCRIPTION
## Summary
- Replace `Platform.OS === 'ios'` with `USE_GLASS` across ~45 files so non-glass iOS devices (<iOS 26) get the same custom headers, back buttons, safe area padding, and solid backgrounds as Android
- Add `FrostedView` component (BlurView on iOS, solid background on Android) to replace raw BlurView usage
- Fix `ReciterProfile` never loading on Android due to `InteractionManager` hanging indefinitely (added 300ms timeout fallback)
- Gate `Link.AppleZoom`, `Stack.Toolbar`, and native header config behind `USE_GLASS`

## Test plan
- [ ] Verify iOS 26+ still uses liquid glass, native headers, and Stack.Toolbar
- [ ] Verify iOS <26 shows custom back buttons, sticky headers, and solid backgrounds (same as Android)
- [ ] Verify Android reciter detail screen loads surahs within 300ms
- [ ] Verify browse cards show title/subtitle on all platforms
- [ ] Verify mushaf page shows custom header/bottom bar on non-glass iOS
- [ ] Verify collection sub-screens (loved, downloads, bookmarks, etc.) show proper top inset on non-glass iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)