### PR TITLE
fix(analytics): disable PostHogProvider when no API key is configured

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -435,11 +435,14 @@ function RootLayout() {
   return (
     <ErrorBoundary>
       <PostHogProvider
-        apiKey={process.env.EXPO_PUBLIC_POSTHOG_API_KEY ?? ''}
+        apiKey={
+          process.env.EXPO_PUBLIC_POSTHOG_API_KEY || 'phc_disabled_placeholder'
+        }
         options={{
           host: 'https://us.i.posthog.com',
           flushAt: 20,
           flushInterval: 30000,
+          disabled: !process.env.EXPO_PUBLIC_POSTHOG_API_KEY,
         }}
         autocapture={{
           captureScreens: true,


### PR DESCRIPTION
## Problem

On a fresh clone with no `.env` (or with `EXPO_PUBLIC_POSTHOG_API_KEY=` empty in `.env.example`), the app crashes on startup before the home tab can render:

> Either a PostHog client or an apiKey is required. If you want to use the PostHogProvider without a client, please provide an apiKey and the options={ disabled: true }.

This contradicts the README's claim that *"the app runs out of the box with bundled reciter data — no keys required."*

## Root cause

`app/_layout.tsx:437` initializes `PostHogProvider` with `apiKey={process.env.EXPO_PUBLIC_POSTHOG_API_KEY ?? ''}`. PostHog's provider rejects empty-string API keys at construction time. Catching the error in the `ErrorBoundary` blocks the rest of the tree from mounting.

## Fix

Follow PostHog's own error-message guidance: provide a placeholder `apiKey` **and** pass `disabled: true` together when no real key is configured. PostHog requires both — `disabled` alone with empty `apiKey` still errors.

When `EXPO_PUBLIC_POSTHOG_API_KEY` is set, behavior is unchanged: real key used, `disabled` becomes `false`.

## Verification

- Without `.env`: app loads and renders the home tab on iOS (iPhone 16 Pro / iOS 26.4) and Android (Pixel 7).
- With `EXPO_PUBLIC_POSTHOG_API_KEY=phc_real_key`: PostHog initializes normally, analytics work.

## Notes

- 4-line change. `npx prettier --write app/_layout.tsx` already run.
- Skipped `tsc --noEmit` validation since the change is purely a default-value + boolean flag and introduces no new types.