### PR TITLE
docs(rfc): RFC-002 — @bayaan/types shared primitives package

### DIFF
--- a/docs/rfcs/002-bayaan-types-package.md
+++ b/docs/rfcs/002-bayaan-types-package.md
@@ -1,0 +1,178 @@
+# RFC-002: `@bayaan/types` shared primitives package
+
+| Field    | Value      |
+| -------- | ---------- |
+| Status   | Proposed   |
+| Date     | 2026-05-01 |
+| Author   | Omar Zarka |
+
+## Summary
+
+Add the first package to the workspace established by [RFC-001](001-workspace-and-rfc-convention.md): `@bayaan/types`, a small TypeScript-only library that holds shared primitives (`BaseTrack`, `PlaybackState`, `AyahTimestamp`, `LockScreenMetadata`, `AmbientSoundType`) and the `BayaanError` class hierarchy with a stable `ErrorCode` enum. Includes a contract test suite for the error machinery. Does not move or rename any existing app-side type today.
+
+## Motivation
+
+When future RFCs propose extracting feature packages (e.g., audio engine, mushaf rendering), each one will need to express types that cross package boundaries — `BaseTrack` for track payloads, `AyahTimestamp` for follow-along data, `LockScreenMetadata` for OS integration, error types for callback APIs. If each feature package re-defines those primitives locally, identical-shape types diverge silently and consumers get instanceof failures across package boundaries.
+
+A small shared types package solves this once. The constraint is keeping it small — the trap to avoid is `@bayaan/types` becoming a grab-bag every package depends on, where every schema change ripples through the whole platform. Three rules of thumb to keep it bounded (see [Decision §Scope rules](#scope-rules) below):
+
+1. Only types with no clear single-owning concern.
+2. Only types reachable from 3+ feature packages, or atomic primitives / enums.
+3. Promotion from a feature package to `@bayaan/types` is a deliberate breaking-change event.
+
+The error machinery deserves special attention. Today the codebase throws plain `Error` with message strings; consumers (analytics, UI banners, retry logic) parse messages to decide behavior, which is fragile. A `BayaanError` base class with a stable `code` enum gives every consumer a reliable branch point. Subclasses (`BayaanAudioError`, etc.) preserve `instanceof` matching across the platform. This RFC introduces the machinery without rewriting any existing throw sites; a future RFC will migrate them.
+
+## Decision
+
+### Package layout
+
+```
+packages/bayaan-types/
+├── package.json          # name: @bayaan/types, version: 0.1.0, AGPL-3.0-or-later, "private": true
+├── tsconfig.json         # extends expo/tsconfig.base
+├── jest.config.js        # preset: jest-expo, testMatch: src/**/__tests__/**/*.test.ts
+├── README.md
+└── src/
+    ├── index.ts          # re-exports
+    ├── playback.ts       # BaseTrack, PlaybackState
+    ├── mushaf.ts         # AyahTimestamp
+    ├── lock-screen.ts    # LockScreenMetadata
+    ├── ambient.ts        # AmbientSoundType
+    ├── errors.ts         # BayaanError, subclasses, ErrorCode
+    └── __tests__/
+        └── errors.test.ts
+```
+
+The package's `main` and `types` both point at `src/index.ts`. No build step. Metro and `tsc` both consume `.ts` directly via the workspace symlink at `node_modules/@bayaan/types`.
+
+### What the package contains
+
+**Playback primitives** (`src/playback.ts`):
+
+```ts
+export type PlaybackState =
+  | 'idle' | 'loading' | 'ready' | 'playing' | 'paused' | 'error';
+
+export interface BaseTrack {
+  id: string;
+  url: string;
+  title: string;
+  artist?: string;
+  artworkUrl?: string;
+  durationMs?: number;
+}
+```
+
+**Mushaf** (`src/mushaf.ts`): `AyahTimestamp` (`{ ayahNumber, timestampFromMs, timestampToMs }`).
+
+**Lock-screen** (`src/lock-screen.ts`): `LockScreenMetadata` (`{ title, artist, artworkUrl?, durationMs, positionMs, isPlaying }`).
+
+**Ambient** (`src/ambient.ts`): `AmbientSoundType` union of seven sound types.
+
+**Errors** (`src/errors.ts`):
+
+```ts
+export class BayaanError extends Error {
+  readonly code: ErrorCode;
+  readonly recoverable: boolean;
+  readonly context: Readonly<Record<string, unknown>>;
+  readonly cause?: unknown;
+  // ...
+}
+
+export class BayaanAudioError extends BayaanError { /* name = 'BayaanAudioError' */ }
+export class BayaanMushafError extends BayaanError { /* name = 'BayaanMushafError' */ }
+export class BayaanLifecycleError extends BayaanError { /* name = 'BayaanLifecycleError' */ }
+export class BayaanNetworkError extends BayaanError { /* name = 'BayaanNetworkError' */ }
+
+export type ErrorCode =
+  | 'LIFECYCLE_AFTER_DESTROY' | 'LIFECYCLE_BEFORE_INIT' | 'PRECONDITION_VIOLATED'
+  | 'AUDIO_LOAD_FAILED' | 'AUDIO_SEEK_FAILED' | /* ... 17 codes total ... */;
+```
+
+Twenty starting `ErrorCode` values across audio, mushaf, lifecycle, and network domains. Adding a code is a minor-version bump; renaming or removing is a major-version bump.
+
+### What the package does NOT contain
+
+- **`RewayahId`** stays at [`services/rewayah/RewayahIdentity.ts`](../../services/rewayah/RewayahIdentity.ts) per its file-header directive ("All other rewayah-aware code imports from here. Do not define a RewayahId literal […] anywhere else."). A future RFC may propose moving its canonical home, but only with explicit alignment.
+- **Port interfaces** (`PlayerController`, `CoordinatorHooks`, etc.) — owned by future feature packages (e.g., `@bayaan/audio`), not the types package.
+- **Concrete `Track` shape with metadata** — consumer-defined; consumers extend `BaseTrack` with their own meta type.
+- **Logger / event-bus / runtime utility code** — types-only package by design.
+
+### Scope rules
+
+Future contributors deciding where a new type belongs:
+
+1. Used by **0–1 feature packages** → stays in the feature package; export from there.
+2. Used by **2+ feature packages**, with a clear owning concept → stays in the most-related feature package; others import from there.
+3. Used by **3+ feature packages**, or is a primitive/enum with no owner → promote to `@bayaan/types` (breaking change; major version of every dependent).
+
+### Smoke test
+
+The contract test suite at `packages/bayaan-types/src/__tests__/errors.test.ts` is the proof-of-life. Twelve tests covering construction, frozen context, defensive copying, instanceof, name property, stack-trace preservation, and per-subclass discrimination.
+
+Running `npx jest packages/bayaan-types` (or eventually `npm test --workspace=@bayaan/types` once npm workspaces test integration is wired up) executes the suite. Passing means: workspace resolution works, the package compiles, classes behave as documented, future feature packages can throw / catch them with confidence.
+
+This RFC deliberately does NOT add app-side imports of `@bayaan/types` symbols. That work happens in subsequent RFCs as each feature is migrated. Decoupling "package exists" from "package consumed" keeps this PR's diff bounded and respects the Tidy First constraint.
+
+### Versioning
+
+Starts at `0.1.0`. Stays `0.x` until a feature package consumes it in production. Promotes to `1.0.0` after the first stable adoption.
+
+## Alternatives considered
+
+### A — Maximal-shared (every cross-boundary type lives here)
+
+Every type touching any package boundary lands in `@bayaan/types`.
+
+**Rejected.** Becomes a coordination point — any schema change requires cascading releases. Feature packages become skeletal. Skia-typed values (e.g., justification results) end up in a types-only package that can't take a Skia peer dependency cleanly.
+
+### B — Minimal-shared (every package owns its types)
+
+`@bayaan/types` doesn't exist; each feature package exports its own types.
+
+**Rejected.** Consumers import from N packages to compose a config. Identical-shape types like `BaseTrack` get duplicated and diverge subtly. Port interfaces can't reference each other's basic shapes without circular package deps.
+
+### C — Re-export wrapper
+
+`@bayaan/types` is a thin file that re-exports from `services/`, `types/`, `store/`. The package is a pointer.
+
+**Rejected.** Forces the package to import from `@/services/...`, which inverts the dependency — the package becomes a dependent of the app instead of a leaf. Defeats the purpose.
+
+### D — Defer the package; use TypeScript path aliases
+
+Add `@bayaan/types` as a `tsconfig.json` `paths` alias pointing at a `types/shared/` directory. No npm workspace package.
+
+**Rejected.** Path aliases don't resolve in `npm pack` / `npm install` flows — the moment the platform is consumed cross-repo (which is where the workspace pays off), aliases break. Workspace symlinks survive the cross-repo case.
+
+## Consequences
+
+**Positive**
+
+- One canonical home for the small set of types that genuinely cross feature boundaries.
+- `BayaanError` machinery available for future feature packages from day one.
+- Zero behavior change in the existing app — the package exists but no app code imports from it yet.
+- The RFC-001 workspace gets its first real package, validating the npm-workspaces approach end-to-end.
+
+**Neutral**
+
+- `npm install` continues to work unchanged. Adding the workspace package adds a single symlink under `node_modules/@bayaan/types` pointing at `packages/bayaan-types`.
+- Existing CI (`lint.yml`'s `tsc --noEmit` step) covers the package automatically because the root `tsconfig.json` includes `**/*.ts`.
+
+**Negative / risks**
+
+- The 20 `ErrorCode` values are a guess at what future packages will need. Some may be wrong, others missing. Mitigation: codes are additive (minor-version bump), so wrong-by-omission is cheap to fix.
+- Twenty codes is enough rope for cargo-cult adoption — contributors might create new code names instead of reusing existing ones. Mitigation: explicit guidance in the package README and code review.
+
+## How we'll know it worked
+
+- The package's `errors.test.ts` suite passes (`npx jest packages/bayaan-types`): 12 tests, ~30ms.
+- `npx tsc --noEmit` from repo root produces no new errors versus develop's baseline.
+- iOS and Android builds produce identical artifacts to develop (no Metro / Babel resolution surprises from the new workspace package).
+- A subsequent RFC (likely the audio seam RFC) imports `BayaanError` from `@bayaan/types` and the import resolves cleanly without further configuration.
+
+## Open questions (deferred)
+
+- **Jest workspace integration.** Does `npm test` from root pick up the package's tests, or do they need an explicit invocation? Will validate during this PR; if not auto-discovered, a follow-up RFC adds a Jest projects config.
+- **`@bayaan/types` consumption pattern in app code.** Should app files import directly from `@bayaan/types` (`import { BayaanError } from '@bayaan/types'`) or from a relay (e.g., `@/lib/errors` re-exports)? Not decided here. Will surface naturally in the first migration RFC.
+- **Where `RewayahId` ultimately lives.** Today: `services/rewayah/RewayahIdentity.ts` per its file-header directive. Whether to relocate is a separate discussion with its own RFC.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,17 @@
 {
   "name": "bayaan",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bayaan",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "hasInstallScript": true,
+      "license": "AGPL-3.0-or-later",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1029.0",
         "@babel/runtime": "^7.20.6",
@@ -3429,6 +3433,10 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bayaan/types": {
+      "resolved": "packages/bayaan-types",
+      "link": true
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -3440,7 +3448,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -3453,7 +3461,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -8741,28 +8749,28 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node18": {
@@ -9422,7 +9430,7 @@
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
       "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -11017,7 +11025,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cross-fetch": {
@@ -11592,7 +11600,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -18556,7 +18564,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -24115,7 +24123,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -24159,7 +24167,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/ts-toolbelt": {
@@ -24681,7 +24689,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -25182,7 +25190,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -25257,6 +25265,11 @@
           "optional": true
         }
       }
+    },
+    "packages/bayaan-types": {
+      "name": "@bayaan/types",
+      "version": "0.1.0",
+      "license": "AGPL-3.0-or-later"
     }
   }
 }

