### PR TITLE
Redesign network banner as floating overlay pill

### DIFF
--- a/components/ApiDisruptionBanner.tsx
+++ b/components/ApiDisruptionBanner.tsx
@@ -1,334 +1,119 @@
-import React, {useState} from 'react';
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  Modal,
-  ScrollView,
-  StyleSheet,
-  ActivityIndicator,
-} from 'react-native';
+import React, {useEffect} from 'react';
+import {View, Text, StyleSheet} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useApiHealthStore} from '@/store/apiHealthStore';
 import {useNetworkStore} from '@/store/networkStore';
+import {useDevSettingsStore} from '@/store/devSettingsStore';
+import {useTheme} from '@/hooks/useTheme';
+import {Feather} from '@expo/vector-icons';
+import {moderateScale} from 'react-native-size-matters';
+import Color from 'color';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+  interpolate,
+  runOnJS,
+} from 'react-native-reanimated';
+
+const SLIDE_DURATION = 280;
 
 export function ApiDisruptionBanner() {
-  const {isDisrupted, usingStaleCache, retryFn} = useApiHealthStore();
+  const {isDisrupted, usingStaleCache} = useApiHealthStore();
   const isOnline = useNetworkStore(s => s.isOnline);
-  const [modalVisible, setModalVisible] = useState(false);
-  const [retrying, setRetrying] = useState(false);
+  const {theme} = useTheme();
   const insets = useSafeAreaInsets();
 
-  const showBanner = !isOnline || isDisrupted;
-  const isOffline = !isOnline;
+  const forceNetworkBanner = useDevSettingsStore(s => s.forceNetworkBanner);
 
-  if (!showBanner) return null;
+  const showBanner = !isOnline || isDisrupted || forceNetworkBanner;
+  const isOffline = !isOnline || (forceNetworkBanner && !isDisrupted);
 
-  const handleRetry = async () => {
-    if (retrying) return;
-    setRetrying(true);
-    try {
-      if (retryFn) await retryFn();
-    } finally {
-      setRetrying(false);
+  const progress = useSharedValue(0);
+  const [mounted, setMounted] = React.useState(false);
+
+  useEffect(() => {
+    if (showBanner) {
+      setMounted(true);
+      progress.value = withTiming(1, {
+        duration: SLIDE_DURATION,
+        easing: Easing.out(Easing.cubic),
+      });
+    } else {
+      progress.value = withTiming(
+        0,
+        {duration: SLIDE_DURATION, easing: Easing.in(Easing.cubic)},
+        finished => {
+          if (finished) {
+            runOnJS(setMounted)(false);
+          }
+        },
+      );
     }
-  };
+  }, [showBanner, progress]);
 
-  const bannerBg = isOffline ? '#F3F4F6' : '#FEF3C7';
-  const bannerBorder = isOffline ? '#D1D5DB' : '#F59E0B';
-  const bannerTextColor = isOffline ? '#374151' : '#92400E';
-  const buttonBg = isOffline ? '#E5E7EB' : '#FDE68A';
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(progress.value, [0, 1], [0, 1]),
+    transform: [{translateY: interpolate(progress.value, [0, 1], [-8, 0])}],
+  }));
+
+  if (!mounted) return null;
+
+  const icon: React.ComponentProps<typeof Feather>['name'] = isOffline
+    ? 'wifi-off'
+    : 'alert-circle';
+
+  const label = isOffline
+    ? 'No internet connection'
+    : usingStaleCache
+      ? 'Showing cached data'
+      : 'Backend unreachable';
+
+  const pillBg = Color(theme.colors.text).alpha(0.08).toString();
+  const pillBorder = Color(theme.colors.text).alpha(0.06).toString();
+  const iconColor = Color(theme.colors.text).alpha(0.5).toString();
+  const textColor = Color(theme.colors.text).alpha(0.7).toString();
 
   return (
-    <>
+    <Animated.View
+      style={[
+        styles.wrapper,
+        {top: insets.top + moderateScale(4)},
+        animatedStyle,
+      ]}
+      pointerEvents="none">
       <View
         style={[
-          styles.banner,
-          {
-            paddingTop: insets.top > 0 ? insets.top + 4 : 12,
-            backgroundColor: bannerBg,
-            borderBottomColor: bannerBorder,
-          },
+          styles.pill,
+          {backgroundColor: pillBg, borderColor: pillBorder},
         ]}>
-        <View style={styles.bannerContent}>
-          <Text style={styles.bannerIcon}>{isOffline ? '📵' : '⚠️'}</Text>
-          <Text
-            style={[styles.bannerText, {color: bannerTextColor}]}
-            numberOfLines={1}>
-            {isOffline
-              ? 'No internet connection'
-              : usingStaleCache
-              ? 'Showing cached data — backend unreachable'
-              : 'Backend unreachable — some content unavailable'}
-          </Text>
-        </View>
-        <View style={styles.bannerActions}>
-          <TouchableOpacity
-            onPress={handleRetry}
-            disabled={retrying}
-            style={[styles.bannerButton, {backgroundColor: buttonBg}]}>
-            {retrying ? (
-              <ActivityIndicator size="small" color={bannerTextColor} />
-            ) : (
-              <Text style={[styles.bannerButtonText, {color: bannerTextColor}]}>
-                Retry
-              </Text>
-            )}
-          </TouchableOpacity>
-          {!isOffline && (
-            <TouchableOpacity
-              onPress={() => setModalVisible(true)}
-              style={[styles.bannerButton, {backgroundColor: '#F59E0B22'}]}>
-              <Text style={[styles.bannerButtonText, {color: bannerTextColor}]}>
-                More
-              </Text>
-            </TouchableOpacity>
-          )}
-        </View>
+        <Feather name={icon} size={moderateScale(12)} color={iconColor} />
+        <Text style={[styles.label, {color: textColor}]}>{label}</Text>
       </View>
-
-      <Modal
-        visible={modalVisible}
-        animationType="slide"
-        presentationStyle="pageSheet"
-        onRequestClose={() => setModalVisible(false)}>
-        <View style={styles.modal}>
-          <View style={styles.modalHandle} />
-
-          <ScrollView
-            contentContainerStyle={styles.modalContent}
-            showsVerticalScrollIndicator={false}>
-            <Text style={styles.modalTitle}>Service Disruption</Text>
-            <Text style={styles.modalSubtitle}>
-              The Bayaan backend is temporarily unreachable. Our team is already
-              aware and working to restore it.
-            </Text>
-
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>What's affected</Text>
-              <StatusRow emoji="🔴" label="Loading new reciters" ok={false} />
-              <StatusRow emoji="🔴" label="Reciter metadata updates" ok={false} />
-            </View>
-
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>What still works</Text>
-              <StatusRow emoji="🟢" label="Audio playback" ok={true} />
-              <StatusRow emoji="🟢" label="Downloads" ok={true} />
-              <StatusRow emoji="🟢" label="Bookmarks & notes" ok={true} />
-              <StatusRow emoji="🟢" label="Playlists & favorites" ok={true} />
-              <StatusRow emoji="🟢" label="Mushaf & reading" ok={true} />
-              {usingStaleCache && (
-                <StatusRow
-                  emoji="🟡"
-                  label="Reciter list (showing cached data)"
-                  ok={true}
-                />
-              )}
-            </View>
-
-            <View style={styles.notice}>
-              <Text style={styles.noticeText}>
-                We apologize for the inconvenience. If this persists, check our
-                status page or reach out on GitHub.
-              </Text>
-            </View>
-          </ScrollView>
-
-          <View
-            style={[styles.modalFooter, {paddingBottom: insets.bottom + 8}]}>
-            <TouchableOpacity
-              style={[
-                styles.retryButton,
-                retrying && styles.retryButtonDisabled,
-              ]}
-              onPress={async () => {
-                await handleRetry();
-                setModalVisible(false);
-              }}
-              disabled={retrying}>
-              {retrying ? (
-                <ActivityIndicator color="#fff" />
-              ) : (
-                <Text style={styles.retryButtonText}>Retry Now</Text>
-              )}
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.dismissButton}
-              onPress={() => setModalVisible(false)}>
-              <Text style={styles.dismissButtonText}>Dismiss</Text>
-            </TouchableOpacity>
-          </View>
-
-        </View>
-      </Modal>
-    </>
-  );
-}
-
-function StatusRow({
-  emoji,
-  label,
-  ok,
-}: {
-  emoji: string;
-  label: string;
-  ok: boolean;
-}) {
-  return (
-    <View style={styles.statusRow}>
-      <Text style={styles.statusEmoji}>{emoji}</Text>
-      <Text style={[styles.statusLabel, !ok && styles.statusLabelDown]}>
-        {label}
-      </Text>
-    </View>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
-  banner: {
-    backgroundColor: '#FEF3C7',
-    paddingHorizontal: 14,
-    paddingBottom: 10,
+  wrapper: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    zIndex: 999,
+    alignItems: 'center',
+  },
+  pill: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#F59E0B',
+    gap: moderateScale(6),
+    paddingHorizontal: moderateScale(14),
+    paddingVertical: moderateScale(7),
+    borderRadius: moderateScale(20),
+    borderWidth: 1,
   },
-  bannerContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-    gap: 6,
-  },
-  bannerIcon: {
-    fontSize: 13,
-  },
-  bannerText: {
-    fontSize: 12,
-    color: '#92400E',
-    fontWeight: '500',
-    flex: 1,
-  },
-  bannerActions: {
-    flexDirection: 'row',
-    gap: 4,
-    marginLeft: 8,
-  },
-  bannerButton: {
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 6,
-    backgroundColor: '#FDE68A',
-    minWidth: 44,
-    alignItems: 'center',
-  },
-  bannerButtonMore: {
-    backgroundColor: '#F59E0B22',
-  },
-  bannerButtonText: {
-    fontSize: 12,
-    color: '#92400E',
-    fontWeight: '600',
-  },
-  modal: {
-    flex: 1,
-    backgroundColor: '#fff',
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-  },
-  modalHandle: {
-    width: 36,
-    height: 4,
-    backgroundColor: '#D1D5DB',
-    borderRadius: 2,
-    alignSelf: 'center',
-    marginTop: 10,
-    marginBottom: 4,
-  },
-  modalContent: {
-    padding: 24,
-    paddingBottom: 8,
-  },
-  modalTitle: {
-    fontSize: 22,
-    fontWeight: '700',
-    color: '#111827',
-    marginBottom: 8,
-  },
-  modalSubtitle: {
-    fontSize: 15,
-    color: '#6B7280',
-    lineHeight: 22,
-    marginBottom: 28,
-  },
-  section: {
-    marginBottom: 24,
-  },
-  sectionTitle: {
-    fontSize: 13,
-    fontWeight: '600',
-    color: '#9CA3AF',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    marginBottom: 12,
-  },
-  statusRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    paddingVertical: 8,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#F3F4F6',
-  },
-  statusEmoji: {
-    fontSize: 14,
-  },
-  statusLabel: {
-    fontSize: 15,
-    color: '#374151',
-  },
-  statusLabelDown: {
-    color: '#6B7280',
-  },
-  notice: {
-    backgroundColor: '#FEF3C7',
-    borderRadius: 10,
-    padding: 14,
-    marginBottom: 16,
-  },
-  noticeText: {
-    fontSize: 13,
-    color: '#92400E',
-    lineHeight: 19,
-  },
-  modalFooter: {
-    padding: 16,
-    paddingTop: 8,
-    gap: 8,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: '#F3F4F6',
-  },
-  retryButton: {
-    backgroundColor: '#F59E0B',
-    borderRadius: 12,
-    paddingVertical: 14,
-    alignItems: 'center',
-  },
-  retryButtonDisabled: {
-    opacity: 0.6,
-  },
-  retryButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  dismissButton: {
-    paddingVertical: 10,
-    alignItems: 'center',
-  },
-  dismissButtonText: {
-    color: '#6B7280',
-    fontSize: 15,
+  label: {
+    fontSize: moderateScale(11.5),
+    fontFamily: 'Manrope-Medium',
   },
 });

