### PR TITLE
feat(surah): cards share hero's gradient mesh; hero accepts resumePage

### DIFF
--- a/components/cards/SurahCard.tsx
+++ b/components/cards/SurahCard.tsx
@@ -12,8 +12,11 @@ import {
 import {useTheme} from '@/hooks/useTheme';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {surahGlyphMap} from '@/utils/surahGlyphMap';
-import {LinearGradient} from 'expo-linear-gradient';
 import Color from 'color';
+import {
+  SurahGradientMesh,
+  paletteForSurah,
+} from '@/components/hero/SurahGradientMesh';
 import {MakkahIcon, MadinahIcon, HeartIcon} from '@/components/Icons';
 import {Ionicons, Feather} from '@expo/vector-icons';
 import Animated, {
@@ -161,12 +164,10 @@ export const SurahCard: React.FC<SurahCardProps> = ({
     onPress();
   };
 
-  const gradientColors = React.useMemo((): [string, string] => {
-    const baseColor = Color(color);
-    const gradientStart = baseColor.alpha(0.15).toString();
-    const gradientEnd = baseColor.alpha(0.05).toString();
-    return [gradientStart, gradientEnd];
-  }, [color]);
+  // Match the surah hero's gradient-mesh treatment so card and hero
+  // share the same visual vocabulary. Palette rotates deterministically
+  // per surah id, so a card always shows the same colors.
+  const meshPalette = React.useMemo(() => paletteForSurah(id), [id]);
   const styles = StyleSheet.create({
     container: {
       width: moderateScale(120),
@@ -329,11 +330,11 @@ export const SurahCard: React.FC<SurahCardProps> = ({
 
   const cardContent = (
     <>
-      <LinearGradient
-        colors={gradientColors as [string, string]}
-        start={{x: 0, y: 0}}
-        end={{x: 1, y: 1}}
-        style={StyleSheet.absoluteFill}
+      <SurahGradientMesh
+        palette={meshPalette}
+        isDark={theme.isDarkMode}
+        viewBoxWidth={120}
+        viewBoxHeight={120}
       />
       <View style={styles.placeIcon}>
         {revelationPlace.toLowerCase() === 'makkah' ? (

--- a/components/hero/ContinueReadingHero.tsx
+++ b/components/hero/ContinueReadingHero.tsx
@@ -61,6 +61,10 @@ export function ContinueReadingHero({
             onLongPress={onSurahLongPress}
             title={title}
             style={cardStyle}
+            // Only wire the resume page when the user actually has
+            // reading history; otherwise the hero falls back to
+            // Surah of the Day and should open at page 1.
+            resumePage={lastReadPage ?? undefined}
           />
         </View>
       }

--- a/components/hero/SurahGradientMesh.tsx
+++ b/components/hero/SurahGradientMesh.tsx
@@ -1,0 +1,122 @@
+import React, {useId} from 'react';
+import {StyleSheet} from 'react-native';
+import Svg, {
+  Defs,
+  RadialGradient as SvgRadialGradient,
+  Stop,
+  Rect,
+} from 'react-native-svg';
+
+// Shared gradient-mesh palettes used by the surah hero and grid cards
+// so both surfaces read with the same visual vocabulary.
+export const MESH_PALETTES = [
+  // Purple dream
+  ['#e879f9', '#a78bfa', '#38bdf8', '#34d399'],
+  // Ocean depths
+  ['#38bdf8', '#818cf8', '#5eead4', '#a78bfa'],
+  // Golden hour
+  ['#fbbf24', '#fb923c', '#f87171', '#e879f9'],
+  // Rose garden
+  ['#f9a8d4', '#fb7185', '#a78bfa', '#38bdf8'],
+  // Emerald forest
+  ['#34d399', '#86efac', '#38bdf8', '#a78bfa'],
+  // Twilight
+  ['#a5b4fc', '#c4b5fd', '#f9a8d4', '#5eead4'],
+] as const;
+
+export type MeshPalette = (typeof MESH_PALETTES)[number];
+
+export function paletteForSurah(surahId: number): MeshPalette {
+  return MESH_PALETTES[(surahId - 1) % MESH_PALETTES.length];
+}
+
+interface SurahGradientMeshProps {
+  palette: MeshPalette | readonly string[];
+  isDark: boolean;
+  // Optional viewBox; defaults to the hero's aspect ratio. Callers
+  // with different aspect ratios can override without it affecting
+  // the blob positions (they're % based).
+  viewBoxWidth?: number;
+  viewBoxHeight?: number;
+}
+
+/**
+ * Four soft radial-gradient blobs laid over a transparent background.
+ * Each blob has a unique id (via useId) so multiple meshes can coexist
+ * on one screen without gradient-id collisions.
+ */
+export function SurahGradientMesh({
+  palette,
+  isDark,
+  viewBoxWidth = 400,
+  viewBoxHeight = 155,
+}: SurahGradientMeshProps): React.ReactElement {
+  const uid = useId();
+  const id = (n: number): string => `bayaan-mesh-${uid}-${n}`;
+
+  const mainOpacity = isDark ? 0.12 : 0.15;
+  const tertiaryOpacity = isDark ? 0.08 : 0.1;
+  const quaternaryOpacity = isDark ? 0.06 : 0.08;
+
+  return (
+    <Svg
+      style={StyleSheet.absoluteFill}
+      viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
+      preserveAspectRatio="xMidYMid slice">
+      <Defs>
+        <SvgRadialGradient id={id(1)} cx="0.2" cy="0.3" r="0.35">
+          <Stop offset="0" stopColor={palette[0]} stopOpacity={mainOpacity} />
+          <Stop offset="1" stopColor={palette[0]} stopOpacity={0} />
+        </SvgRadialGradient>
+        <SvgRadialGradient id={id(2)} cx="0.75" cy="0.7" r="0.3">
+          <Stop offset="0" stopColor={palette[1]} stopOpacity={mainOpacity} />
+          <Stop offset="1" stopColor={palette[1]} stopOpacity={0} />
+        </SvgRadialGradient>
+        <SvgRadialGradient id={id(3)} cx="0.55" cy="0.2" r="0.25">
+          <Stop
+            offset="0"
+            stopColor={palette[2]}
+            stopOpacity={tertiaryOpacity}
+          />
+          <Stop offset="1" stopColor={palette[2]} stopOpacity={0} />
+        </SvgRadialGradient>
+        <SvgRadialGradient id={id(4)} cx="0.35" cy="0.8" r="0.2">
+          <Stop
+            offset="0"
+            stopColor={palette[3]}
+            stopOpacity={quaternaryOpacity}
+          />
+          <Stop offset="1" stopColor={palette[3]} stopOpacity={0} />
+        </SvgRadialGradient>
+      </Defs>
+      <Rect
+        x="0"
+        y="0"
+        width={viewBoxWidth}
+        height={viewBoxHeight}
+        fill={`url(#${id(1)})`}
+      />
+      <Rect
+        x="0"
+        y="0"
+        width={viewBoxWidth}
+        height={viewBoxHeight}
+        fill={`url(#${id(2)})`}
+      />
+      <Rect
+        x="0"
+        y="0"
+        width={viewBoxWidth}
+        height={viewBoxHeight}
+        fill={`url(#${id(3)})`}
+      />
+      <Rect
+        x="0"
+        y="0"
+        width={viewBoxWidth}
+        height={viewBoxHeight}
+        fill={`url(#${id(4)})`}
+      />
+    </Svg>
+  );
+}

--- a/components/hero/SurahsHero.tsx
+++ b/components/hero/SurahsHero.tsx
@@ -11,31 +11,14 @@ import {SurahOfTheDay} from './SurahOfTheDay';
 import {Link} from 'expo-router';
 import {GlassView} from 'expo-glass-effect';
 import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
-import Svg, {
-  Defs,
-  RadialGradient as SvgRadialGradient,
-  Stop,
-  Rect,
-} from 'react-native-svg';
 import {SESSION_SEED, pickHeroTheme} from '@/components/hero/heroThemes';
+import {
+  MESH_PALETTES,
+  SurahGradientMesh,
+} from '@/components/hero/SurahGradientMesh';
 
 // Same SECTION_HEIGHT as ScrollingHero for consistency
 const SECTION_HEIGHT = moderateScale(150);
-
-const MESH_PALETTES = [
-  // Purple dream
-  ['#e879f9', '#a78bfa', '#38bdf8', '#34d399'],
-  // Ocean depths
-  ['#38bdf8', '#818cf8', '#5eead4', '#a78bfa'],
-  // Golden hour
-  ['#fbbf24', '#fb923c', '#f87171', '#e879f9'],
-  // Rose garden
-  ['#f9a8d4', '#fb7185', '#a78bfa', '#38bdf8'],
-  // Emerald forest
-  ['#34d399', '#86efac', '#38bdf8', '#a78bfa'],
-  // Twilight
-  ['#a5b4fc', '#c4b5fd', '#f9a8d4', '#5eead4'],
-];
 
 interface SurahHeroSectionProps {
   surah: Surah;
@@ -43,6 +26,10 @@ interface SurahHeroSectionProps {
   title?: string;
   isCompact?: boolean;
   style?: ViewStyle | ViewStyle[];
+  // When provided, tapping the hero opens the mushaf at this exact
+  // page (e.g. where the user last stopped). Without it the link
+  // falls back to the surah's first page.
+  resumePage?: number;
 }
 
 /**
@@ -54,6 +41,7 @@ export const SurahHeroSection = ({
   onLongPress,
   title = 'SURAH OF THE DAY',
   style,
+  resumePage,
 }: SurahHeroSectionProps) => {
   const {theme} = useTheme();
   const glassColorScheme = useGlassColorScheme();
@@ -86,42 +74,8 @@ export const SurahHeroSection = ({
     <>
       {/* Solid background behind mesh */}
       <View style={[StyleSheet.absoluteFill, {backgroundColor: baseBg}]} />
-      {/* SVG gradient mesh blobs */}
-      <Svg
-        style={StyleSheet.absoluteFill}
-        viewBox="0 0 400 155"
-        preserveAspectRatio="xMidYMid slice">
-        <Defs>
-          <SvgRadialGradient id="blob1" cx="0.2" cy="0.3" r="0.35">
-            <Stop offset="0" stopColor={palette[0]} stopOpacity={mainOpacity} />
-            <Stop offset="1" stopColor={palette[0]} stopOpacity={0} />
-          </SvgRadialGradient>
-          <SvgRadialGradient id="blob2" cx="0.75" cy="0.7" r="0.3">
-            <Stop offset="0" stopColor={palette[1]} stopOpacity={mainOpacity} />
-            <Stop offset="1" stopColor={palette[1]} stopOpacity={0} />
-          </SvgRadialGradient>
-          <SvgRadialGradient id="blob3" cx="0.55" cy="0.2" r="0.25">
-            <Stop
-              offset="0"
-              stopColor={palette[2]}
-              stopOpacity={isDark ? 0.08 : 0.1}
-            />
-            <Stop offset="1" stopColor={palette[2]} stopOpacity={0} />
-          </SvgRadialGradient>
-          <SvgRadialGradient id="blob4" cx="0.35" cy="0.8" r="0.2">
-            <Stop
-              offset="0"
-              stopColor={palette[3]}
-              stopOpacity={isDark ? 0.06 : 0.08}
-            />
-            <Stop offset="1" stopColor={palette[3]} stopOpacity={0} />
-          </SvgRadialGradient>
-        </Defs>
-        <Rect x="0" y="0" width="400" height="155" fill="url(#blob1)" />
-        <Rect x="0" y="0" width="400" height="155" fill="url(#blob2)" />
-        <Rect x="0" y="0" width="400" height="155" fill="url(#blob3)" />
-        <Rect x="0" y="0" width="400" height="155" fill="url(#blob4)" />
-      </Svg>
+      <SurahGradientMesh palette={palette} isDark={isDark} />
+
       <View style={styles.content}>
         <View style={styles.topSection}>
           <View style={styles.topRow}>
@@ -163,7 +117,12 @@ export const SurahHeroSection = ({
   const linkProps = {
     href: {
       pathname: '/mushaf' as const,
-      params: {surah: surah.id.toString()},
+      // Prefer the resume page when we have one — that's what makes
+      // the hero a true "Continue reading" shortcut instead of just
+      // "open this surah at page 1".
+      params: resumePage
+        ? {page: resumePage.toString()}
+        : {surah: surah.id.toString()},
     },
     asChild: true as const,
   };


### PR DESCRIPTION
## Summary

Two related fixes to the Surahs tab:

1. **Surah cards adopt the hero's gradient-mesh background.** Extracted `SurahGradientMesh` (`components/hero/SurahGradientMesh.tsx`) — four soft radial-gradient blobs keyed by a shared `MESH_PALETTES` table. Used by both `SurahHeroSection` (random per session) and `SurahCard` (cycled deterministically per surah id via `paletteForSurah(id)`). `useId`-based blob ids prevent gradient-id collisions when many cards render together.

2. **Surah hero accepts a `resumePage` prop.** When provided, tapping the hero opens `/mushaf?page=<n>` directly — matches the Continue-reading affordance already in the mushaf search screen. `ContinueReadingHero` wires `mushafSessionStore.getLastReadPage()` through, so the hero now genuinely continues from the exact page; previously it dropped the user at the surah's first page.

SurahCard drops the single-color LinearGradient in favor of the shared mesh.

## Test plan
- [ ] Open Surahs tab → hero card shows mesh (as before) + grid cards now show mesh variants.
- [ ] Scroll through the grid — each card has a stable palette per surah.
- [ ] Read a few pages in the mushaf, back out to Surahs tab, tap the hero → mushaf opens at your last page (not page 1 of that surah).

🤖 Generated with [Claude Code](https://claude.com/claude-code)