--- a/packages/bayaan-types/README.md
+++ b/packages/bayaan-types/README.md
@@ -1,0 +1,25 @@
+# @bayaan/types
+
+Shared TypeScript primitives and error machinery for the Bayaan platform.
+
+This package is intentionally small. It contains only types that have no clear single-owning concern, plus the `BayaanError` hierarchy used across future platform packages.
+
+## What lives here
+
+- **Playback primitives** — `BaseTrack`, `PlaybackState` (native union)
+- **Mushaf primitives** — `AyahTimestamp`
+- **Lock-screen** — `LockScreenMetadata`
+- **Ambient** — `AmbientSoundType`
+- **Errors** — `BayaanError` base class, `BayaanAudioError` / `BayaanMushafError` / `BayaanLifecycleError` / `BayaanNetworkError` subclasses, `ErrorCode` enum
+
+## What does not live here
+
+- `RewayahId` — canonical at [`services/rewayah/RewayahIdentity.ts`](../../services/rewayah/RewayahIdentity.ts) per its file header.
+- Port interfaces (`PlayerController`, `CoordinatorHooks`, etc.) — owned by the feature packages that publish them (e.g. future `@bayaan/audio`).
+- Concrete `Track` shapes with metadata — consumer-defined; consumers extend `BaseTrack`.
+
+See [RFC-002](../../docs/rfcs/002-bayaan-types-package.md) for the full distribution rationale.
+
+## Status
+
+Pre-1.0. The shapes here are stable in intent but may be revised as feature packages adopt them.