--- a/components/DevMenu.tsx
+++ b/components/DevMenu.tsx
@@ -27,6 +27,10 @@ export function DevMenu({whatsNewModalRef}: DevMenuProps) {
   const cycleRandomCardVariant = useDevSettingsStore(
     s => s.cycleRandomCardVariant,
   );
+  const forceNetworkBanner = useDevSettingsStore(s => s.forceNetworkBanner);
+  const toggleForceNetworkBanner = useDevSettingsStore(
+    s => s.toggleForceNetworkBanner,
+  );
 
   function getRandomCardLabel() {
     if (randomCardVariantIndex < 0) return 'Auto (session seed)';
@@ -188,6 +192,25 @@ export function DevMenu({whatsNewModalRef}: DevMenuProps) {
             onPressOut={() => setPressedItem(null)}>
             <Text style={[styles.devMenuText, {color: theme.colors.text}]}>
               🎨 Random Card: {getRandomCardLabel()}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            activeOpacity={1}
+            style={[
+              styles.devMenuItem,
+              {
+                backgroundColor:
+                  pressedItem === 'networkBanner'
+                    ? Color(theme.colors.text).alpha(0.08).toString()
+                    : 'transparent',
+              },
+            ]}
+            onPress={toggleForceNetworkBanner}
+            onPressIn={() => setPressedItem('networkBanner')}
+            onPressOut={() => setPressedItem(null)}>
+            <Text style={[styles.devMenuText, {color: theme.colors.text}]}>
+              📡 Network Banner: {forceNetworkBanner ? 'ON' : 'OFF'}
             </Text>
           </TouchableOpacity>
 

--- a/store/devSettingsStore.ts
+++ b/store/devSettingsStore.ts
@@ -6,6 +6,8 @@ interface DevSettingsState {
   showFloatingDevMenu: boolean;
   setShowFloatingDevMenu: (show: boolean) => void;
   toggleFloatingDevMenu: () => void;
+  forceNetworkBanner: boolean;
+  toggleForceNetworkBanner: () => void;
   // Random card design override (-1 = auto/session seed)
   randomCardVariantIndex: number;
   setRandomCardVariantIndex: (index: number) => void;
@@ -20,6 +22,9 @@ export const useDevSettingsStore = create<DevSettingsState>()(
         set({showFloatingDevMenu: show}),
       toggleFloatingDevMenu: () =>
         set(state => ({showFloatingDevMenu: !state.showFloatingDevMenu})),
+      forceNetworkBanner: false,
+      toggleForceNetworkBanner: () =>
+        set(state => ({forceNetworkBanner: !state.forceNetworkBanner})),
       randomCardVariantIndex: -1,
       setRandomCardVariantIndex: (index: number) =>
         set({randomCardVariantIndex: index}),


### PR DESCRIPTION
## Summary
- Replaced the layout-displacing `ApiDisruptionBanner` with a non-intrusive floating pill that overlays content using `position: absolute` + `zIndex`
- Uses alpha design-system tokens (`Color(theme.colors.text).alpha(...)`) instead of hardcoded hex colors — fully theme-aware for dark/light mode
- Animated slide-in/out with `react-native-reanimated`, Feather icon (`wifi-off` / `alert-circle`) instead of emoji
- Removed retry button and "More" modal — auto-retry on reconnect already handles recovery
- Added dev menu toggle ("📡 Network Banner: ON/OFF") to force-show the banner for testing

## Test plan
- [ ] Toggle airplane mode on device — verify pill appears with "No internet connection" and slides away on reconnect
- [ ] Kill backend or simulate API failure — verify "Backend unreachable" / "Showing cached data" states
- [ ] Confirm pill overlays content without pushing layout down
- [ ] Verify dark mode and light mode rendering
- [ ] Open dev menu → toggle "Network Banner" ON/OFF — confirm banner appears/hides on demand
- [ ] Scroll content behind the pill — confirm it stays floating

🤖 Generated with [Claude Code](https://claude.com/claude-code)