### PR TITLE
fix(settings): inset handling + iOS 26 glass pass; search keyboard; surah card cleanup

### DIFF
--- a/app/(tabs)/(d.settings)/index.tsx
+++ b/app/(tabs)/(d.settings)/index.tsx
@@ -9,6 +9,8 @@ import {clearPlayerCache} from '@/services/player/utils/storage';
 import Color from 'color';
 import {useBottomInset} from '@/hooks/useBottomInset';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
+import {GlassView} from 'expo-glass-effect';
 import {openAppStoreForReview, markAsRated} from '@/utils/reviewUtils';
 import {
   QuranIcon,
@@ -203,10 +205,11 @@ export default function SettingsScreen() {
   const bottomInset = useBottomInset();
   const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const glassColorScheme = useGlassColorScheme();
   const {showFloatingDevMenu, toggleFloatingDevMenu} = useDevSettingsStore();
 
-  const iconColor = Color(theme.colors.text).alpha(0.7).toString();
-  const chevronColor = Color(theme.colors.text).alpha(0.2).toString();
+  const iconColor = theme.colors.text;
+  const chevronColor = theme.colors.textSecondary;
 
   const trackColor = useMemo(
     () => ({
@@ -266,17 +269,33 @@ export default function SettingsScreen() {
     }
   };
 
+  // iOS 26+ NativeTabs: automatic content insets handle top/bottom; manual
+  // padding would double-pad. Other platforms: opt out of automatic and pad
+  // manually.
+  const contentPadding = USE_GLASS
+    ? undefined
+    : {
+        paddingTop: insets.top + moderateScale(10),
+        paddingBottom: bottomInset,
+      };
+
+  const renderCard = (children: React.ReactNode) =>
+    USE_GLASS ? (
+      <GlassView
+        style={styles.card}
+        glassEffectStyle="regular"
+        colorScheme={glassColorScheme}>
+        {children}
+      </GlassView>
+    ) : (
+      <View style={styles.card}>{children}</View>
+    );
+
   return (
     <View style={styles.container}>
       <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={[
-          styles.scrollContent,
-          {
-            paddingTop: insets.top + moderateScale(10),
-            paddingBottom: bottomInset,
-          },
-        ]}
+        contentInsetAdjustmentBehavior={USE_GLASS ? 'automatic' : 'never'}
+        contentContainerStyle={[styles.scrollContent, contentPadding]}
         showsVerticalScrollIndicator={false}>
         {/* Appearance */}
         <View style={styles.section}>
@@ -290,8 +309,8 @@ export default function SettingsScreen() {
             <Text style={styles.sectionHeader}>
               {section.section.toUpperCase()}
             </Text>
-            <View style={styles.card}>
-              {section.items.map((item, itemIndex) => (
+            {renderCard(
+              section.items.map((item, itemIndex) => (
                 <React.Fragment key={item.type}>
                   {itemIndex > 0 && <View style={styles.divider} />}
                   <Pressable
@@ -320,8 +339,8 @@ export default function SettingsScreen() {
                     />
                   </Pressable>
                 </React.Fragment>
-              ))}
-            </View>
+              )),
+            )}
           </View>
         ))}
 
@@ -329,7 +348,7 @@ export default function SettingsScreen() {
         {__DEV__ && (
           <View style={styles.section}>
             <Text style={styles.sectionHeader}>DEVELOPER</Text>
-            <View style={styles.card}>
+            {renderCard(
               <View style={styles.settingsRow}>
                 <View style={styles.settingsItemIcon}>
                   <Feather
@@ -352,8 +371,8 @@ export default function SettingsScreen() {
                   ios_backgroundColor={trackColor.false}
                   style={styles.switchStyle}
                 />
-              </View>
-            </View>
+              </View>,
+            )}
           </View>
         )}
       </ScrollView>
@@ -376,7 +395,7 @@ const createStyles = (theme: Theme) =>
     sectionHeader: {
       fontSize: moderateScale(10.5),
       fontFamily: 'Manrope-SemiBold',
-      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+      color: theme.colors.textSecondary,
       letterSpacing: 1.2,
       textTransform: 'uppercase',
       marginBottom: moderateScale(6),
@@ -385,15 +404,21 @@ const createStyles = (theme: Theme) =>
 
     // --- Cards ---
     card: {
-      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      backgroundColor: USE_GLASS
+        ? undefined
+        : Color(theme.colors.text).alpha(0.04).toString(),
       borderRadius: moderateScale(14),
-      borderWidth: 1,
-      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      borderWidth: USE_GLASS ? 0 : 1,
+      borderColor: USE_GLASS
+        ? undefined
+        : Color(theme.colors.text).alpha(0.06).toString(),
       overflow: 'hidden',
     },
     divider: {
       height: 1,
-      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      backgroundColor: Color(theme.colors.text)
+        .alpha(USE_GLASS ? 0.1 : 0.06)
+        .toString(),
       marginHorizontal: moderateScale(16),
     },
 
@@ -419,12 +444,12 @@ const createStyles = (theme: Theme) =>
     settingsTitle: {
       fontSize: moderateScale(13.5),
       fontFamily: 'Manrope-Medium',
-      color: Color(theme.colors.text).alpha(0.85).toString(),
+      color: theme.colors.text,
     },
     settingsDescription: {
       fontSize: moderateScale(11),
       fontFamily: 'Manrope-Regular',
-      color: Color(theme.colors.textSecondary).alpha(0.45).toString(),
+      color: theme.colors.textSecondary,
       marginTop: moderateScale(1),
     },
 

--- a/components/cards/SurahCard.tsx
+++ b/components/cards/SurahCard.tsx
@@ -27,8 +27,7 @@ import Animated, {
 import * as Haptics from 'expo-haptics';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {Link} from 'expo-router';
-import {GlassView} from 'expo-glass-effect';
-import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
+import {USE_GLASS} from '@/hooks/useGlassProps';
 
 import {NowPlayingIndicator} from '@/components/NowPlayingIndicator';
 import {GradientText} from '@/components/GradientText';
@@ -80,7 +79,6 @@ export const SurahCard: React.FC<SurahCardProps> = ({
   mushafLink = false,
 }) => {
   const {theme} = useTheme();
-  const glassColorScheme = useGlassColorScheme();
 
   // Get download state
   const isDownloadedBase = useIsDownloaded(
@@ -172,16 +170,6 @@ export const SurahCard: React.FC<SurahCardProps> = ({
     container: {
       width: moderateScale(120),
       height: moderateScale(120),
-      borderRadius: moderateScale(20),
-      overflow: 'hidden',
-      borderWidth: 1,
-      borderColor: Color(color).alpha(0.15).toString(),
-    },
-    glassWrapper: {
-      height: moderateScale(120),
-    },
-    glassInner: {
-      flex: 1,
       borderRadius: moderateScale(20),
       overflow: 'hidden',
     },
@@ -438,15 +426,8 @@ export const SurahCard: React.FC<SurahCardProps> = ({
             onLongPress || onOptionsPress ? handleLongPressWrapper : undefined
           }
           delayLongPress={500}
-          style={StyleSheet.flatten([styles.glassWrapper, style])}>
-          <Link.AppleZoom>
-            <GlassView
-              style={styles.glassInner}
-              glassEffectStyle="regular"
-              colorScheme={glassColorScheme}>
-              {cardContent}
-            </GlassView>
-          </Link.AppleZoom>
+          style={StyleSheet.flatten([styles.container, style])}>
+          <Link.AppleZoom>{cardContent}</Link.AppleZoom>
         </Pressable>
       </Link>
     );
@@ -480,13 +461,8 @@ export const SurahCard: React.FC<SurahCardProps> = ({
           onLongPress || onOptionsPress ? handleLongPressWrapper : undefined
         }
         delayLongPress={500}
-        style={StyleSheet.flatten([styles.glassWrapper, style])}>
-        <GlassView
-          style={styles.glassInner}
-          glassEffectStyle="regular"
-          colorScheme={glassColorScheme}>
-          {cardContent}
-        </GlassView>
+        style={StyleSheet.flatten([styles.container, style])}>
+        {cardContent}
       </Pressable>
     );
   }

--- a/components/search/SearchView.tsx
+++ b/components/search/SearchView.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   FlatList,
   Keyboard,
+  Platform,
   Animated as RNAnimated,
 } from 'react-native';
 import {useRouter} from 'expo-router';
@@ -82,6 +83,24 @@ export function SearchView({
   const {askEveryTime, defaultReciterSelection} = useSettings();
   const defaultReciter = useReciterStore(state => state.defaultReciter);
   const insets = useSafeAreaInsets();
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    const showEvent =
+      Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent =
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+    const showSub = Keyboard.addListener(showEvent, e => {
+      setKeyboardHeight(e.endCoordinates.height);
+    });
+    const hideSub = Keyboard.addListener(hideEvent, () => {
+      setKeyboardHeight(0);
+    });
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
 
   // Drive the mode transition from external state
   const isSearchMode = isSearchActive || query.length > 0;
@@ -444,7 +463,7 @@ export function SearchView({
             showsVerticalScrollIndicator={false}
             contentContainerStyle={[
               styles.scrollContent,
-              {paddingBottom: bottomInset},
+              {paddingBottom: Math.max(keyboardHeight, bottomInset)},
             ]}
             keyboardShouldPersistTaps="handled">
             {recentSearches.length > 0 ? (
@@ -530,7 +549,10 @@ export function SearchView({
             data={searchResults}
             renderItem={renderSearchResult}
             keyExtractor={(item, index) => `${item.type}-${index}`}
-            contentContainerStyle={styles.resultsContent}
+            contentContainerStyle={[
+              styles.resultsContent,
+              {paddingBottom: Math.max(keyboardHeight, bottomInset)},
+            ]}
             showsVerticalScrollIndicator={false}
             keyboardShouldPersistTaps="handled"
             onScrollBeginDrag={() => Keyboard.dismiss()}


### PR DESCRIPTION
## Summary
- **Settings screen** — correct inset handling on iOS 26 NativeTabs (was double-padding top/bottom) and align to the app's glass language (GlassView cards, full-alpha text, brighter chevron).
- **SurahCard** — drop the 1px tinted border and the GlassView wrapper in glass paths so the gradient mesh reads at full saturation.
- **Search** — pad the results and recent-searches lists by keyboard height so the last items stay reachable when the keyboard is up.

## Test plan
- [ ] Settings tab on iOS 26 simulator: no extra top/bottom padding; cards render as real glass
- [ ] Settings tab on pre-iOS-26 / Android: falls back to flat tint + border; manual insets correct
- [ ] Text contrast feels alive, not dimmed
- [ ] Surahs tab: cards show varied mesh palette edge-to-edge, no hairline border
- [ ] Search tab: focus the search bar, type, verify the last result is reachable above the keyboard; drag to dismiss, verify padding snaps back

🤖 Generated with [Claude Code](https://claude.com/claude-code)