### PR TITLE
fix: Android crash on setColorScheme(null) and settings top inset

### DIFF
--- a/app/(tabs)/(d.settings)/index.tsx
+++ b/app/(tabs)/(d.settings)/index.tsx
@@ -8,6 +8,7 @@ import {Feather, MaterialIcons} from '@expo/vector-icons';
 import {clearPlayerCache} from '@/services/player/utils/storage';
 import Color from 'color';
 import {useBottomInset} from '@/hooks/useBottomInset';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {openAppStoreForReview, markAsRated} from '@/utils/reviewUtils';
 import {
   QuranIcon,
@@ -200,6 +201,7 @@ export default function SettingsScreen() {
   const router = useRouter();
   const {theme} = useTheme();
   const bottomInset = useBottomInset();
+  const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const {showFloatingDevMenu, toggleFloatingDevMenu} = useDevSettingsStore();
 
@@ -271,6 +273,7 @@ export default function SettingsScreen() {
         contentContainerStyle={[
           styles.scrollContent,
           {
+            paddingTop: insets.top + moderateScale(10),
             paddingBottom: bottomInset,
           },
         ]}

--- a/store/themeStore.ts
+++ b/store/themeStore.ts
@@ -2,7 +2,7 @@ import {create} from 'zustand';
 import {createJSONStorage, persist} from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {ThemeMode, PrimaryColor, Theme, createTheme} from '@/utils/themeUtils';
-import {Appearance} from 'react-native';
+import {Appearance, Platform} from 'react-native';
 
 interface ThemeState {
   themeMode: ThemeMode;
@@ -47,8 +47,11 @@ export const useThemeStore = create<ThemeState>()(
         set(state => {
           const newTheme = getEffectiveTheme(mode, state.primaryColor);
           // Sync native UI (keyboard, alerts, liquid glass chrome) with the choice
+          // Android's AppearanceModule.setColorScheme crashes on null — skip the call entirely
           if (mode === 'system') {
-            Appearance.setColorScheme(null as any); // revert to system
+            if (Platform.OS !== 'android') {
+              Appearance.setColorScheme(null as any);
+            }
           } else {
             Appearance.setColorScheme(mode);
           }
@@ -79,7 +82,9 @@ export const useThemeStore = create<ThemeState>()(
           const theme = getEffectiveTheme(state.themeMode, state.primaryColor);
           // Sync native UI with the persisted preference on app launch
           if (state.themeMode === 'system') {
-            Appearance.setColorScheme(null as any);
+            if (Platform.OS !== 'android') {
+              Appearance.setColorScheme(null as any);
+            }
           } else {
             Appearance.setColorScheme(state.themeMode);
           }


### PR DESCRIPTION
## Summary
- Skip `Appearance.setColorScheme` when reverting to system theme on Android — the Kotlin native module requires non-null, passing null throws `NullPointerException` and crashes the app on launch
- Add safe area top padding to settings screen which was missing on Android (`contentInsetAdjustmentBehavior="automatic"` only works on iOS)

## Test plan
- [ ] Launch app on Android device — no crash on startup
- [ ] Toggle theme between system/light/dark in settings — no crash
- [ ] Settings screen has proper top inset on Android
- [ ] iOS still works as before (setColorScheme(null) path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)