### PR TITLE
feat(share): canonical URLs matching web app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,15 @@
         <data android:scheme="com.bayaan.app"/>
         <data android:scheme="exp+bayaan"/>
       </intent-filter>
+      <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="https" android:host="app.thebayaan.com" android:pathPrefix="/quran"/>
+        <data android:scheme="https" android:host="app.thebayaan.com" android:pathPrefix="/reciter"/>
+        <data android:scheme="https" android:host="app.thebayaan.com" android:pathPrefix="/mushaf"/>
+        <data android:scheme="https" android:host="app.thebayaan.com" android:pathPrefix="/adhkar"/>
+      </intent-filter>
     </activity>
   </application>
 </manifest>

--- a/app.config.js
+++ b/app.config.js
@@ -19,6 +19,7 @@ module.exports = {
       bundleIdentifier: 'com.bayaan.app',
       buildNumber: versionInfo.buildNumber,
       supportsTablet: true,
+      associatedDomains: ['applinks:app.thebayaan.com'],
       config: {
         usesNonExemptEncryption: false,
       },
@@ -93,6 +94,35 @@ module.exports = {
         backgroundColor: '#8dc9d6',
       },
       screenOrientation: 'portrait',
+      intentFilters: [
+        {
+          action: 'VIEW',
+          autoVerify: true,
+          data: [
+            {
+              scheme: 'https',
+              host: 'app.thebayaan.com',
+              pathPrefix: '/quran',
+            },
+            {
+              scheme: 'https',
+              host: 'app.thebayaan.com',
+              pathPrefix: '/reciter',
+            },
+            {
+              scheme: 'https',
+              host: 'app.thebayaan.com',
+              pathPrefix: '/mushaf',
+            },
+            {
+              scheme: 'https',
+              host: 'app.thebayaan.com',
+              pathPrefix: '/adhkar',
+            },
+          ],
+          category: ['BROWSABLE', 'DEFAULT'],
+        },
+      ],
     },
     updates: {
       enabled: true,

--- a/app/mushaf/[page].tsx
+++ b/app/mushaf/[page].tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {Redirect} from 'expo-router';
+
+// Receiver for https://app.thebayaan.com/mushaf/{page}. The app does not
+// currently expose a standalone mushaf route (the mushaf renders inside the
+// player sheet), so we fall back to the home tab. This keeps Android App Link
+// autoverify green and prevents the URL from opening in the browser.
+export default function MushafDeepLinkReceiver(): React.ReactElement {
+  return <Redirect href="/" />;
+}

--- a/app/quran/[surah].tsx
+++ b/app/quran/[surah].tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {Redirect} from 'expo-router';
+
+// Receiver for https://app.thebayaan.com/quran/{surah}?v={ayah}. The app does
+// not currently expose a standalone quran surah route, so we fall back to the
+// home tab. This keeps Android App Link autoverify green and prevents the URL
+// from opening in the browser.
+export default function QuranSurahDeepLinkReceiver(): React.ReactElement {
+  return <Redirect href="/" />;
+}

--- a/app/quran/[surah]/[ayah].tsx
+++ b/app/quran/[surah]/[ayah].tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {Redirect} from 'expo-router';
+
+// Receiver for https://app.thebayaan.com/quran/{surah}/{ayah}. The app does
+// not currently expose a standalone verse route, so we fall back to the home
+// tab. This keeps Android App Link autoverify green and prevents the URL from
+// opening in the browser.
+export default function QuranVerseDeepLinkReceiver(): React.ReactElement {
+  return <Redirect href="/" />;
+}

--- a/app/reciter/[id]/[surah].tsx
+++ b/app/reciter/[id]/[surah].tsx
@@ -1,0 +1,97 @@
+import React, {useEffect, useRef} from 'react';
+import {View} from 'react-native';
+import {Redirect, useLocalSearchParams} from 'expo-router';
+import TrackPlayer from 'react-native-track-player';
+import {LoadingIndicator} from '@/components/LoadingIndicator';
+import {getReciterById, getAllSurahs} from '@/services/dataService';
+import {generateSmartAudioUrl} from '@/utils/audioUtils';
+import {getReciterArtwork} from '@/utils/artworkUtils';
+import {usePlayerStore} from '@/services/player/store/playerStore';
+import {useDownloadStore} from '@/services/player/store/downloadStore';
+
+// Receiver for canonical recitation deep links:
+//   https://app.thebayaan.com/reciter/{slug}/{surah}?rewayah={id}&t={sec}
+//
+// Triggers playback of the requested surah for the reciter, then redirects
+// to the reciter profile page inside the home tab.
+export default function RecitationDeepLinkReceiver(): React.ReactElement {
+  const params = useLocalSearchParams<{
+    id: string;
+    surah: string;
+    rewayah?: string;
+    t?: string;
+  }>();
+  const didStartRef = useRef(false);
+
+  useEffect(() => {
+    if (didStartRef.current) return;
+    didStartRef.current = true;
+
+    const reciterId = params.id;
+    const surahNum = Number(params.surah);
+    const rewayahId = params.rewayah;
+    const tSec = params.t ? Number(params.t) : undefined;
+
+    if (!reciterId || !Number.isFinite(surahNum)) return;
+
+    (async () => {
+      try {
+        const reciter = await getReciterById(reciterId);
+        if (!reciter) return;
+        const surahs = await getAllSurahs();
+        const surah = surahs.find(s => s.id === surahNum);
+        if (!surah) return;
+
+        const chosenRewayat =
+          (rewayahId && reciter.rewayat.find(r => r.id === rewayahId)) ||
+          reciter.rewayat[0];
+        if (!chosenRewayat) return;
+
+        useDownloadStore.getState();
+        const artwork = getReciterArtwork(reciter);
+        const firstTrack = {
+          id: `${reciter.id}:${surah.id}`,
+          url: generateSmartAudioUrl(
+            reciter,
+            surah.id.toString(),
+            chosenRewayat.id,
+          ),
+          title: surah.name,
+          artist: reciter.name,
+          reciterId: reciter.id,
+          artwork,
+          surahId: surah.id.toString(),
+          reciterName: reciter.name,
+          rewayatId: chosenRewayat.id,
+        };
+
+        await TrackPlayer.reset();
+        await TrackPlayer.add(firstTrack);
+        if (tSec && Number.isFinite(tSec) && tSec > 0) {
+          await TrackPlayer.seekTo(tSec);
+        }
+        await TrackPlayer.play();
+
+        usePlayerStore.getState().updateQueueState({
+          tracks: [firstTrack],
+          currentIndex: 0,
+          total: 1,
+          loading: false,
+          endReached: false,
+        });
+      } catch (error) {
+        console.error('[Deep link] Failed to start recitation:', error);
+      }
+    })();
+  }, [params.id, params.surah, params.rewayah, params.t]);
+
+  if (!params.id) {
+    return (
+      <View style={{flex: 1}}>
+        <LoadingIndicator />
+      </View>
+    );
+  }
+
+  return <Redirect href={`/reciter/${params.id}`} />;
+}

--- a/utils/shareUtils.ts
+++ b/utils/shareUtils.ts
@@ -1,0 +1,48 @@
+import {Share} from 'react-native';
+
+const BASE_URL = 'https://app.thebayaan.com';
+
+export function verseShareUrl(surah: number, ayah: number): string {
+  return `${BASE_URL}/quran/${surah}/${ayah}`;
+}
+
+export function surahShareUrl(surah: number, ayah?: number): string {
+  return ayah
+    ? `${BASE_URL}/quran/${surah}?v=${ayah}`
+    : `${BASE_URL}/quran/${surah}`;
+}
+
+export function reciterShareUrl(slug: string): string {
+  return `${BASE_URL}/reciter/${slug}`;
+}
+
+export function recitationShareUrl(
+  slug: string,
+  surahNum: number,
+  rewayahId?: string,
+  tSec?: number,
+): string {
+  const params = new URLSearchParams();
+  if (rewayahId) params.set('rewayah', rewayahId);
+  if (tSec) params.set('t', String(tSec));
+  const q = params.toString();
+  return `${BASE_URL}/reciter/${slug}/${surahNum}${q ? `?${q}` : ''}`;
+}
+
+export function mushafShareUrl(page: number, theme?: 'light'): string {
+  return theme === 'light'
+    ? `${BASE_URL}/mushaf/${page}?theme=light`
+    : `${BASE_URL}/mushaf/${page}`;
+}
+
+export function adhkarShareUrl(superId: string): string {
+  return `${BASE_URL}/adhkar/${superId}`;
+}
+
+export function dhikrShareUrl(superId: string, dhikrId: string): string {
+  return `${BASE_URL}/adhkar/${superId}/${dhikrId}`;
+}
+
+export async function shareUrl(url: string, message: string): Promise<void> {
+  await Share.share({message: `${message}\n${url}`, url});
+}


### PR DESCRIPTION
## Summary

Mobile half of the canonical share URLs feature. Aligns the Expo app with the new URL contract landed on the web (drop `/share/` prefix, drop `style` path segment).

- `utils/shareUtils.ts`: new builders (`verseShareUrl`, `surahShareUrl`, `reciterShareUrl`, `recitationShareUrl`, `mushafShareUrl`, `adhkarShareUrl`, `dhikrShareUrl`, `shareUrl`) matching the web's `src/lib/share-urls.ts`. `recitationShareUrl` is the 4-arg signature `(slug, surahNum, rewayahId?, tSec?)`.
- `app.config.js`: added `ios.associatedDomains: ['applinks:app.thebayaan.com']` and `android.intentFilters` (autoVerify) for `/quran`, `/reciter`, `/mushaf`, `/adhkar`.
- `android/app/src/main/AndroidManifest.xml`: added a mirrored `<intent-filter android:autoVerify="true">` with four `<data>` elements so Android App Links are verified on install.
- New minimal receiver routes so expo-router resolves the canonical paths:
  - `app/reciter/[id]/[surah].tsx` — autoplays the surah for the reciter, honours `?rewayah={id}` and seeks to `?t={sec}`, then redirects to the reciter profile in the home tab.
  - `app/mushaf/[page].tsx`, `app/quran/[surah].tsx`, `app/quran/[surah]/[ayah].tsx` — redirect to `/` (home tab) as a graceful fallback, since the app does not currently expose standalone mushaf/quran routes (the mushaf lives inside the player sheet, and there is no standalone Quran reader).

## Notes on plan deviations

- The plan assumed pre-existing `app/share/*` receiver routes and callers of a 5-arg `recitationShareUrl` in `SurahOptionsSheet.tsx` / `PlayerOptionsSheet.tsx`. Neither exists in this repo — no `/share/*` routes, no callers of the old signature. Nothing to delete, no callers to update.
- `/reciter/{slug}` and `/adhkar/{superId}{,/{dhikrId}}` are already handled by the existing tab-scoped routes (`app/(tabs)/(a.home)/...`), which expo-router matches natively since route groups don't appear in URLs.
- Used `[id]` (not `[slug]`) for the new recitation receiver to stay consistent with the existing `reciter/[id]` param name.

## Test plan

- [ ] `npx tsc --noEmit` — 27 pre-existing errors on `main`, zero new errors introduced by this PR (verified via baseline diff with `git stash`).
- [ ] `npx prettier --write` on all changed files — clean.
- [ ] `npx jest --watchAll=false` — only existing test file is `utils/__tests__/storageAnalytics.test.ts`, which is empty at baseline (unrelated pre-existing failure).
- [ ] Manual: install dev build on Android, `adb shell am start -W -a android.intent.action.VIEW -d "https://app.thebayaan.com/reciter/mishary-rashid-alafasy/36?rewayah=hafs-murattal&t=30"` should open the app, autoplay Yā-Sīn, and seek to 30s.
- [ ] Manual: on iOS after the web AASA file is live, tap a shared recitation link — should Universal Link into the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)