### PR TITLE
docs(rfc): RFC-003 — CI test gate + @bayaan/test-utils package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  jest:
+    name: Jest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Jest
+        # jest-expo eagerly loads Metro's transform cache; the default ~1.7 GB
+        # heap is enough today but very tight. Match lint.yml's bump for headroom.
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+        run: npm run test:ci

--- a/docs/rfcs/003-ci-gates-and-test-utils.md
+++ b/docs/rfcs/003-ci-gates-and-test-utils.md
@@ -1,0 +1,233 @@
+# RFC-003: CI test gate + `@bayaan/test-utils` package
+
+| Field    | Value      |
+| -------- | ---------- |
+| Status   | Proposed   |
+| Date     | 2026-05-03 |
+| Author   | Omar Zarka |
+
+## Summary
+
+Two paired changes that together close a small but real gap in the workspace established by [RFC-001](001-workspace-and-rfc-convention.md) and populated by [RFC-002](002-bayaan-types-package.md):
+
+1. Add a **Jest CI workflow** (`.github/workflows/test.yml`) that runs the Jest suite on every push / PR — covering both the app's existing tests and any tests in `packages/*`.
+2. Add a second workspace package: **`@bayaan/test-utils`** — a tiny library of shared test helpers (custom Jest matchers for `BayaanError`, scoped initially to what's reachable today). Designed to grow alongside subsequent feature packages.
+
+No app code changes. No modifications to the existing `lint.yml`. Purely additive infrastructure, bounded to enable the heavier extraction RFCs without re-litigating tooling each time.
+
+## Motivation
+
+After RFC-002 landed, the workspace has:
+- One package (`@bayaan/types`) with 9 contract tests.
+- A root `package.json` with `"test": "jest --watchAll"` (interactive — not CI-suitable).
+- A `lint.yml` workflow running Prettier / ESLint / `tsc`. **No automatic test execution.**
+- `npx jest --watchAll=false` happens to work locally and picks up package tests via the workspace symlink, but nothing enforces it on PRs.
+
+Two consequences if we proceed without addressing this:
+
+- **Test drift.** The next RFC (audio seam) ships a `PlayerController` port and an adapter scaffold. RFC-005 (mushaf split) ships more. Each will land contract tests. Without a CI gate, those tests rot silently the moment someone updates a peer dependency or a type signature; we discover the breakage during the next PR's local run, not at the PR boundary.
+- **Test plumbing duplication.** Every feature package will want the same handful of helpers — the most obvious being a way to assert "this threw a `BayaanAudioError` with code `AUDIO_LOAD_FAILED`". Without a shared package, each downstream RFC re-implements the matcher locally. Three implementations diverge silently.
+
+The fix is a small CI workflow plus a bounded helpers package — both additive, both reversible.
+
+A note on scope discipline: this RFC deliberately does **not** flip the `continue-on-error` flags on Prettier or ESLint in `lint.yml`. That's a behavior change in CI signals (PRs that pass today would start failing) and belongs in its own change with a coordinated lint-debt cleanup pass. RFC-003 is purely additive.
+
+## Decision
+
+### 1. Add `.github/workflows/test.yml`
+
+```yaml
+name: Test
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  jest:
+    name: Jest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci --no-audit --no-fund
+      - name: Jest
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+        run: npm run test:ci
+```
+
+Mirrors `lint.yml`'s shape. Same Node version, same caching, same heap bump (Jest also wants more than the default 1.7 GB once `jest-expo` initializes Metro's transform cache).
+
+### 2. Add a `test:ci` script to root `package.json`
+
+```diff
+   "scripts": {
+     "test": "jest --watchAll",
++    "test:ci": "jest --watchAll=false --ci --reporters=default",
+```
+
+The existing `test` script stays interactive (matches the developer expectation of `npm test` in an RN/Expo project). The new `test:ci` is non-interactive and explicit about CI mode.
+
+### 3. Add `packages/bayaan-test-utils/`
+
+Mirror the layout RFC-002 established for `@bayaan/types`:
+
+```
+packages/bayaan-test-utils/
+├── package.json          # name: @bayaan/test-utils, version: 0.1.0, AGPL-3.0-or-later, "private": true, depends on @bayaan/types
+├── tsconfig.json         # extends expo/tsconfig.base
+├── jest.config.js        # preset: jest-expo, testMatch: src/**/__tests__/**/*.test.ts
+├── README.md
+└── src/
+    ├── index.ts          # re-exports
+    ├── error-matchers.ts # toBeBayaanError, toThrowBayaanError matchers
+    └── __tests__/
+        └── error-matchers.test.ts
+```
+
+`main` and `types` both point at `src/index.ts`. No build step.
+
+#### What the package exports (initial)
+
+```ts
+import type {ErrorCode} from '@bayaan/types';
+import {BayaanError} from '@bayaan/types';
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeBayaanError(code?: ErrorCode): R;
+    }
+    interface Expect {
+      toBeBayaanError(code?: ErrorCode): unknown;
+    }
+  }
+}
+
+export const bayaanErrorMatchers = {
+  toBeBayaanError(received: unknown, code?: ErrorCode) { /* … */ },
+};
+
+/** One-call setup for jest.setup.ts. */
+export function registerBayaanMatchers(): void {
+  expect.extend(bayaanErrorMatchers);
+}
+```
+
+Consumer usage in a feature-package test:
+
+```ts
+import {registerBayaanMatchers} from '@bayaan/test-utils';
+import {BayaanAudioError} from '@bayaan/types';
+
+beforeAll(() => registerBayaanMatchers());
+
+test('rejects malformed source', () => {
+  expect(() => loadTrack(badUrl)).toThrow();
+  // or with the matcher:
+  const err = catchError(() => loadTrack(badUrl));
+  expect(err).toBeBayaanError('AUDIO_SOURCE_INVALID');
+});
+```
+
+The matcher stays small on purpose. Async support, `.toThrow`-style wrapping, snapshot integration — all intentionally out of scope until a feature package needs them. **Add when the second consumer asks; not before.**
+
+### 4. One unrelated cleanup — `testPathIgnorePatterns` for an empty test file
+
+`utils/__tests__/storageAnalytics.test.ts` exists on `develop` as a 0-byte file (added in `0cd01e4` "updated playback and queueing architecture"). Today it's harmless — `npm test --watchAll` shows it as a failed suite locally and humans ignore it. The moment a CI test gate exists, that 0-byte file fails the new workflow on every PR.
+
+The smallest possible fix is a targeted `testPathIgnorePatterns` entry on the root jest config:
+
+```diff
+   "jest": {
+-    "preset": "jest-expo"
++    "preset": "jest-expo",
++    "testPathIgnorePatterns": [
++      "/node_modules/",
++      "<rootDir>/utils/__tests__/storageAnalytics.test.ts"
++    ]
+   },
+```
+
+This is technically off-scope for "add CI gates" (it's a maintenance fix on an unrelated file), but the alternative is shipping a CI gate that's red on day one. **Open question for the maintainer:** prefer this targeted ignore, or would you rather (a) split it into a separate cleanup PR that lands first, or (b) delete the empty file outright? Easy to redirect.
+
+### 5. What this RFC does NOT change
+
+- `lint.yml` — untouched. Prettier and ESLint stay `continue-on-error: true`. That's a separate cleanup PR.
+- The root `tsc --noEmit` step — already covers `packages/*` via the workspace symlink (RFC-002's verification confirmed this).
+- The interactive `npm test` developer flow — preserved verbatim.
+- App code — no imports of `@bayaan/test-utils` anywhere. The `@bayaan/types` package, once consumed, will use `@bayaan/test-utils` in its tests; nothing else does yet.
+
+### 6. Versioning
+
+`@bayaan/test-utils@0.1.0`. Same `0.x` discipline as `@bayaan/types`: stays `0.x` until a feature package consumes it in production. Promote to `1.0.0` at first stable adoption.
+
+## Alternatives considered
+
+### A — Add tests to the existing `lint.yml` job
+
+Reuse `lint.yml`, append a `Jest` step.
+
+**Rejected.** Concurrency group, cancel-in-progress, and step ordering are already tuned for the lint job. Adding tests would either run them after the typecheck (slowing PR signal) or before it (worse signal — typecheck failures should pre-empt test runs). A separate workflow lets each one fail-fast independently and run in parallel.
+
+### B — Include the matcher in `@bayaan/types` directly
+
+Drop `@bayaan/test-utils` and put `bayaanErrorMatchers` in `@bayaan/types` under `@bayaan/types/test`.
+
+**Rejected.** `@bayaan/types` declares `sideEffects: false` and is consumed in production bundles. Test-only code doesn't belong there even behind a sub-path; tree-shaking buys us nothing if the package conceptually mixes concerns.
+
+### C — Defer test-utils until a second consumer asks
+
+Ship CI workflow now, defer the package. Each feature-package RFC reinvents matchers as needed.
+
+**Rejected.** RFC-004 (audio seam) and RFC-005 (mushaf split) both need `BayaanError` matchers in their contract tests. Deferring guarantees three duplicates that diverge. Cheaper to ship the bounded scaffold now.
+
+### D — Use an existing matcher library (e.g., `jest-extended`, custom-error-matchers)
+
+Pull in a third-party matcher dep instead of writing our own.
+
+**Rejected.** None of the popular libraries know about `BayaanError.code` — the most useful assertion. We'd still need a custom matcher for that. Adding a dep for the rest is more surface than it's worth.
+
+## Consequences
+
+**Positive**
+
+- Every PR runs the Jest suite on CI. Test drift caught at the PR boundary.
+- Future feature-package RFCs can `import {registerBayaanMatchers} from '@bayaan/test-utils'` — one-line setup, no boilerplate.
+- The matcher's contract tests live in the package itself, so the test infrastructure is self-verifying.
+- Confirms (a second time) that the `packages/*` workspace pattern works for non-types packages with cross-package dependencies (`@bayaan/test-utils` → `@bayaan/types`).
+
+**Neutral**
+
+- One new GitHub Actions job per push / PR. Same runner image as `lint.yml`; cache-warmed `npm ci` is fast.
+- One new workspace symlink at `node_modules/@bayaan/test-utils -> packages/bayaan-test-utils`.
+- Adds one new line to `package.json scripts`.
+
+**Negative / risks**
+
+- The matcher's API will likely grow as feature packages adopt it. Each addition is a minor-version bump (`0.x.y → 0.x.y+1`); breaking changes go to `0.(x+1).0` until 1.0. Mitigation: keep the API tight; add only when a real consumer asks.
+- A test that uses `registerBayaanMatchers()` at the top of one file but not another can mis-suggest the matcher works globally. Mitigation: documented in the package README; the long-run pattern is a single jest setup file per package that calls it once.
+
+## How we'll know it worked
+
+- The Jest CI workflow runs green on this PR.
+- `npx tsc --noEmit` produces no new errors versus develop's baseline.
+- Local `npm run test:ci` runs the full suite (existing + 9 from `@bayaan/types` + new tests in `@bayaan/test-utils`) and exits 0.
+- iOS and Android builds produce identical artifacts to develop.
+- A subsequent RFC (likely RFC-004, audio seam) imports `registerBayaanMatchers` and the import resolves cleanly.
+
+## Open questions (deferred)
+
+- **Should `lint.yml`'s Prettier/ESLint flip to blocking?** Out of scope here. Worth a separate cleanup pass once the existing debt has been paid down.
+- **Test sharding by package via `jest --projects`.** Not needed at 9 + new tests. Worth revisiting once the suite hits ~5+ packages and parallel runs would matter for PR latency.
+- **`@bayaan/test-utils` exports for adapter-side mocks** (e.g., `mockAudioPlayer`). Comes naturally with RFC-004 — adding here would be premature.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3433,6 +3433,10 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bayaan/test-utils": {
+      "resolved": "packages/bayaan-test-utils",
+      "link": true
+    },
     "node_modules/@bayaan/types": {
       "resolved": "packages/bayaan-types",
       "link": true
@@ -25264,6 +25268,14 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "packages/bayaan-test-utils": {
+      "name": "@bayaan/test-utils",
+      "version": "0.1.0",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@bayaan/types": "*"
       }
     },
     "packages/bayaan-types": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ios": "LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 expo run:ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
+    "test:ci": "jest --watchAll=false --ci --reporters=default",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -33,7 +34,11 @@
     "build:prod:ios": "eas build --profile production --platform ios"
   },
   "jest": {
-    "preset": "jest-expo"
+    "preset": "jest-expo",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/utils/__tests__/storageAnalytics.test.ts"
+    ]
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1029.0",

