### PR TITLE
fix: increase Quran tab icon size for visual balance

### DIFF
--- a/components/BottomTabBar.tsx
+++ b/components/BottomTabBar.tsx
@@ -36,7 +36,9 @@ function getIcon(
     case '(a.home)':
       return <HomeIcon filled={isFocused} color={color} size={iconSize} />;
     case '(b.surahs)':
-      return <QuranIcon filled={isFocused} color={color} size={iconSize} />;
+      return (
+        <QuranIcon filled={isFocused} color={color} size={iconSize * 1.2} />
+      );
     case '(b.search)':
       return <SearchIcon filled={isFocused} color={color} size={iconSize} />;
     case '(c.collection)':


### PR DESCRIPTION
## Summary
- Bumps the Quran tab icon size by 1.2x to better match the visual weight of other tab bar icons

## Test plan
- [ ] Verify Quran tab icon looks balanced alongside other tab icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)