--- a/packages/bayaan-types/jest.config.js
+++ b/packages/bayaan-types/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'jest-expo',
+  testMatch: ['<rootDir>/src/**/__tests__/**/*.test.ts'],
+};

--- a/packages/bayaan-types/package.json
+++ b/packages/bayaan-types/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@bayaan/types",
+  "version": "0.1.0",
+  "description": "Shared type primitives and error machinery for the Bayaan platform.",
+  "license": "AGPL-3.0-or-later",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "sideEffects": false,
+  "scripts": {
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/bayaan-types/src/__tests__/errors.test.ts
+++ b/packages/bayaan-types/src/__tests__/errors.test.ts
@@ -1,0 +1,136 @@
+import {
+  BayaanError,
+  BayaanAudioError,
+  BayaanMushafError,
+  BayaanLifecycleError,
+  BayaanNetworkError,
+} from '../errors';
+
+describe('BayaanError', () => {
+  describe('construction', () => {
+    it('captures code, recoverable, message, and frozen context', () => {
+      const err = new BayaanError('AUDIO_LOAD_FAILED', 'load failed', {
+        recoverable: true,
+        context: {url: 'https://example.invalid/track.mp3'},
+      });
+
+      expect(err.code).toBe('AUDIO_LOAD_FAILED');
+      expect(err.recoverable).toBe(true);
+      expect(err.message).toBe('load failed');
+      expect(err.context).toEqual({url: 'https://example.invalid/track.mp3'});
+      expect(Object.isFrozen(err.context)).toBe(true);
+    });
+
+    it('defaults context to an empty frozen object when omitted', () => {
+      const err = new BayaanError('PRECONDITION_VIOLATED', 'no player', {
+        recoverable: false,
+      });
+
+      expect(err.context).toEqual({});
+      expect(Object.isFrozen(err.context)).toBe(true);
+    });
+
+    it('preserves a cause via options.cause', () => {
+      const cause = new TypeError('bad uri');
+      const err = new BayaanError('AUDIO_SOURCE_INVALID', 'invalid source', {
+        recoverable: false,
+        cause,
+      });
+
+      expect(err.cause).toBe(cause);
+    });
+
+    it('does not retain a reference to the caller-provided context object', () => {
+      const ctx = {surahId: 42} as Record<string, unknown>;
+      const err = new BayaanError('AUDIO_PLAYBACK_FAILED', 'failed', {
+        recoverable: true,
+        context: ctx,
+      });
+
+      // Mutating the original object must not change the error's context.
+      ctx.surahId = 99;
+      expect(err.context).toEqual({surahId: 42});
+    });
+  });
+
+  describe('Error inheritance', () => {
+    it('is an instance of Error and BayaanError', () => {
+      const err = new BayaanError('AUDIO_LOAD_FAILED', 'x', {
+        recoverable: true,
+      });
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(BayaanError);
+    });
+
+    it('preserves a stack trace', () => {
+      const err = new BayaanError('AUDIO_LOAD_FAILED', 'x', {
+        recoverable: true,
+      });
+      expect(typeof err.stack).toBe('string');
+      expect(err.stack ?? '').toContain('Error');
+    });
+  });
+});
+
+describe('Domain subclasses', () => {
+  it('all extend BayaanError and Error', () => {
+    const audio = new BayaanAudioError('AUDIO_LOAD_FAILED', 'a', {
+      recoverable: true,
+    });
+    const mushaf = new BayaanMushafError('MUSHAF_DB_NOT_FOUND', 'm', {
+      recoverable: false,
+    });
+    const lifecycle = new BayaanLifecycleError('LIFECYCLE_AFTER_DESTROY', 'l', {
+      recoverable: false,
+    });
+    const network = new BayaanNetworkError('NETWORK_TIMEOUT', 'n', {
+      recoverable: true,
+    });
+
+    for (const err of [audio, mushaf, lifecycle, network]) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(BayaanError);
+    }
+  });
+
+  it('have the right name property for each subclass', () => {
+    expect(
+      new BayaanAudioError('AUDIO_LOAD_FAILED', 'x', {recoverable: true}).name,
+    ).toBe('BayaanAudioError');
+    expect(
+      new BayaanMushafError('MUSHAF_DB_NOT_FOUND', 'x', {recoverable: false})
+        .name,
+    ).toBe('BayaanMushafError');
+    expect(
+      new BayaanLifecycleError('LIFECYCLE_AFTER_DESTROY', 'x', {
+        recoverable: false,
+      }).name,
+    ).toBe('BayaanLifecycleError');
+    expect(
+      new BayaanNetworkError('NETWORK_TIMEOUT', 'x', {recoverable: true}).name,
+    ).toBe('BayaanNetworkError');
+  });
+
+  it('lets consumers branch on instanceof for each domain', () => {
+    const errs = [
+      new BayaanAudioError('AUDIO_LOAD_FAILED', 'a', {recoverable: true}),
+      new BayaanMushafError('MUSHAF_DB_NOT_FOUND', 'm', {recoverable: false}),
+      new BayaanLifecycleError('LIFECYCLE_AFTER_DESTROY', 'l', {
+        recoverable: false,
+      }),
+      new BayaanNetworkError('NETWORK_TIMEOUT', 'n', {recoverable: true}),
+    ] as const;
+
+    expect(errs[0]).toBeInstanceOf(BayaanAudioError);
+    expect(errs[0]).not.toBeInstanceOf(BayaanMushafError);
+
+    expect(errs[1]).toBeInstanceOf(BayaanMushafError);
+    expect(errs[1]).not.toBeInstanceOf(BayaanAudioError);
+
+    expect(errs[2]).toBeInstanceOf(BayaanLifecycleError);
+    expect(errs[2]).not.toBeInstanceOf(BayaanNetworkError);
+
+    expect(errs[3]).toBeInstanceOf(BayaanNetworkError);
+    expect(errs[3]).not.toBeInstanceOf(BayaanLifecycleError);
+  });
+});

