### PR TITLE
fix: player cleanup and hydration timeout fallback

### DIFF
--- a/components/player/v2/PlayerContent/TrackInfo.tsx
+++ b/components/player/v2/PlayerContent/TrackInfo.tsx
@@ -7,7 +7,6 @@ import {SymbolView} from 'expo-symbols';
 import {Pressable} from 'react-native-gesture-handler';
 import {moderateScale} from 'react-native-size-matters';
 import {useTheme} from '@/hooks/useTheme';
-import {usePlayerActions} from '@/hooks/usePlayerActions';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {useReciterNavigation} from '@/hooks/useReciterNavigation';
 import {ReciterImage} from '@/components/ReciterImage';
@@ -24,7 +23,6 @@ import Animated, {
 export const TrackInfo = () => {
   const {theme} = useTheme();
   const glassColorScheme = useGlassColorScheme();
-  const {setSheetMode} = usePlayerActions();
   const queue = usePlayerStore(s => s.queue);
   const {navigateToReciterProfile} = useReciterNavigation();
   const currentTrack = queue?.tracks?.[queue?.currentIndex ?? -1];
@@ -72,17 +70,9 @@ export const TrackInfo = () => {
 
   const handleReciterPress = useCallback(() => {
     if (currentTrack && !isUploadWithoutReciter) {
-      setSheetMode('hidden');
-      setTimeout(() => {
-        navigateToReciterProfile(currentTrack.reciterId);
-      }, 100);
+      navigateToReciterProfile(currentTrack.reciterId);
     }
-  }, [
-    currentTrack,
-    isUploadWithoutReciter,
-    setSheetMode,
-    navigateToReciterProfile,
-  ]);
+  }, [currentTrack, isUploadWithoutReciter, navigateToReciterProfile]);
 
   const handleToggleLoved = useCallback(() => {
     if (currentTrack) {

--- a/services/player/utils/restoreSession.ts
+++ b/services/player/utils/restoreSession.ts
@@ -14,18 +14,37 @@ import {createUserUploadTrack} from '@/utils/track';
 
 /**
  * Waits for playerStore to finish hydrating from AsyncStorage.
- * Returns immediately if already hydrated.
+ * Returns immediately if already hydrated. Falls back after a timeout
+ * to prevent the splash screen from hanging indefinitely on Android
+ * where AsyncStorage (SQLite-backed) can be slow or miss the event.
  */
-function waitForPlayerStoreHydration(): Promise<void> {
+function waitForPlayerStoreHydration(timeoutMs = 3000): Promise<void> {
   return new Promise(resolve => {
     if (usePlayerStore.persist.hasHydrated()) {
       resolve();
       return;
     }
+
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
     const unsub = usePlayerStore.persist.onFinishHydration(() => {
       unsub();
-      resolve();
+      settle();
     });
+
+    setTimeout(() => {
+      if (__DEV__ && !settled) {
+        console.warn(
+          `[RestoreSession] playerStore hydration timed out after ${timeoutMs}ms, continuing`,
+        );
+      }
+      settle();
+    }, timeoutMs);
   });
 }
 


### PR DESCRIPTION
## Summary
- Remove redundant `setSheetMode` from TrackInfo (already handled by `useReciterNavigation`)
- Add timeout fallback (3s) to playerStore hydration to prevent splash screen hang on Android

## Test plan
- [ ] Tap reciter image in player sheet → navigates to profile, sheet closes
- [ ] Launch app on Android → splash screen doesn't hang indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)