### PR TITLE
feat: adhkar See More, rewayah navigation context & canonical ordering

### DIFF
--- a/app/(tabs)/(a.home)/adhkar/index.tsx
+++ b/app/(tabs)/(a.home)/adhkar/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {useRouter} from 'expo-router';
+import {AdhkarView} from '@/components/AdhkarView';
+import {SuperCategory} from '@/types/adhkar';
+
+export default function AdhkarIndexScreen() {
+  const router = useRouter();
+
+  const handleCategoryPress = (superCategory: SuperCategory) => {
+    router.push({
+      pathname: '/(tabs)/(a.home)/adhkar/[superId]',
+      params: {superId: superCategory.id},
+    });
+  };
+
+  const handleSavedPress = () => {
+    router.push('/(tabs)/(a.home)/adhkar/saved');
+  };
+
+  return (
+    <AdhkarView
+      onCategoryPress={handleCategoryPress}
+      onSavedPress={handleSavedPress}
+      headerHeight={0}
+    />
+  );
+}

--- a/app/(tabs)/(a.home)/reciter/[id].tsx
+++ b/app/(tabs)/(a.home)/reciter/[id].tsx
@@ -3,13 +3,16 @@ import {useLocalSearchParams} from 'expo-router';
 import ReciterProfile from '@/components/reciter-profile/ReciterProfile';
 
 const HomeReciterProfile: React.FC = () => {
-  const {id} = useLocalSearchParams<{id: string}>();
+  const {id, rewayatId} = useLocalSearchParams<{
+    id: string;
+    rewayatId?: string;
+  }>();
 
   if (!id) {
     return null; // Handle the absence of id appropriately
   }
 
-  return <ReciterProfile id={id} />;
+  return <ReciterProfile id={id} initialRewayatId={rewayatId} />;
 };
 
 export default HomeReciterProfile;

--- a/components/RecitersView.tsx
+++ b/components/RecitersView.tsx
@@ -479,10 +479,7 @@ function RecitersView({onReciterPress}: RecitersViewProps) {
         : [],
     [sessionSeed, registryLoaded],
   );