--- a/packages/bayaan-types/src/ambient.ts
+++ b/packages/bayaan-types/src/ambient.ts
@@ -1,0 +1,13 @@
+/**
+ * Built-in ambient sound types supported by the platform's ambient audio
+ * service. Future ambient package may expose a richer registry; for now this
+ * is the canonical taxonomy.
+ */
+export type AmbientSoundType =
+  | 'rain'
+  | 'forest'
+  | 'ocean'
+  | 'stream'
+  | 'thunder'
+  | 'fireplace'
+  | 'wind';

--- a/packages/bayaan-types/src/errors.ts
+++ b/packages/bayaan-types/src/errors.ts
@@ -1,0 +1,108 @@
+/**
+ * Bayaan platform error machinery.
+ *
+ * Every error produced by `@bayaan/*` packages is a `BayaanError` subclass.
+ * Consumers branch on `error.code` (stable enum) or `error instanceof
+ * BayaanAudioError` (domain marker), never on `error.message`.
+ *
+ * Two categories by handling:
+ *   - Recoverable (`recoverable: true`) — flow through callback ports
+ *     (`onError` callbacks); service continues to function.
+ *   - Non-recoverable (`recoverable: false`) — thrown synchronously from the
+ *     offending method; signal a programming error (lifecycle violation,
+ *     precondition failure).
+ */
+
+/**
+ * Stable enum of error codes. Adding a code is a minor-version bump; renaming
+ * or removing is a major-version bump. Consumers may safely branch on any
+ * string in this union.
+ */
+export type ErrorCode =
+  // ── Lifecycle (across all services) ────────────────────────────────────────
+  | 'LIFECYCLE_AFTER_DESTROY'
+  | 'LIFECYCLE_BEFORE_INIT'
+  | 'PRECONDITION_VIOLATED'
+  // ── Audio ──────────────────────────────────────────────────────────────────
+  | 'AUDIO_LOAD_FAILED'
+  | 'AUDIO_SEEK_FAILED'
+  | 'AUDIO_PLAYBACK_FAILED'
+  | 'AUDIO_SOURCE_INVALID'
+  | 'AUDIO_INTERRUPTED'
+  // ── Mushaf data ────────────────────────────────────────────────────────────
+  | 'MUSHAF_DB_NOT_FOUND'
+  | 'MUSHAF_DB_SCHEMA_MISMATCH'
+  | 'MUSHAF_REWAYAH_NOT_AVAILABLE'
+  | 'MUSHAF_PAGE_OUT_OF_RANGE'
+  // ── Rewayat ────────────────────────────────────────────────────────────────
+  | 'REWAYAT_DIFF_MISSING'
+  | 'REWAYAT_DIFF_MALFORMED'
+  // ── Mushaf render ──────────────────────────────────────────────────────────
+  | 'SKIA_NOT_READY'
+  | 'LAYOUT_COMPUTE_FAILED'
+  // ── Lock screen ────────────────────────────────────────────────────────────
+  | 'LOCK_SCREEN_METADATA_REJECTED'
+  | 'LOCK_SCREEN_CONTROLS_UNAVAILABLE'
+  // ── Network ────────────────────────────────────────────────────────────────
+  | 'NETWORK_TIMEOUT'
+  | 'NETWORK_OFFLINE'
+  | 'NETWORK_HTTP_ERROR';
+
+export interface BayaanErrorOptions {
+  recoverable: boolean;
+  context?: Record<string, unknown>;
+  cause?: unknown;
+}
+
+/**
+ * Base class for all platform errors. Use the domain subclasses
+ * (`BayaanAudioError`, `BayaanMushafError`, …) when throwing or constructing
+ * for `instanceof` matching downstream.
+ */
+export class BayaanError extends Error {
+  readonly code: ErrorCode;
+  readonly recoverable: boolean;
+  readonly context: Readonly<Record<string, unknown>>;
+  readonly cause?: unknown;
+
+  constructor(code: ErrorCode, message: string, options: BayaanErrorOptions) {
+    super(message);
+    this.name = 'BayaanError';
+    this.code = code;
+    this.recoverable = options.recoverable;
+    this.context = Object.freeze({...(options.context ?? {})});
+    this.cause = options.cause;
+  }
+}
+
+/** Audio-domain errors. Use for AUDIO_* codes. */
+export class BayaanAudioError extends BayaanError {
+  constructor(code: ErrorCode, message: string, options: BayaanErrorOptions) {
+    super(code, message, options);
+    this.name = 'BayaanAudioError';
+  }
+}
+
+/** Mushaf-domain errors. Use for MUSHAF_* / REWAYAT_* / SKIA_* codes. */
+export class BayaanMushafError extends BayaanError {
+  constructor(code: ErrorCode, message: string, options: BayaanErrorOptions) {
+    super(code, message, options);
+    this.name = 'BayaanMushafError';
+  }
+}
+
+/** Lifecycle errors. Use for LIFECYCLE_* / PRECONDITION_* codes. */
+export class BayaanLifecycleError extends BayaanError {
+  constructor(code: ErrorCode, message: string, options: BayaanErrorOptions) {
+    super(code, message, options);
+    this.name = 'BayaanLifecycleError';
+  }
+}
+
+/** Network errors. Use for NETWORK_* codes. */
+export class BayaanNetworkError extends BayaanError {
+  constructor(code: ErrorCode, message: string, options: BayaanErrorOptions) {
+    super(code, message, options);
+    this.name = 'BayaanNetworkError';
+  }
+}

