### PR TITLE
Fix broken audio URLs for Maher Al Meaqli and Minshawi

### DIFF
--- a/data/reciters.json
+++ b/data/reciters.json
@@ -16773,7 +16773,7 @@
         "reciter_id": "06c3f79f-02d9-42e8-9e9b-c6f355648305",
         "name": "Hafs A'n Assem",
         "style": "murattal",
-        "server": "https://download.quranicaudio.com/qdc/maher_al_meaqli/year1440",
+        "server": "https://server12.mp3quran.net/maher",
         "surah_total": 114,
         "surah_list": [
           1,
@@ -22790,7 +22790,7 @@
         "reciter_id": "b5acd08c-b023-4bf3-b806-f1b8c12d6d33",
         "name": "Hafs A'n Assem",
         "style": "mojawwad",
-        "server": "https://download.quranicaudio.com/qdc/siddiq_al-minshawi/mujawwad",
+        "server": "https://server10.mp3quran.net/minsh/Almusshaf-Al-Mojawwad",
         "surah_total": 114,
         "surah_list": [
           1,


### PR DESCRIPTION
## Summary
- Replaced 2 broken `quranicaudio.com/qdc/` server URLs with working `mp3quran.net` alternatives
- **Maher Al Meaqli (murattal):** `server12.mp3quran.net/maher`
- **Minshawi (mujawwad):** `server10.mp3quran.net/minsh/Almusshaf-Al-Mojawwad`

## Root cause
The `/qdc/` path on `download.quranicaudio.com` was decommissioned (returns 404). The 4 other quranicaudio URLs using the `/quran/` path still work fine.

## Test plan
- [ ] Play any surah from Maher Al Meaqli's murattal — should load and play
- [ ] Play any surah from Minshawi's mujawwad — should load and play
- [ ] Verify other reciters still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)