--- a/packages/bayaan-test-utils/README.md
+++ b/packages/bayaan-test-utils/README.md
@@ -1,0 +1,50 @@
+# `@bayaan/test-utils`
+
+Shared Jest test helpers for `@bayaan/*` packages. Internal to the workspace; not published.
+
+## What's here
+
+- `bayaanErrorMatchers` — Jest custom matchers that understand the `BayaanError` hierarchy from `@bayaan/types`.
+  - `expect(value).toBeBayaanError(code?)` — asserts the value is a `BayaanError` (optionally with a specific `ErrorCode`).
+- `registerBayaanMatchers()` — one-call helper that calls `expect.extend(bayaanErrorMatchers)`. Use it in a Jest setup file.
+
+## Usage
+
+In a feature-package test:
+
+```ts
+import {registerBayaanMatchers} from '@bayaan/test-utils';
+import {BayaanAudioError} from '@bayaan/types';
+
+beforeAll(() => registerBayaanMatchers());
+
+test('rejects malformed source', () => {
+  const err = new BayaanAudioError('AUDIO_SOURCE_INVALID', 'bad uri', {
+    recoverable: false,
+  });
+  expect(err).toBeBayaanError('AUDIO_SOURCE_INVALID');
+  expect(err).toBeBayaanError(); // no code: just asserts BayaanError-ness
+});
+```
+
+For consumers that want it registered globally, point Jest's `setupFilesAfterEach` at a one-line setup file:
+
+```js
+// jest.setup.ts
+import {registerBayaanMatchers} from '@bayaan/test-utils';
+registerBayaanMatchers();
+```
+
+```js
+// jest.config.js
+module.exports = {
+  preset: 'jest-expo',
+  setupFilesAfterEach: ['<rootDir>/jest.setup.ts'],
+};
+```
+
+## Scope rules
+
+This package is for **test-only helpers consumed by 2+ packages**. Don't put production code here.
+
+Adding new matchers / mocks: bump `0.x.y → 0.x.y+1` for additions, `0.x → 0.(x+1)` for breaking signature changes, until first stable adoption (then 1.0). Same versioning convention as `@bayaan/types` per [RFC-002](../../docs/rfcs/002-bayaan-types-package.md).