--- a/packages/bayaan-types/src/index.ts
+++ b/packages/bayaan-types/src/index.ts
@@ -1,0 +1,21 @@
+// Playback
+export type {BaseTrack, PlaybackState} from './playback';
+
+// Mushaf
+export type {AyahTimestamp} from './mushaf';
+
+// Lock screen
+export type {LockScreenMetadata} from './lock-screen';
+
+// Ambient
+export type {AmbientSoundType} from './ambient';
+
+// Errors
+export type {BayaanErrorOptions, ErrorCode} from './errors';
+export {
+  BayaanError,
+  BayaanAudioError,
+  BayaanMushafError,
+  BayaanLifecycleError,
+  BayaanNetworkError,
+} from './errors';

--- a/packages/bayaan-types/src/lock-screen.ts
+++ b/packages/bayaan-types/src/lock-screen.ts
@@ -1,0 +1,14 @@
+/**
+ * Metadata payload for OS lock-screen / Now Playing controls.
+ *
+ * Consumer apps build this from their playback state and the active track;
+ * future audio package's lock-screen integration consumes it.
+ */
+export interface LockScreenMetadata {
+  title: string;
+  artist: string;
+  artworkUrl?: string;
+  durationMs: number;
+  positionMs: number;
+  isPlaying: boolean;
+}

