### PR TITLE
fix(ios): set UTF-8 locale for pod install to avoid Ruby encoding error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
     "android": "expo run:android",
-    "ios": "expo run:ios",
+    "ios": "LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 expo run:ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
     "lint": "eslint .",

--- a/scripts/ios-archive.sh
+++ b/scripts/ios-archive.sh
@@ -5,6 +5,12 @@
 
 set -e
 
+# Force UTF-8 locale for CocoaPods. Ruby 3.3 + CocoaPods 1.16.x raise
+# Encoding::CompatibilityError when LANG isn't a UTF-8 locale. Mirrors
+# the same guard in package.json's "ios" script.
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Problem

On a fresh clone, `npm run ios` fails during pod install with a Ruby encoding error before any build happens:

\`\`\`
Unicode Normalization not appropriate for ASCII-8BIT (Encoding::CompatibilityError)
  from cocoapods-1.16.2/lib/cocoapods/config.rb:167:in \`unicode_normalize'
  from cocoapods-1.16.2/lib/cocoapods/config.rb:227:in \`podfile_path'
  ...
\`\`\`

This blocks first-time setup until the user discovers they need to change their shell locale.

## Root cause

CocoaPods 1.16.x with Ruby 3.3.x calls `String#unicode_normalize` on the Podfile path. When the user's terminal locale is not a UTF-8 locale (common on default macOS Terminal.app and some iTerm2 profiles), Ruby's default external encoding is ASCII-8BIT and the call raises.

CocoaPods itself prints the canonical fix in its error output:

> CocoaPods requires your terminal to be using UTF-8 encoding.
> Consider adding the following to ~/.profile: \`export LANG=en_US.UTF-8\`

## Fix

Set `LANG` and `LC_ALL` inline in the `ios` script. This makes \`npm run ios\` succeed regardless of the user's shell environment without requiring them to modify `.profile`.

## Compatibility notes

- The inline assignment (\`LANG=...\`) is bash/zsh/sh syntax. The \`ios\` script is macOS-only — Windows users wouldn't run it anyway.
- No effect on systems that already have LANG set correctly: the inline assignment is shell-local for this single command and does not override the user's environment.
- No effect on the existing prebuild / EAS build paths.

## Verification

- Tested on a fresh clone in a default terminal (LANG unset). \`npm run ios\` now reaches xcodebuild and successfully launches the app on the simulator.