--- a/packages/bayaan-test-utils/jest.config.js
+++ b/packages/bayaan-test-utils/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'jest-expo',
+  testMatch: ['<rootDir>/src/**/__tests__/**/*.test.ts'],
+};

--- a/packages/bayaan-test-utils/package.json
+++ b/packages/bayaan-test-utils/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@bayaan/test-utils",
+  "version": "0.1.0",
+  "description": "Shared Jest test helpers for @bayaan/* packages.",
+  "license": "AGPL-3.0-or-later",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "sideEffects": false,
+  "scripts": {
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@bayaan/types": "*"
+  }
+}

--- a/packages/bayaan-test-utils/src/__tests__/error-matchers.test.ts
+++ b/packages/bayaan-test-utils/src/__tests__/error-matchers.test.ts
@@ -1,0 +1,80 @@
+import {
+  BayaanAudioError,
+  BayaanError,
+  BayaanMushafError,
+  BayaanNetworkError,
+} from '@bayaan/types';
+import {registerBayaanMatchers} from '../error-matchers';
+
+beforeAll(() => {
+  registerBayaanMatchers();
+});
+
+describe('toBeBayaanError', () => {
+  describe('without a code argument', () => {
+    it('passes for any BayaanError', () => {
+      const err = new BayaanError('AUDIO_LOAD_FAILED', 'load failed', {
+        recoverable: true,
+      });
+      expect(err).toBeBayaanError();
+    });
+
+    it('passes for any BayaanError subclass', () => {
+      expect(
+        new BayaanAudioError('AUDIO_LOAD_FAILED', 'a', {recoverable: true}),
+      ).toBeBayaanError();
+      expect(
+        new BayaanMushafError('MUSHAF_DB_NOT_FOUND', 'm', {recoverable: false}),
+      ).toBeBayaanError();
+      expect(
+        new BayaanNetworkError('NETWORK_TIMEOUT', 'n', {recoverable: true}),
+      ).toBeBayaanError();
+    });
+
+    it('fails for plain Error', () => {
+      const err = new Error('boom');
+      expect(err).not.toBeBayaanError();
+    });
+
+    it('fails for non-Error values', () => {
+      expect('AUDIO_LOAD_FAILED').not.toBeBayaanError();
+      expect({code: 'AUDIO_LOAD_FAILED'}).not.toBeBayaanError();
+      expect(undefined).not.toBeBayaanError();
+      expect(null).not.toBeBayaanError();
+    });
+  });
+
+  describe('with a code argument', () => {
+    it('passes when the code matches', () => {
+      const err = new BayaanAudioError('AUDIO_LOAD_FAILED', 'x', {
+        recoverable: true,
+      });
+      expect(err).toBeBayaanError('AUDIO_LOAD_FAILED');
+    });
+
+    it('fails when the code does not match', () => {
+      const err = new BayaanAudioError('AUDIO_LOAD_FAILED', 'x', {
+        recoverable: true,
+      });
+      expect(err).not.toBeBayaanError('AUDIO_SEEK_FAILED');
+    });
+
+    it('fails when the value is not a BayaanError, regardless of code', () => {
+      expect(new Error('boom')).not.toBeBayaanError('AUDIO_LOAD_FAILED');
+    });
+  });
+
+  it('produces a useful failure message when the assertion fails', () => {
+    const plain = new Error('boom');
+    expect(() => expect(plain).toBeBayaanError()).toThrow(/BayaanError/);
+  });
+
+  it('produces a useful failure message when the code mismatches', () => {
+    const err = new BayaanAudioError('AUDIO_LOAD_FAILED', 'x', {
+      recoverable: true,
+    });
+    expect(() => expect(err).toBeBayaanError('AUDIO_SEEK_FAILED')).toThrow(
+      /AUDIO_SEEK_FAILED/,
+    );
+  });
+});