--- a/packages/bayaan-types/src/mushaf.ts
+++ b/packages/bayaan-types/src/mushaf.ts
@@ -1,0 +1,10 @@
+/**
+ * Ayah timing data for verse-by-verse follow-along.
+ *
+ * Times are millisecond offsets from the beginning of a recitation track.
+ */
+export interface AyahTimestamp {
+  ayahNumber: number;
+  timestampFromMs: number;
+  timestampToMs: number;
+}

--- a/packages/bayaan-types/src/playback.ts
+++ b/packages/bayaan-types/src/playback.ts
@@ -1,0 +1,33 @@
+/**
+ * Native playback state union, used by audio services to communicate with consumers.
+ *
+ * - `idle` — no track loaded
+ * - `loading` — load in progress
+ * - `ready` — track loaded, not playing
+ * - `playing` — actively playing
+ * - `paused` — track loaded, paused (distinct from idle/ready)
+ * - `error` — last operation failed; consumer should inspect onError
+ */
+export type PlaybackState =
+  | 'idle'
+  | 'loading'
+  | 'ready'
+  | 'playing'
+  | 'paused'
+  | 'error';
+
+/**
+ * Minimum fields every track must have. Consumer apps extend this with their
+ * own metadata shape (surah / reciter / rewayah / album / chapter / etc.).
+ *
+ * Future audio package will expose `Track<TMeta extends BaseTrack>` so consumer
+ * metadata stays consumer-typed without leaking into the package.
+ */
+export interface BaseTrack {
+  id: string;
+  url: string;
+  title: string;
+  artist?: string;
+  artworkUrl?: string;
+  durationMs?: number;
+}

