### PR TITLE
docs: add TRADEMARKS.md

### DIFF
--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,72 @@
+# Bayaan Trademark Policy
+
+Bayaan's source code is licensed under the GNU Affero General Public License v3.0 or later. **The name "Bayaan" and the Bayaan logo are not covered by that license.** They are trademarks of the Bayaan project and are governed by this policy.
+
+This separation is standard for open-source projects. It lets anyone study, run, and contribute to the code while preventing confusion about which builds are the official Bayaan.
+
+---
+
+## What this policy covers
+
+- The word mark **"Bayaan"** (including common variations like "Bayaan App").
+- The Bayaan logo, app icon, splash screen artwork, and any associated brand marks in `assets/`.
+- Any stylized use of "Bayaan" that suggests the project endorses a product, fork, or service.
+
+---
+
+## What forks and derivatives **must** do
+
+If you fork, modify, or redistribute Bayaan, you must:
+
+1. **Choose a new name.** Your fork cannot be called "Bayaan", "Bayaan 2", "Bayaan Plus", "New Bayaan", "Bayaan Pro", or any confusingly similar variant.
+2. **Use your own icons and splash artwork.** Replace `assets/images/icon.png`, the adaptive icons, and the splash images. You may not ship builds using the original Bayaan icons.
+3. **Use your own bundle identifier.** Change the iOS bundle ID and Android application ID from `com.bayaan.app` to your own. Builds submitted to the App Store or Google Play must not reuse Bayaan's identifiers.
+4. **Remove or replace brand strings.** If your fork displays "Bayaan" anywhere in its UI, settings, or metadata, replace those strings with your own product name.
+5. **Comply with the AGPL.** The code license applies whether or not you comply with this policy; this policy is additional.
+
+---
+
+## What you **may** do without asking
+
+You do not need permission to:
+
+- Refer to "Bayaan" by name when reviewing, writing about, tutorial-ing, or critiquing the project (nominative fair use).
+- State accurately that your fork is "based on Bayaan" or "forked from Bayaan," as long as it is clear your fork is not the original and not endorsed by the Bayaan project.
+- Use the Bayaan name in academic, journalistic, or educational contexts.
+- Link to the official Bayaan repository or website.
+
+---
+
+## What you **may not** do
+
+- Ship a product, app, service, or website that uses "Bayaan" in its name or branding without written permission.
+- Use the Bayaan logo or icons in your own product's marketing, app listings, or UI.
+- Imply that your fork is endorsed by, affiliated with, or maintained by the Bayaan project.
+- Register domain names, social media handles, or trademarks containing "Bayaan" that could be confused with the official project.
+- Monetize products or services that use the Bayaan name or logo.
+
+---
+
+## Requesting permission
+
+If you would like to use the Bayaan name or logo for a purpose not permitted above — for example, a community event, a translation partnership, or an officially-endorsed fork — open a GitHub issue or contact the maintainers.
+
+Permission is granted case-by-case in writing. A "no" today is not a "yes" tomorrow; do not assume prior grants extend to new uses.
+
+---
+
+## Enforcement
+
+The Bayaan project reserves the right to:
+
+- Request that App Store and Play Store listings using the Bayaan name or logo be removed.
+- File DMCA notices and trademark complaints against infringing products.
+- Pursue the remedies available to trademark holders under applicable law.
+
+Most conflicts are resolved amicably when people understand the policy. If you are unsure whether your use is permitted, ask first.
+
+---
+
+## Precedent
+
+This policy follows the pattern used by established open-source projects that separate code licensing from brand protection — most notably Mozilla (Firefox), Signal, Element, and the Linux Foundation. The underlying principle is the same: the code is free, the name is not.


### PR DESCRIPTION
## Summary
- Add `TRADEMARKS.md` documenting the brand carve-out referenced in the README License section (added in #212)
- Clarifies that AGPL-3.0 covers code but not the Bayaan name, logo, or app icons
- Sets rebranding requirements for forks (new name, new icons, new bundle ID) while preserving nominative fair use for reviews, tutorials, and academic work

## Why
Permissive + copyleft OSS licenses do not grant trademark rights. Without a written policy, forks can legally rebrand and ship clones to app stores using the Bayaan name and icons. This policy closes that gap.

Follows the Mozilla / Signal / Element model: the code is free, the name is not.

## Stacking
Sits alongside #212 (AGPL license swap). Non-conflicting — can merge in either order. The README in #212 references this file; once both merge, the reference resolves.

## Test plan
- [x] Prettier-formatted
- [x] No code changes, no TS impact
- [ ] Reviewer to sanity-check the plain-English wording and the enforcement section

🤖 Generated with [Claude Code](https://claude.com/claude-code)