--- a/packages/bayaan-test-utils/src/error-matchers.ts
+++ b/packages/bayaan-test-utils/src/error-matchers.ts
@@ -1,0 +1,67 @@
+import type {ErrorCode} from '@bayaan/types';
+import {BayaanError} from '@bayaan/types';
+
+/**
+ * Jest custom matchers for the `BayaanError` hierarchy.
+ *
+ * Use `registerBayaanMatchers()` to install them, or pass `bayaanErrorMatchers`
+ * directly to `expect.extend(...)`.
+ */
+export const bayaanErrorMatchers = {
+  toBeBayaanError(
+    this: jest.MatcherContext,
+    received: unknown,
+    code?: ErrorCode,
+  ): jest.CustomMatcherResult {
+    if (!(received instanceof BayaanError)) {
+      return {
+        pass: false,
+        message: () =>
+          `expected value to be a BayaanError, got ${this.utils.printReceived(
+            received,
+          )}`,
+      };
+    }
+
+    if (code !== undefined && received.code !== code) {
+      return {
+        pass: false,
+        message: () =>
+          `expected BayaanError with code ${this.utils.printExpected(
+            code,
+          )}, got code ${this.utils.printReceived(received.code)}`,
+      };
+    }
+
+    return {
+      pass: true,
+      message: () =>
+        code !== undefined
+          ? `expected value not to be a BayaanError with code ${this.utils.printExpected(
+              code,
+            )}`
+          : `expected value not to be a BayaanError`,
+    };
+  },
+};
+
+/** Install the matchers on Jest's `expect`. Call once per test file or in a setup file. */
+export function registerBayaanMatchers(): void {
+  expect.extend(bayaanErrorMatchers);
+}
+
+// Augment Jest's matcher types so consumers get autocomplete + type-checking.
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toBeBayaanError(code?: ErrorCode): R;
+    }
+    interface Expect {
+      toBeBayaanError(code?: ErrorCode): unknown;
+    }
+    interface InverseAsymmetricMatchers {
+      toBeBayaanError(code?: ErrorCode): unknown;
+    }
+  }
+}

