### PR TITLE
docs(rfc): RFC-001 — workspace structure and RFC convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Thank you for contributing to Bayaan. This guide covers everything you need to g
 6. [AI-assisted development](#ai-assisted-development)
 7. [Architecture navigation](#architecture-navigation)
 8. [Pull request workflow](#pull-request-workflow)
+9. [Architectural RFCs](#architectural-rfcs)
 
 ---
 
@@ -282,6 +283,7 @@ Full architecture documentation: [docs/architecture/current-state.md](docs/archi
   - `fix/description` — bug fix
   - `chore/description` — tooling, dependencies, cleanup
   - `docs/description` — documentation only
+  - `rfc/NNN-short-title` — Architectural RFC (see [Architectural RFCs](#architectural-rfcs) below)
 3. **Before submitting:**
   ```bash
    npx prettier --write .
@@ -303,6 +305,16 @@ docs: update player architecture doc
 ```
 
 Do not include AI tool names or attributions in commit messages.
+
+---
+
+## Architectural RFCs
+
+Larger architectural changes — extracting modules into packages, defining cross-cutting interfaces, modifying governance — go through a lightweight RFC process before implementation lands.
+
+An RFC PR adds a single document under [`docs/rfcs/`](docs/rfcs/) using the [template](docs/rfcs/000-template.md) and may include scaffolding the design enables (new types, contract test fixtures, CI workflow files) as long as no existing service behavior changes. Refactors of existing code land in named follow-up PRs that reference the merged RFC.
+
+If you're not sure whether your change warrants an RFC: when in doubt, open a regular PR. Reviewers will redirect to the RFC track if the scope justifies it.
 
 ---
 

--- a/docs/rfcs/000-template.md
+++ b/docs/rfcs/000-template.md
@@ -1,0 +1,37 @@
+# RFC-NNN: Title
+
+| Field    | Value                                                          |
+| -------- | -------------------------------------------------------------- |
+| Status   | Proposed / Accepted / Rejected / Superseded by RFC-XXX         |
+| Date     | YYYY-MM-DD                                                     |
+| Author   | Name                                                           |
+
+## Summary
+
+One-paragraph summary of what this RFC proposes. The reader should be able to skip the rest of the document if this paragraph isn't relevant to them.
+
+## Motivation
+
+What problem does this solve? Why is the current state insufficient? Cite real code (`file.ts:line`) or behavior, not abstractions.
+
+## Decision
+
+The proposal itself. Be specific. If the RFC introduces an interface, paste the TypeScript. If it changes a workflow, show the before/after. Cite paths and line numbers where they matter.
+
+## Alternatives considered
+
+List the alternatives evaluated. For each, say why it was rejected. The goal is to demonstrate that the chosen approach was deliberate, not default.
+
+## Consequences
+
+- **Positive:** what improves
+- **Neutral:** what doesn't change
+- **Negative / risks:** what gets worse, or what could go wrong
+
+## How we'll know it worked
+
+Concrete, observable success criteria. Not "the code is cleaner" — "every package's `package.json` declares Skia as a peer dependency, verified by CI."
+
+## Open questions
+
+(Optional.) Things this RFC deliberately does not decide. Useful when scoping a small RFC out of a larger ambition.

--- a/docs/rfcs/001-workspace-and-rfc-convention.md
+++ b/docs/rfcs/001-workspace-and-rfc-convention.md
@@ -1,0 +1,121 @@
+# RFC-001: Workspace structure and RFC convention
+
+| Field    | Value                                              |
+| -------- | -------------------------------------------------- |
+| Status   | Proposed                                           |
+| Date     | 2026-04-30                                         |
+| Author   | Omar Zarka                                         |
+
+## Summary
+
+Add an npm workspace at `packages/*` so reusable platform layers can live alongside the application without forking into a separate repository, and establish a `docs/rfcs/` convention so larger architectural changes can be proposed and reviewed in bounded chunks. This RFC is itself the first instance of the convention — its scope is intentionally small.
+
+## Motivation
+
+The Bayaan codebase combines two kinds of code:
+
+1. **Application concerns** — UI, screens, navigation, branding, app-specific stores.
+2. **Platform concerns** — audio engine, mushaf rendering, rewayat logic, downloads. These don't depend on Bayaan's UI and could in principle serve additional consumers (an alternate UI, a web client, a headless tool).
+
+Today they live intermixed. Whenever someone wants to reuse a platform layer — even informally, e.g. for testing in isolation — they have to navigate the application layer to find it.
+
+A workspace layout fixes this without committing to anything else. Adding `packages/*` is purely structural. No code moves yet. Future RFCs can propose extracting specific concerns into their own packages, each as a separate decision.
+
+The RFC convention exists for the same reason: split larger architectural changes into focused proposals that can be reviewed individually. A 4,000-word grand-design document forces the reviewer to consent to dozens of decisions at once. A series of 500-word RFCs lets each decision be debated, modified, or rejected on its own.
+
+## Decision
+
+### Workspace
+
+Add an npm workspaces declaration at the repository root:
+
+```json
+"workspaces": ["packages/*"]
+```
+
+The `packages/` directory is created with a `.gitkeep` placeholder. No package code lands in this RFC — the first package is proposed in RFC-002.
+
+`npm install` from the repository root continues to work unchanged. Once packages exist, npm will hoist their dependencies and link `@bayaan/<name>` imports to the workspace copies automatically.
+
+### RFC convention
+
+Create `docs/rfcs/` containing:
+
+- `000-template.md` — a single-page template for new RFCs
+- `001-workspace-and-rfc-convention.md` — this document
+
+Each subsequent RFC PR follows the same shape:
+
+1. Adds exactly one `docs/rfcs/NNN-title.md` document, numbered sequentially.
+2. May include scaffolding the design enables, as long as it does not change observable behavior — for example, new types, contract test fixtures, CI workflow files, or empty package skeletons.
+3. Does **not** include refactors of existing services. Refactors land as named follow-up PRs that reference the merged RFC. This keeps each RFC's diff small enough to review alongside the design discussion, and avoids wasted code if the design needs revision.
+
+`CONTRIBUTING.md` gets a one-paragraph section pointing at the convention and adding `rfc/<short-title>` to the existing branch-naming list.
+
+## Alternatives considered
+
+### A — Single-app, no workspace
+
+Continue with the current flat layout. Keep platform and application code intermixed.
+
+Rejected because every future "extract this into a reusable layer" conversation reopens the question of where reusable code should live. Adding the workspace once, separately from any extraction, makes future RFCs about *what to extract* rather than *where to put it*.
+
+### B — Separate `bayaan/platform` repository
+
+Stand up a parallel repo for reusable modules. Application stays in `thebayaan/Bayaan`, platform lives elsewhere.
+
+Rejected for now. Cross-repo refactors (move code from app repo to platform repo) require coordinated PRs across both repositories, doubling review burden for every extraction. Single-repo workspace lets refactor-then-move land in a single PR series. The separate-repo option remains available later if the platform genuinely outgrows being a workspace.
+
+### C — pnpm or yarn workspaces
+
+Both offer better install performance and stricter hoisting than npm workspaces.
+
+Rejected for this RFC. Bayaan currently uses npm. Switching package managers is a separate decision worth its own RFC if install-time performance becomes a real problem; not worth bundling into this proposal. npm workspaces are sufficient for the immediate need.
+
+### D — RFC convention in GitHub Discussions
+
+Use the Discussions tab for design proposals. Lighter-weight than committing markdown.
+
+Rejected because Discussions don't sit alongside the code that implements them. RFCs as committed markdown make the design record visible from the repository, navigable from the file tree, and durable across changes in third-party tools. The discussion thread on the RFC PR is itself a Discussions-like artifact, attached to the doc.
+
+## Consequences
+
+**Positive**
+
+- A clear pattern for proposing larger architectural changes incrementally.
+- Future cross-cutting work (e.g., extracting the audio engine into a package) has a place to live before the extraction PR series begins.
+- New contributors find `docs/rfcs/000-template.md` and can produce a sensible RFC without further guidance.
+
+**Neutral**
+
+- `npm install` behavior unchanged.
+- Build and run scripts unchanged.
+- `packages/` is empty until RFC-002.
+
+**Negative / risks**
+
+- The RFC convention adds a small process overhead per architectural change. Mitigated by keeping each RFC focused — anything small enough to skip the RFC step should just open a normal PR.
+
+## How we'll know it worked
+
+- The merged change passes existing CI (lint + tsc) without modification to other workflows.
+- A subsequent RFC (RFC-002) lands a real package under `packages/` without re-litigating the workspace setup.
+- The contribution guide's "Pull request workflow" section now distinguishes RFC PRs from regular PRs.
+
+## Open questions (deferred)
+
+- The package manager (npm vs pnpm vs yarn). Revisitable when install performance or hoisting strictness becomes a problem.
+- Test runner organization across packages (per-package Jest config vs shared). Deferred to RFC-003.
+- Static-grep CI gates for package conventions (e.g., "no consumer state imported from packages"). Deferred to RFC-003.
+
+## Roadmap (informative — not committed by this RFC)
+
+This RFC establishes the convention only. Anticipated near-term RFCs that will use it:
+
+- RFC-002: `@bayaan/types` shared primitives
+- RFC-003: CI gates and contract test runners (`@bayaan/test-utils`)
+- RFC-004: Audio extraction seam (`PlayerController` and sibling ports)
+- RFC-005: Mushaf split (data / render / rewayat)
+- RFC-006: Governance and shared maintainership
+
+Each lands as its own PR. Each can be rejected, deferred, or modified independently. None depend on this RFC for anything beyond the workspace and the docs directory existing.

--- a/package.json
+++ b/package.json
@@ -165,5 +165,8 @@
     "react-native-ios-utilities": "5.2.0",
     "@react-native-menu/menu": "2.0.0"
   },
+  "workspaces": [
+    "packages/*"
+  ],
   "private": true
 }


### PR DESCRIPTION
## What this PR is

The first in a planned series of RFC PRs for larger architectural changes. The full document is at [`docs/rfcs/001-workspace-and-rfc-convention.md`](docs/rfcs/001-workspace-and-rfc-convention.md) — please review it as the primary content of this PR; the code changes are the scaffolding the RFC describes.

## What it adds

- An npm workspace at `packages/*` (root `package.json` change). No packages exist yet.
- A `docs/rfcs/` directory with a [template](docs/rfcs/000-template.md) and this RFC.
- A short [Architectural RFCs](CONTRIBUTING.md#architectural-rfcs) section in `CONTRIBUTING.md` and an `rfc/` branch-naming convention.

## What it does not do

- Move any existing code. `services/`, `components/`, `app/` all unchanged.
- Change build, install, or run behavior. `npm install` and `npm run ios/android` work exactly as before.
- Commit to any specific extraction. The RFC's roadmap section lists anticipated follow-up RFCs but explicitly does not bind this one.

## Why this is its own PR

Scope of one decision: do you want a workspace + RFC pattern in this repo? If yes, future architectural decisions can land as focused RFC PRs reviewable in one sitting each. If no — or if you'd prefer a different shape (separate platform repo, GitHub Discussions, pnpm workspaces) — easy to redirect before any extraction work begins.

## Risk if this lands and a later RFC is rejected

This RFC's scaffolding is independently useful. Even if every subsequent extraction RFC is rejected, the repo just has an empty `packages/` directory and a `docs/rfcs/` template, both ignorable.

## Verification

- `npm install` from the root: succeeds, no warnings about the workspaces field with no packages.
- Existing CI (`lint.yml`) passes — only file-format / type changes affect it, and those are docs-only.
- `npx prettier --write` and `npx tsc --noEmit` both clean.

---

The roadmap in the RFC names anticipated near-term follow-ups (`@bayaan/types`, contract test runners, audio seam, mushaf split, governance). I'm happy to iterate on framing, structure, or sequencing — including dropping the roadmap section entirely if it feels presumptuous to anchor next steps in this PR.