### PR TITLE
fix(surah-hero): resume at the user's last-read page, consistently

### DIFF
--- a/app/mushaf.tsx
+++ b/app/mushaf.tsx
@@ -22,17 +22,13 @@ export default function MushafScreen() {
   const {surah, page, ayah} = useLocalSearchParams<MushafScreenParams>();
   const {theme} = useTheme();
 
-  // Safety net — DK data is initialized at AppInitializer priority 4-5
-  if (!digitalKhattDataService.initialized) {
-    return (
-      <View
-        style={[styles.loading, {backgroundColor: theme.colors.background}]}>
-        <ActivityIndicator size="large" color={theme.colors.text} />
-      </View>
-    );
-  }
-
-  const surahStartPages = digitalKhattDataService.getSurahStartPages();
+  // Safety net — DK data is initialized at AppInitializer priority 4-5,
+  // so in practice this is always true by the time MushafScreen mounts.
+  // Capture it as a value so the hooks below run unconditionally.
+  const dkReady = digitalKhattDataService.initialized;
+  const surahStartPages = dkReady
+    ? digitalKhattDataService.getSurahStartPages()
+    : {};
 
   // Resolve page number from params
   const pageNumber = useMemo(() => {
@@ -84,6 +80,15 @@ export default function MushafScreen() {
       useMushafVerseSelectionStore.getState().clearSelection();
     };
   }, [initialVerseKey, pageNumber]);
+
+  if (!dkReady) {
+    return (
+      <View
+        style={[styles.loading, {backgroundColor: theme.colors.background}]}>
+        <ActivityIndicator size="large" color={theme.colors.text} />
+      </View>
+    );
+  }
 
   return (
     <View

--- a/components/hero/ContinueReadingHero.tsx
+++ b/components/hero/ContinueReadingHero.tsx
@@ -1,6 +1,7 @@
-import React, {useMemo} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import {View, ViewStyle} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
+import {useFocusEffect} from '@react-navigation/native';
 import {SURAHS, Surah} from '@/data/surahData';
 import {mushafSessionStore} from '@/services/mushaf/MushafSessionStore';
 import {HeroSection} from './HeroSection';
@@ -37,7 +38,19 @@ const SECTION_HEIGHT = moderateScale(150);
 export function ContinueReadingHero({
   onSurahLongPress,
 }: ContinueReadingHeroProps) {
-  const lastReadPage = mushafSessionStore.getLastReadPage();
+  // MMKV reads aren't reactive, and this component is typically cached
+  // inside a memoized FlashList header — so re-read the session value
+  // every time the Surahs tab regains focus (e.g. after backing out of
+  // the mushaf) to keep "Continue Reading" in sync with the latest page.
+  const [lastReadPage, setLastReadPage] = useState<number | null>(() =>
+    mushafSessionStore.getLastReadPage(),
+  );
+  useFocusEffect(
+    useCallback(() => {
+      setLastReadPage(mushafSessionStore.getLastReadPage());
+    }, []),
+  );
+
   const surahOfTheDay = useMemo(() => getSurahOfTheDay(), []);
 
   const lastReadSurah = lastReadPage

--- a/components/mushaf/main.tsx
+++ b/components/mushaf/main.tsx
@@ -666,10 +666,14 @@ export default function MushafViewer({
   // Vertical mode callbacks — update the same state as horizontal FlatList
   const handleContinuousPageChange = useCallback(
     (page: number) => {
+      // Record last-read unconditionally so "Continue Reading" resumes
+      // correctly even when the viewer mounts on a fresh page (e.g.
+      // opened via a surah tap) and the user never scrolls away. The
+      // horizontal onViewableItemsChanged handler does the same.
+      mushafSessionStore.setLastReadPage(page);
       if (page !== currentPage) {
         setCurrentPage(page);
         useMushafPlayerStore.setState({currentPage: page});
-        mushafSessionStore.setLastReadPage(page);
         trackPageChange(page);
         const surahId = pageToSurah[page];
         if (surahId) {

--- a/docs/features/widgets.md
+++ b/docs/features/widgets.md
@@ -32,9 +32,9 @@ Build native home screen widgets for iOS (WidgetKit + SwiftUI) and Android (App 
 - Calligraphic presentation using existing Uthmani fonts
 
 #### 4. Last Read (Mushaf Bookmark)
-- Shows last mushaf page and surah name from `mushafSettingsStore.lastReadPage`
+- Shows last mushaf page and surah name from `mushafSessionStore.getLastReadPage()` (MMKV-backed)
 - "Continue reading" — one tap opens mushaf where the user left off
-- Uses `recentPages` for additional context
+- Uses `mushafSettingsStore.recentPages` for additional context
 
 ### Tier 2 — Medium Complexity
 
@@ -154,7 +154,7 @@ Since widgets are native code, integration with the Expo/RN project requires:
 | Now Playing | `playerStore` (current track, progress) | Yes |
 | Quick Play | `playCountStore.getMostPlayed()`, `recentSurahStore` | Yes |
 | Daily Verse | `surahData`, verse text from SQLite | Yes |
-| Last Read | `mushafSettingsStore.lastReadPage`, `recentPages` | Yes |
+| Last Read | `mushafSessionStore.getLastReadPage()` (MMKV), `mushafSettingsStore.recentPages` | Yes |
 | Adhkar | `adhkarStore`, `adhkarSettingsStore` | Yes |
 | Listening Stats | `playCountStore` | Yes (counts only, no duration) |
 | Playlist | `PlaylistService` (SQLite) | Yes |


### PR DESCRIPTION
## Summary
The Continue Reading hero was reading `lastReadPage` non-reactively from inside SurahsView's memoized FlashList header — so after backing out of the mushaf it kept whatever value it had at first mount and tapped to page 1 instead of resuming. This PR makes the hero refresh on tab focus, aligns vertical and horizontal scroll modes on how they record `lastReadPage`, fixes a latent rules-of-hooks violation, and updates stale docs.

## Changes
- **`components/hero/ContinueReadingHero.tsx`** — hold `lastReadPage` in `useState` and refresh via `useFocusEffect` (matches existing convention in `collection/bookmarks.tsx`). Hero now reflects the latest MMKV value whenever the Surahs tab regains focus.
- **`components/mushaf/main.tsx`** — lift `mushafSessionStore.setLastReadPage(page)` out of the `page !== currentPage` guard in `handleContinuousPageChange`, so vertical mode records the initial page the same way horizontal's `onViewableItemsChanged` does. Fixes "open Al-Baqarah via a surah tap in vertical mode, don't scroll, leave" never recording page 2.
- **`app/mushaf.tsx`** — the early return for `!digitalKhattDataService.initialized` sat above four hooks, violating rules-of-hooks if DK ever initializes mid-render. Moved the early return below all hook calls; `surahStartPages` now falls back to `{}` when DK isn't ready yet (harmless — `useMemo` falls through to `return 1`).
- **`docs/features/widgets.md`** — replace stale `mushafSettingsStore.lastReadPage` references with `mushafSessionStore.getLastReadPage()` (that key was moved to MMKV in mushaf-settings migration v5).

## Test plan
- [ ] Cold start with no reading history → hero shows "SURAH OF THE DAY".
- [ ] Tap Surah of the Day → lands on page 1, scroll to page 5, back out → hero now says "CONTINUE READING" for that surah, tap resumes at page 5.
- [ ] Horizontal mode: open a surah, immediately back out → next visit resumes at that surah's first page (not the previous one).
- [ ] Vertical (continuous) mode: same check — opening Al-Baqarah via surah tap then backing out records page 2.
- [ ] Kill app while on mushaf → relaunch restores to the saved page (existing `_layout.tsx` flow, unaffected).
- [ ] Tab switch back and forth between Surahs and Collection → hero value stays in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)