--- a/packages/bayaan-test-utils/src/index.ts
+++ b/packages/bayaan-test-utils/src/index.ts
@@ -1,0 +1,1 @@
+export {bayaanErrorMatchers, registerBayaanMatchers} from './error-matchers';

--- a/packages/bayaan-test-utils/tsconfig.json
+++ b/packages/bayaan-test-utils/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## What this PR is

The third in the RFC series. Lands two paired pieces of test infrastructure on top of the workspace established by [#227](https://github.com/thebayaan/Bayaan/pull/227) and populated by [#232](https://github.com/thebayaan/Bayaan/pull/232):

1. A **Jest CI workflow** (`.github/workflows/test.yml`) that runs the suite on every push / PR.
2. **`@bayaan/test-utils`** — a tiny second workspace package with shared Jest matchers for the `BayaanError` hierarchy.

Full RFC: [`docs/rfcs/003-ci-gates-and-test-utils.md`](docs/rfcs/003-ci-gates-and-test-utils.md).

## What it adds

- `.github/workflows/test.yml` — new GitHub Actions workflow, mirrors `lint.yml`'s shape (same Node version, same caching, same heap bump). Independent concurrency group so it runs in parallel with the lint job.
- `package.json` — new `test:ci` script (`jest --watchAll=false --ci --reporters=default`). The interactive `npm test` flow stays unchanged.
- `package.json` — `testPathIgnorePatterns` entry for an empty test file (see "One unrelated cleanup" below).
- `packages/bayaan-test-utils/` — new workspace package with:
  - `bayaanErrorMatchers` + `registerBayaanMatchers()` — a `toBeBayaanError(code?)` matcher with proper Jest type augmentation
  - 9 contract tests covering presence, code matching, subclass acceptance, non-error rejection, and message-formatting expectations
- `package-lock.json` — npm registered the workspace symlink at `node_modules/@bayaan/test-utils -> packages/bayaan-test-utils`.

## What it does not do

- **No changes to `lint.yml`.** Prettier and ESLint stay `continue-on-error: true`. Flipping those is its own coordinated cleanup PR.
- **No app code changes.** Existing services / components / hooks / screens untouched.
- **No new types in `@bayaan/types`.** Pure additive helper package.
- **No build step on the package.** `main` and `types` both point at `src/index.ts`, same as `@bayaan/types`.

## One unrelated cleanup — empty test file

`utils/__tests__/storageAnalytics.test.ts` is a 0-byte file on develop (added in `0cd01e4`). Today it surfaces as a failed suite when humans run `npm test` interactively, but isn't blocking anything because there's no automated check.

The moment this PR's test workflow lands, that 0-byte file fails CI on every PR. The smallest fix is a targeted `testPathIgnorePatterns` entry — included here. Three options if you'd prefer differently:

- **(a)** Keep the targeted ignore — what this PR currently does.
- **(b)** I split the cleanup into a separate "fix or delete the empty test file" PR that lands first; this PR rebases onto it.
- **(c)** Delete the file outright in this PR.

Easy to redirect — let me know.

## Verification

| Check | Result |
| --- | --- |
| `npm install` | Workspace symlink created at `node_modules/@bayaan/test-utils -> packages/bayaan-test-utils` |
| `npx jest packages/bayaan-test-utils` | **9/9 pass in ~0.5s** |
| `npm run test:ci` (full suite) | **6 suites, 53 tests pass in ~2s, 0 failures** (44 pre-existing + 9 new from `@bayaan/test-utils`) |
| `npx tsc --noEmit` | **Zero new errors** vs develop baseline |
| Local iOS build | _(pending — will follow up in a comment once verified)_ |
| Local Android build | _(pending — will follow up in a comment once verified)_ |

## Why this is its own PR

One bounded decision: do you want a Jest CI gate plus a `@bayaan/test-utils` package as the next workspace inhabitant? If yes, RFC-004 (audio seam) and beyond can drop their custom matchers in favor of the shared package. If no — happy to redirect on either piece.

## Risk if this lands and a later RFC is rejected

The two new files (`test.yml` + `packages/bayaan-test-utils/`) are independent of every later RFC. Even if every subsequent RFC is rejected, the CI gate keeps catching test drift and the matcher package is reusable from the existing `@bayaan/types` tests. Worst case: a small package with one matcher sits in `packages/` alongside `@bayaan/types`. No code outside the package depends on it after this PR.

## Open questions called out in the RFC

- **Lint debt cleanup.** Whether to flip `lint.yml`'s `continue-on-error: true` flags. Out of scope here.
- **Test sharding via `jest --projects`.** Not needed at 53 tests. Worth revisiting at ~5+ packages.
- **Adapter-side mocks (e.g., `mockAudioPlayer`) in `@bayaan/test-utils`.** Comes naturally with RFC-004 (audio seam); premature here.

---

Happy to iterate on the matcher API, the CI workflow shape, or the "empty test file" cleanup choice.
