### PR TITLE
fix: canonicalize persisted rewayah ids

### DIFF
--- a/store/mushafSettingsStore.ts
+++ b/store/mushafSettingsStore.ts
@@ -39,15 +39,6 @@ export type MushafAllahNameHighlightColor =
   | 'emerald'
   | 'blue'
   | 'rose';
-export type RewayahId =
-  | 'hafs'
-  | 'shouba'
-  | 'bazzi'
-  | 'qumbul'
-  | 'warsh'
-  | 'qaloon'
-  | 'doori'
-  | 'soosi';
 export interface RecentRead {
   surahId: number;
   page: number;
@@ -247,7 +238,7 @@ export const useMushafSettingsStore = create<MushafSettingsState>()(
     {
       name: 'mushaf-settings',
       storage: createJSONStorage(() => AsyncStorage),
-      version: 14,
+      version: 15,
       migrate: (persistedState: unknown, version: number) => {
         const state = persistedState as Record<string, unknown>;
         if (version === 0) {
@@ -319,6 +310,11 @@ export const useMushafSettingsStore = create<MushafSettingsState>()(
         if (version < 14) {
           state.showAllahNameHighlight = false;
           state.allahNameHighlightColor = 'gold';
+        }
+        if (version < 15) {
+          state.rewayah = migratePersistedId(
+            typeof state.rewayah === 'string' ? state.rewayah : 'hafs',
+          );
         }
         return state as unknown as MushafSettingsState;
       },


### PR DESCRIPTION
## What changed

- removed the stale `RewayahId` union from `store/mushafSettingsStore.ts`
- kept `services/rewayah/RewayahIdentity.ts` as the single source of truth for rewayah slugs
- bumped the persisted store version from `14` to `15`
- added a persisted-state migration that normalizes legacy slugs like `shouba`, `qaloon`, and `doori` through `migratePersistedId(...)`

## Root cause

The repo had partially migrated to a canonical rewayah model, but `mushafSettingsStore.ts` still re-declared an older 8-value `RewayahId` union with pre-canonical slugs. That created two incompatible type universes:

- canonical ids from `RewayahIdentity.ts` such as `shubah`, `qalun`, and `al-duri-abi-amr`
- legacy ids from `mushafSettingsStore.ts` such as `shouba`, `qaloon`, and `doori`

TypeScript failures then cascaded anywhere values crossed between the store-backed type and the canonical type. The store also imported `migratePersistedId` but never applied it in its persisted-state migration path, so old AsyncStorage values could survive indefinitely.

## Impact

- fixes the repo-wide `RewayahId` type split
- preserves existing users by migrating persisted legacy slugs to canonical ones on hydration
- unblocks clean typechecking without changing runtime behavior beyond slug normalization

## Validation

- `npx tsc --noEmit`