--- a/packages/bayaan-types/tsconfig.json
+++ b/packages/bayaan-types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## What this PR is

The second in the RFC series started by [#227](https://github.com/thebayaan/Bayaan/pull/227). Lands the first package in the workspace: `@bayaan/types` — a TypeScript-only library with shared primitives and the `BayaanError` class hierarchy.

The full RFC is at [`docs/rfcs/002-bayaan-types-package.md`](docs/rfcs/002-bayaan-types-package.md).

## What it adds

- `packages/bayaan-types/` — package scaffolding (package.json, tsconfig, jest.config, README) plus `src/` modules: `playback.ts` (`BaseTrack`, `PlaybackState`), `mushaf.ts` (`AyahTimestamp`), `lock-screen.ts` (`LockScreenMetadata`), `ambient.ts` (`AmbientSoundType`), `errors.ts` (`BayaanError` + 4 subclasses + `ErrorCode` enum)
- `packages/bayaan-types/src/__tests__/errors.test.ts` — 9 contract tests covering construction, frozen context, defensive copying, `instanceof` semantics, name property, stack trace preservation, per-subclass discrimination
- `package-lock.json` — npm registered the workspace symlink at `node_modules/@bayaan/types -> packages/bayaan-types`
- `docs/rfcs/002-bayaan-types-package.md` — RFC document

## What it does not do

- **No `RewayahId`.** Stays canonical at [`services/rewayah/RewayahIdentity.ts`](services/rewayah/RewayahIdentity.ts) per the explicit file-header directive ("All other rewayah-aware code imports from here. Do not define a RewayahId literal […] anywhere else."). A future RFC may propose moving it; not in scope here.
- **No port interfaces** (`PlayerController`, `CoordinatorHooks`, etc.) — owned by future feature packages, not types.
- **No app-side imports of `@bayaan/types`.** Existing app code unchanged. Migration of throw sites + type usage happens in subsequent RFCs as each feature is migrated. Keeps this PR's diff bounded and respects the Tidy First constraint.
- **No build step on the package.** `main` and `types` both point at `src/index.ts`; Metro and `tsc` consume `.ts` directly via the workspace symlink.

## Verification

| Check | Result |
| --- | --- |
| `npm install` | Workspace symlink created at `node_modules/@bayaan/types -> packages/bayaan-types` |
| `npx jest packages/bayaan-types` | **9/9 pass in 686 ms** (auto-discovered by root jest config) |
| `npx jest --watchAll=false` (full suite) | 5 suites pass, 1 known-empty failure (`utils/__tests__/storageAnalytics.test.ts`), 44 tests pass — up from 31 on develop baseline |
| `npx tsc --noEmit` | **Zero new errors** vs develop baseline |
| `npx prettier --write packages/bayaan-types` | Clean |
| Local iOS build | In progress — will follow up in a comment once verified |

## Why this is its own PR

One bounded decision: do you want this small, types-only package as the first inhabitant of `packages/`? If yes, the rest of the platform RFC series (audio seam, mushaf split, contract test runners) build on top. If you'd prefer a different shape — different module boundaries, different error model, defer the package entirely — easy to redirect before any feature package depends on it.

## Risk if this lands and a later RFC is rejected

The package is ~250 lines of types + tests. Even if every subsequent RFC is rejected, the package is independently useful as a place for the `BayaanError` machinery. Worst case: it sits in `packages/` unused. No code outside the package depends on it after this PR.

## Open questions called out in the RFC

- **Jest workspace integration.** `npm test` from root currently picks up the package's tests via the existing `jest-expo` config without changes — works today. May want a `projects` config later for per-package isolation; not in scope here.
- **Consumption pattern.** Whether app code imports directly from `@bayaan/types` or via a relay (`@/lib/errors` re-exports) — surfaces naturally in the first migration RFC.
- **`RewayahId` home.** Today: `services/rewayah/RewayahIdentity.ts`. Whether to relocate is a separate discussion.

---

Happy to iterate on the error code list, the type-distribution rules, or the package's structure based on your read.