### PR TITLE
fix: adhkar header styling and settings scroll behavior

### DIFF
--- a/app/(tabs)/(a.home)/adhkar/_layout.tsx
+++ b/app/(tabs)/(a.home)/adhkar/_layout.tsx
@@ -1,16 +1,34 @@
 import {Stack} from 'expo-router';
 import {AdhkarAudioProvider} from '@/components/adhkar/AdhkarAudioProvider';
+import {useTheme} from '@/hooks/useTheme';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 export default function AdhkarLayout() {
+  const {theme} = useTheme();
+
   return (
     <AdhkarAudioProvider>
       <Stack
         screenOptions={{
           headerShown: true,
-          headerTransparent: true,
+          freezeOnBlur: true,
+          headerTintColor: theme.colors.text,
+          ...(USE_GLASS
+            ? {
+                headerTransparent: true,
+                headerStyle: {backgroundColor: 'transparent'},
+              }
+            : {
+                headerStyle: {backgroundColor: theme.colors.background},
+              }),
+          headerTitleStyle: {
+            fontFamily: 'Manrope-SemiBold',
+            color: theme.colors.text,
+          },
           headerShadowVisible: false,
-          headerBackTitle: '',
+          headerBackButtonDisplayMode: 'minimal',
         }}>
+        <Stack.Screen name="index" options={{title: 'Adhkar'}} />
         <Stack.Screen name="[superId]/index" />
         <Stack.Screen name="[superId]/[dhikrId]" />
         <Stack.Screen name="saved" />

--- a/app/(tabs)/(d.settings)/index.tsx
+++ b/app/(tabs)/(d.settings)/index.tsx
@@ -6,7 +6,6 @@ import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {Theme} from '@/utils/themeUtils';
 import {Feather, MaterialIcons} from '@expo/vector-icons';
 import {clearPlayerCache} from '@/services/player/utils/storage';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import Color from 'color';
 import {useBottomInset} from '@/hooks/useBottomInset';
 import {openAppStoreForReview, markAsRated} from '@/utils/reviewUtils';
@@ -200,7 +199,6 @@ const renderIcon = (
 export default function SettingsScreen() {
   const router = useRouter();
   const {theme} = useTheme();
-  const insets = useSafeAreaInsets();
   const bottomInset = useBottomInset();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const {showFloatingDevMenu, toggleFloatingDevMenu} = useDevSettingsStore();
@@ -269,10 +267,10 @@ export default function SettingsScreen() {
   return (
     <View style={styles.container}>
       <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={[
           styles.scrollContent,
           {
-            paddingTop: insets.top + moderateScale(16),
             paddingBottom: bottomInset,
           },
         ]}


### PR DESCRIPTION
## Summary
- Match adhkar layout header to settings sub-screen pattern (platform-aware transparent/solid header, Manrope font, minimal back button)
- Add `contentInsetAdjustmentBehavior="automatic"` to settings index ScrollView so the mini player collapses on scroll
- Remove unused manual safe-area inset padding from settings index

## Test plan
- [ ] Verify adhkar index header looks like settings sub-screens on Android and iOS < 26
- [ ] Verify settings tab mini player collapses on scroll (iOS 26+)
- [ ] Verify settings screen content is not clipped at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)