-  const rewayatTypes = useMemo(
-    () => seededShuffle(getAllRewayatTypes(), sessionSeed + 7),
-    [sessionSeed],
-  );
+  const rewayatTypes = useMemo(() => getAllRewayatTypes(), []);
 
   // Handler for rewayat card press
   const handleRewayatPress = (rewayat: RewayatInfo) => {
@@ -599,6 +596,21 @@ function RecitersView({onReciterPress}: RecitersViewProps) {
             <Text style={[styles.sectionTitle, {color: theme.colors.text}]}>
               Adhkar
             </Text>
+            <Pressable
+              onPress={() => router.push('/(tabs)/(a.home)/adhkar')}
+              hitSlop={8}>
+              <Text
+                style={[
+                  styles.seeMoreButton,
+                  {
+                    color: Color(theme.colors.textSecondary)
+                      .alpha(0.5)
+                      .toString(),
+                  },
+                ]}>
+                See More
+              </Text>
+            </Pressable>
           </View>
           <FlatList
             data={adhkarCategories}
@@ -675,7 +687,7 @@ function RecitersView({onReciterPress}: RecitersViewProps) {
       {/* Rewayat collection - Browse by different narration styles */}
       {rewayatTypes.length > 0 && (
         <Section
-          title="Explore by Rewayat"
+          title="Explore by Rewayah"
           data={rewayatTypes}
           variant="rewayat"
           onReciterPress={onReciterPress}
@@ -717,6 +729,10 @@ const styles = StyleSheet.create({
     fontFamily: 'Manrope-SemiBold',
   },
   clearButton: {
+    fontSize: moderateScale(13),
+    fontFamily: 'Manrope-Medium',
+  },
+  seeMoreButton: {
     fontSize: moderateScale(13),
     fontFamily: 'Manrope-Medium',
   },

--- a/components/browse/BrowseGrid.tsx
+++ b/components/browse/BrowseGrid.tsx
@@ -17,6 +17,7 @@ interface BrowseGridProps {
   theme: Theme;
   keyboardShouldPersistTaps?: 'always' | 'handled' | 'never';
   onScrollBeginDrag?: () => void;
+  getRewayatIdForReciter?: (reciter: Reciter) => string | undefined;
 }
 
 function createStyles(_theme: Theme) {
@@ -54,7 +55,13 @@ const createItemRows = (
 };
 
 const BrowseGrid = React.memo(
-  ({reciters, onReciterPress, theme, onScrollBeginDrag}: BrowseGridProps) => {
+  ({
+    reciters,
+    onReciterPress,
+    theme,
+    onScrollBeginDrag,
+    getRewayatIdForReciter,
+  }: BrowseGridProps) => {
     const {width: windowWidth} = useWindowDimensions();
     const [isLoading] = useState(false);
 
@@ -97,6 +104,7 @@ const BrowseGrid = React.memo(
               width={itemDimensions.width}
               height={itemDimensions.height}
               theme={theme}
+              rewayatId={getRewayatIdForReciter?.(reciter)}
             />
           ))}
           {/* Add empty placeholders for the last row if needed */}
@@ -111,7 +119,14 @@ const BrowseGrid = React.memo(
               ))}
         </View>
       ),
-      [itemDimensions, onReciterPress, theme, numColumns, styles.row],
+      [
+        itemDimensions,
+        onReciterPress,
+        theme,
+        numColumns,
+        styles.row,
+        getRewayatIdForReciter,
+      ],
     );
 
     const keyExtractor = useCallback(
@@ -153,7 +168,8 @@ const BrowseGrid = React.memo(
   (prevProps, nextProps) =>
     prevProps.theme === nextProps.theme &&
     prevProps.onReciterPress === nextProps.onReciterPress &&
-    prevProps.reciters.length === nextProps.reciters.length,
+    prevProps.reciters.length === nextProps.reciters.length &&
+    prevProps.getRewayatIdForReciter === nextProps.getRewayatIdForReciter,
 );
 
 BrowseGrid.displayName = 'BrowseGrid';

--- a/components/browse/BrowseReciterCard.tsx
+++ b/components/browse/BrowseReciterCard.tsx
@@ -17,6 +17,7 @@ interface BrowseReciterCardProps {
   height: number;
   theme: Theme;
   showFollowAlong?: boolean;
+  rewayatId?: string;
 }
 
 function createStyles(theme: Theme, width: number, height: number) {
@@ -77,6 +78,7 @@ const BrowseReciterCard = React.memo(
     width,
     height,
     theme,
+    rewayatId,
   }: BrowseReciterCardProps) => {
     const glassColorScheme = useGlassColorScheme();
     const styles = useMemo(
@@ -115,7 +117,7 @@ const BrowseReciterCard = React.memo(
 
     const linkHref = {
       pathname: '/(tabs)/(a.home)/reciter/[id]' as const,
-      params: {id: reciter.id},
+      params: {id: reciter.id, ...(rewayatId ? {rewayatId} : {})},
     };
 
     if (USE_GLASS) {

--- a/components/browse/BrowseReciters.tsx
+++ b/components/browse/BrowseReciters.tsx
@@ -410,7 +410,10 @@ export default function BrowseReciters({
       } else {
         router.push({
           pathname: '/(tabs)/(a.home)/reciter/[id]',
-          params: {id: reciter.id},
+          params: {
+            id: reciter.id,
+            ...(selectedRewayatId ? {rewayatId: selectedRewayatId} : {}),
+          },
         });
       }
     },
@@ -423,6 +426,35 @@ export default function BrowseReciters({
       handleSearchBlur();
     }
   }, [isSearchFocused, handleSearchBlur]);
+
+  // Resolve the matching rewayat ID for a given reciter based on current teacher/student filter
+  const getRewayatIdForReciter = useCallback(
+    (reciter: Reciter): string | undefined => {
+      const teacher = selectedTeacher;
+      const student = selectedStudent;
+      if (!teacher && !student) return undefined;
+
+      let match =
+        teacher && student
+          ? reciter.rewayat.find(r => {
+              if (!r.name) return false;
+              return (
+                resolveTeacher(r.name) === teacher &&
+                resolveStudent(r.name) === student
+              );
+            })
+          : undefined;
+
+      if (!match && teacher) {
+        match = reciter.rewayat.find(
+          r => r.name && resolveTeacher(r.name) === teacher,
+        );
+      }
+
+      return match?.id;
+    },
+    [selectedTeacher, selectedStudent],
+  );
 
   // Top offset: native header height on iOS, 0 on Android (custom Header handles it)
   const topOffset = useNativeHeader ? iosHeaderHeight : 0;
@@ -444,7 +476,11 @@ export default function BrowseReciters({
         <View
           style={[
             styles.searchFilterContainer,
-            {marginTop: useNativeHeader ? topOffset : insets.top + moderateScale(56)},
+            {
+              marginTop: useNativeHeader
+                ? topOffset
+                : insets.top + moderateScale(56),
+            },
           ]}>
           <SearchInput
             placeholder="Search reciters..."
@@ -551,6 +587,7 @@ export default function BrowseReciters({
             theme={theme}
             keyboardShouldPersistTaps="handled"
             onScrollBeginDrag={() => Keyboard.dismiss()}
+            getRewayatIdForReciter={getRewayatIdForReciter}
           />
         </View>
 

--- a/components/browse/FilterModal.tsx
+++ b/components/browse/FilterModal.tsx
@@ -13,6 +13,7 @@ import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {Theme} from '@/utils/themeUtils';
 import {RECITERS} from '@/data/reciterData';
+import {resolveRewayatName, getRewayahNames} from '@/data/rewayat';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 interface FilterModalProps {
@@ -36,20 +37,42 @@ const STYLE_OPTIONS = [
   {label: 'Murattal', value: 'murattal'},
 ];
 
-// Get unique rewayat names from reciters
-const getUniqueRewayatNames = () => {
-  const rewayatNames = new Set<string>();
+// Get rewayat names available in the reciter data, ordered by canonical Qira'at teacher order.
+// Groups DB names (including aliases) under their canonical registry entry, then returns
+// them in registry order so the UI follows the traditional Qira'at sequence.
+const getAvailableRewayatNames = (): string[] => {
+  // Collect all unique DB names from reciters
+  const dbNames = new Set<string>();
+  for (const reciter of RECITERS) {
+    for (const r of reciter.rewayat) {
+      if (r.name) dbNames.add(r.name);
+    }
+  }
 
-  RECITERS.forEach(reciter => {
-    reciter.rewayat.forEach(r => {
-      if (r.name) {
-        rewayatNames.add(r.name);
+  // Build ordered list: for each canonical entry, include matching DB names in registry order
+  const canonicalNames = getRewayahNames();
+  const ordered: string[] = [];
+  const placed = new Set<string>();
+
+  for (const primaryName of canonicalNames) {
+    for (const dbName of dbNames) {
+      if (placed.has(dbName)) continue;
+      const resolved = resolveRewayatName(dbName);
+      if (resolved && resolved.name === primaryName) {
+        ordered.push(dbName);
+        placed.add(dbName);
       }
-    });
-  });
+    }
+  }
 
-  // Convert to array and sort alphabetically
-  return Array.from(rewayatNames).sort();
+  // Append any unresolved DB names at the end
+  for (const dbName of dbNames) {
+    if (!placed.has(dbName)) {
+      ordered.push(dbName);
+    }
+  }
+
+  return ordered;
 };
 
 function createStyles(theme: Theme) {
@@ -193,7 +216,7 @@ export default function FilterModal({
 }: FilterModalProps) {
   const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(theme), [theme]);
-  const rewayatNames = useMemo(() => getUniqueRewayatNames(), []);
+  const rewayatNames = useMemo(() => getAvailableRewayatNames(), []);
 
   const defaultFilters: FilterOptions = {
     styles: [],

--- a/components/reciter-profile/ReciterProfile.tsx
+++ b/components/reciter-profile/ReciterProfile.tsx
@@ -68,6 +68,7 @@ import {reciterShareUrl, shareUrl} from '@/utils/shareUtils';
 interface ReciterProfileProps {
   id: string;
   showLoved?: boolean;
+  initialRewayatId?: string;
 }
 
 // Define types matching useSettings
@@ -186,6 +187,7 @@ const isGlass = USE_GLASS;
 const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
   id: currentReciterId,
   showLoved = false,
+  initialRewayatId: initialRewayatIdProp,
 }) => {
   const {theme} = useTheme();
   const styles = createSharedStyles(theme);
@@ -200,7 +202,16 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
     () => initReciter(currentReciterId),
     [currentReciterId],
   );
-  const initialRewayatId = initialReciter?.rewayat[0]?.id;
+  // Prefer the rewayat passed via navigation, then fall back to the first one
+  const initialRewayatId = useMemo(() => {
+    if (
+      initialRewayatIdProp &&
+      initialReciter?.rewayat.some(r => r.id === initialRewayatIdProp)
+    ) {
+      return initialRewayatIdProp;
+    }
+    return initialReciter?.rewayat[0]?.id;
+  }, [initialRewayatIdProp, initialReciter]);
 
   const [reciter, setReciter] = useState<Reciter | null>(initialReciter);
   const surahs = SURAHS;
@@ -211,7 +222,22 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
 
   const scrollY = useRef(new RNAnimated.Value(0)).current;
   const scrollX = useRef(
-    new RNAnimated.Value(initialReciter ? screenWidth : 0),
+    new RNAnimated.Value(
+      initialReciter
+        ? (() => {
+            // "My Uploads" is at index 0; rewayat start at index 1.
+            // Find the index of the initial rewayat to set the correct scroll position.
+            if (!initialRewayatId) return screenWidth;
+            const rewayatIndex = initialReciter.rewayat.findIndex(
+              r => r.id === initialRewayatId,
+            );
+            // +1 because "My Uploads" occupies index 0
+            return rewayatIndex >= 0
+              ? (rewayatIndex + 1) * screenWidth
+              : screenWidth;
+          })()
+        : 0,
+    ),
   ).current;
   const iconsOpacity = useRef(new RNAnimated.Value(1)).current;
   const iconsZIndex = useRef(new RNAnimated.Value(20)).current;
@@ -743,14 +769,25 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
     ],
   );
 
-  // Opacity-gated reveal: scroll pager to first rewayat (index 1) before showing
+  // Opacity-gated reveal: scroll pager to initial rewayat tab before showing.
+  // Defaults to index 1 (first rewayat, skipping "My Uploads" at index 0),
+  // but honours initialRewayatId when navigating from a rewayah-specific context.
+  const initialTabIndex = useMemo(() => {
+    if (!initialRewayatId) return 1;
+    const idx = tabs.findIndex(t => t.id === initialRewayatId);
+    return idx >= 0 ? idx : 1;
+  }, [initialRewayatId, tabs]);
+
   const handlePagerContentSizeChange = useCallback(
     (contentWidth: number) => {
       if (pagerScrolledRef.current) return;
-      if (contentWidth >= 2 * screenWidth) {
+      const targetX = initialTabIndex * screenWidth;
+      if (contentWidth >= targetX + screenWidth) {
         pagerScrolledRef.current = true;
+        // Set scrollX so the tab bar indicator lands on the correct tab immediately
+        scrollX.setValue(targetX);
         horizontalRef.current?.scrollTo({
-          x: screenWidth,
+          x: targetX,
           y: 0,
           animated: false,
         });
@@ -760,7 +797,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
         });
       }
     },
-    [screenWidth, pagerOpacity],
+    [screenWidth, pagerOpacity, initialTabIndex, scrollX],
   );
 
   // Sticky title bar opacity — fades in as the outer scroll collapses the header


### PR DESCRIPTION
## Summary
- Add See More button to the adhkar section on the home screen, linking to a new adhkar index page showing all categories
- Pass rewayatId through navigation so the reciter detail screen opens on the correct rewayah tab when browsing by rewayah
- Order rewayat canonically by Qira'at teacher in the filter modal and home screen instead of alphabetical/shuffled

## Test plan
- [ ] Tap See More on the adhkar section - adhkar index page loads with back button, no extra top spacing
- [ ] Tap a rewayah card on home - browse reciters - tap a reciter - correct rewayah tab is active
- [ ] Normal reciter navigation (not via rewayah) still defaults to first rewayah (Hafs)
- [ ] Filter modal in browse reciters shows rewayat in canonical Qiraat order
- [ ] Explore by Rewayah section on home screen shows rewayat in canonical order (no shuffle)