### PR TITLE
docs(rfc): RFC-004 — audio seam (PlayerController port + adapter scaffold)

### DIFF
--- a/docs/rfcs/004-audio-seam.md
+++ b/docs/rfcs/004-audio-seam.md
@@ -1,0 +1,141 @@
+# RFC-004 — Audio seam: `PlayerController` port + adapter scaffold
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Author | Omar Zarka (Qariah) |
+| Date | 2026-05-05 |
+| Depends on | [RFC-001](./001-workspace-and-rfc-convention.md), [RFC-002](./002-bayaan-types-package.md), [RFC-003](./003-ci-gates-and-test-utils.md) |
+| Drives | RFC-005 (audio services refactor + extraction) |
+
+## TL;DR
+
+Ship the `@bayaan/audio` workspace package with **ports only** — the five
+interfaces from ADR-0001 plus a stub `ExpoAudioPlayerControllerAdapter`.
+**No app code changes.** No imports from this package by `services/audio/*`.
+The diff is exclusively under `packages/bayaan-audio/` and a small addition
+to `@bayaan/test-utils` (`MockAudioPlayer` fixture).
+
+This is ADR-0001's PR 2 ("port interfaces + no-op defaults"). The actual
+refactor of `AudioCoordinator`, `ExpoAudioProvider`, and `LockScreenService`
+to consume these ports is RFC-005, deliberately split off so this PR stays
+mergeable on a single bounded review.
+
+## What this PR adds
+
+### `packages/bayaan-audio/`
+
+- `src/ports.ts` — the five interfaces from [ADR-0001](https://github.com/omar-zarka/bayaan-platform/blob/main/adr/0001-audio-extraction-seam.md):
+  - `PlayerController<TTrack>` — state / progress / persistence bridge
+  - `CoordinatorHooks` — replaces the lazy-`require()` smell in `AudioCoordinator`
+  - `PlayerEventSink<TTrack>` — analytics hook (with `NullPlayerEventSink` no-op)
+  - `TimestampProvider` — ayah-timing fetch
+  - `LockScreenMetadataSource` — subscription source for OS lock-screen metadata
+  - `BayaanAudioConfig<TTrack>` — the full consumer config the future provider takes at init
+- `src/adapters/expo-audio-player-controller.ts` — stub class implementing
+  `PlayerController` end-to-end (no-op bodies). Demonstrates the seam compiles
+  and is implementable as a class. Real wiring lands in RFC-005.
+- `src/__tests__/ports.test.ts` — port shape contract: every method exists,
+  every state is accepted without throwing, the `NullPlayerEventSink` is a
+  full no-op, the stub adapter survives the realistic call ordering during
+  playback.
+- `package.json`, `tsconfig.json`, `jest.config.js`, `README.md` — same
+  shape as `@bayaan/types` and `@bayaan/test-utils`. No build step;
+  `main` and `types` both point at `src/index.ts`.
+
+### `packages/bayaan-test-utils/`
+
+- `src/audio/mock-audio-player.ts` — `MockAudioPlayer` test fixture mirroring
+  `expo-audio`'s `AudioPlayer` surface (play / pause / seekTo / replace /
+  setRate / setVolume / addListener) plus deterministic `simulate*` drivers.
+- `src/__tests__/mock-audio-player.test.ts` — 6 tests covering initial state,
+  listener subscription / removal, the natural-end (`didJustFinish`) transition,
+  source replacement, and jest-mock surface.
+- `src/index.ts` — re-export `MockAudioPlayer` and its types.
+
+## What this PR does not do
+
+- **No `services/audio/*` changes.** Provider, coordinator, services all untouched.
+- **No `playerStore` decoupling.** Bidirectional coupling stays; RFC-005 fixes it.
+- **No `expo-audio` import in the package.** `services/audio/*` keeps owning
+  the engine until RFC-005 PR 6 (the move).
+- **No characterization tests for current audio behavior.** ADR-0001's PR 1
+  covers those — they need real-device fidelity for some flows (lock-screen
+  metadata sync, AppState transitions, interruption rate-reset) and are best
+  authored against the running app, not a new package. They land alongside
+  RFC-005's first refactor PR.
+- **No Qariah adoption.** Qariah's `PlayerController` implementation lives
+  in the Qariah repo and lands when RFC-005 ships.
+
+## Why ports-only as its own PR
+
+Three reasons to land the seam before any refactor that consumes it:
+
+1. **Surface review can happen now.** The five interfaces are the contract
+   that drives every subsequent PR in this series (5a–5g per ADR-0001's
+   sequence, possibly more). Catching shape problems at the type-only stage
+   is cheap; catching them mid-refactor is expensive.
+2. **The diff is bounded and reviewable in isolation.** If a later RFC is
+   rejected, this package keeps compiling and harms nothing. Worst case: a
+   small package sits in `packages/` alongside `@bayaan/types` and
+   `@bayaan/test-utils`, no app code depends on it.
+3. **Tidy First.** Mixing the seam definition with the first refactor would
+   bundle "what shape" with "how to migrate to it" in one diff. Each PR
+   should answer one question.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Port too narrow → RFC-005 has to widen mid-refactor. | Hew exactly to the interface drafted and reviewed in `bayaan-platform/scratch/ports.ts`. The `.contract.ts` file there has been the working reference for ~2 weeks. |
+| Port too wide → adapter spans too many call sites in RFC-005. | Every port method maps to a single existing call site in `services/audio/*`. The mapping is documented in ADR-0001 §Decision and verified by the consumer-side stub being a class (not a free-function bag). |
+| Stub adapter sets a bad precedent for "scaffolding without behavior". | The stub is class-based, every method has a `// RFC-005: ...` comment naming the migration that fills it in. The `ports.test.ts` exercises the stub through realistic call ordering so the contract is real, not paper. |
+| `MockAudioPlayer` drifts from `expo-audio`'s actual `AudioPlayer` surface. | The shape is taken from current Bayaan service code that wraps `useAudioPlayer`. Drift becomes visible the moment a real service test is written against it (RFC-005). Acceptable risk given the alternative is hand-mocking the same surface in every test file. |
+
+## Where the adapter lives
+
+ADR-0001 says "package from day one" so the dependency direction is
+established before any consumer adopts. This PR follows that: the stub
+adapter ships in `packages/bayaan-audio/src/adapters/`, not in
+`services/audio/`. **Open question for review:** Osman, does that match
+your preference, or would you rather the stub stay in `services/` until
+RFC-005 fills it in? Easy to redirect.
+
+## Verification plan
+
+| Check | What it shows |
+| --- | --- |
+| `npm install` | Workspace symlinks for `@bayaan/audio` and the updated `@bayaan/test-utils` register cleanly. |
+| `npx jest packages/bayaan-audio` | Port + adapter contract suite passes (~13 tests). |
+| `npx jest packages/bayaan-test-utils` | Existing matchers + new `MockAudioPlayer` tests pass (~15 tests total). |
+| `npm run test:ci` | Full suite still green; no regressions in app-level tests. |
+| `npx tsc --noEmit` | Zero new errors vs `develop` baseline. |
+| Local iOS build (`npm run ios`) | App builds and launches with the new packages present in the workspace. No native footprint added. |
+| Local Android build (`npm run android`) | Same — app builds and launches on emulator. |
+
+A separate build-verification comment will follow with iOS + Android logs
+and timing, posted at PR-open time per the lesson from RFC-003's retro.
+
+## Open questions
+
+1. **Adapter location:** in-package from day one, or stage in `services/`
+   until RFC-005? See "Where the adapter lives" above.
+2. **Should `BayaanAudioConfig.eventSink` be required-explicit or
+   optional-with-default?** This RFC ships it as required (forces the
+   consumer to acknowledge the analytics decision; pass `NullPlayerEventSink`
+   to opt out). Easy to flip.
+3. **Schema version field on `BayaanAudioConfig`?** Bayaan-Architecture
+   §8.3 M10 flagged versioning as a candidate for the diff JSON; same idea
+   could apply here. Probably premature — flagging only.
+
+## Risk if this lands and RFC-005 is rejected
+
+The package contains no app-side imports. If RFC-005 never ships, the only
+consequence is a small workspace package with port interfaces nobody uses,
+sitting alongside `@bayaan/types` and `@bayaan/test-utils`. No code outside
+the package depends on it after this PR.
+
+---
+
+Happy to iterate on the port shapes, the stub adapter location, or the
+required-vs-optional `eventSink` decision.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3433,6 +3433,10 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bayaan/audio": {
+      "resolved": "packages/bayaan-audio",
+      "link": true
+    },
     "node_modules/@bayaan/test-utils": {
       "resolved": "packages/bayaan-test-utils",
       "link": true
@@ -25268,6 +25272,17 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "packages/bayaan-audio": {
+      "name": "@bayaan/audio",
+      "version": "0.1.0",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@bayaan/types": "*"
+      },
+      "devDependencies": {
+        "@bayaan/test-utils": "*"
       }
     },
     "packages/bayaan-test-utils": {

--- a/packages/bayaan-audio/README.md
+++ b/packages/bayaan-audio/README.md
@@ -1,0 +1,67 @@
+# @bayaan/audio
+
+The audio playback layer for the Bayaan platform. Owns the service singletons
+and the React provider; consumers own all state.
+
+## Status
+
+**RFC-004 (this PR):** Port interfaces only. The package is workspace-only and
+contains no app code yet — services still live in Bayaan's `services/audio/*`.
+
+**RFC-005 (queued):** Refactor of `services/audio/*` to consume these ports
+in-place, then a mechanical move into this package. See [ADR-0001](../../docs/rfcs/004-audio-seam.md)
+and the [extraction plan](https://github.com/omar-zarka/bayaan-platform/blob/main/planning/Bayaan-Extraction-Plan.md)
+for the full sequence.
+
+## What this package exposes today
+
+```ts
+import {
+  // Ports — five interfaces a consumer implements when integrating.
+  type PlayerController,
+  type CoordinatorHooks,
+  type PlayerEventSink,
+  type TimestampProvider,
+  type LockScreenMetadataSource,
+  type BayaanAudioConfig,
+  type Unsubscribe,
+
+  // No-op analytics sink for consumers that opt out.
+  NullPlayerEventSink,
+
+  // Stub adapter — fully wired in RFC-005.
+  ExpoAudioPlayerControllerAdapter,
+} from '@bayaan/audio';
+```
+
+## Design invariants
+
+- **Flow is one-directional:** package → port → consumer. Ports never call back
+  into package services.
+- **Every port method is sync void or returns a Promise.** No hidden state.
+- **The package does not know the consumer's store exists.** No imports of
+  `usePlayerStore`, `useMushafPlayerStore`, or any consumer-side state model.
+- **Repeat / queue / shuffle logic is consumer-side.** The package fires
+  `onTrackEnded(track)`; the consumer decides what happens next.
+
+## Why ports-and-adapters
+
+The audio layer in Bayaan today has bidirectional coupling between
+`ExpoAudioProvider` and `playerStore`, plus a circular dep between
+`AudioCoordinator` and `mushafPlayerStore` patched with a lazy `require()`.
+Neither can be moved into a reusable package without inverting that direction.
+ADR-0001 details the alternatives considered and why the hexagonal split won.
+
+## Testing
+
+```sh
+npx jest packages/bayaan-audio
+```
+
+The package's tests use jest matchers and the `MockAudioPlayer` fixture from
+`@bayaan/test-utils`. Once RFC-005 lands, the same fixture will drive the
+service-layer state-machine tests.
+
+## License
+
+AGPL-3.0-or-later (matches the parent repo).

--- a/packages/bayaan-audio/jest.config.js
+++ b/packages/bayaan-audio/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'jest-expo',
+  testMatch: ['<rootDir>/src/**/__tests__/**/*.test.ts'],
+};

--- a/packages/bayaan-audio/package.json
+++ b/packages/bayaan-audio/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@bayaan/audio",
+  "version": "0.1.0",
+  "description": "Audio playback ports and adapters for the Bayaan platform.",
+  "license": "AGPL-3.0-or-later",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "sideEffects": false,
+  "scripts": {
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@bayaan/types": "*"
+  },
+  "devDependencies": {
+    "@bayaan/test-utils": "*"
+  }
+}

--- a/packages/bayaan-audio/src/__tests__/ports.test.ts
+++ b/packages/bayaan-audio/src/__tests__/ports.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Port shape and no-op default tests.
+ *
+ * These tests assert the seam itself — that the ports compile, that the
+ * NullPlayerEventSink no-op implements the full surface, and that the
+ * stub adapter satisfies the PlayerController contract.
+ *
+ * Behavior tests for real implementations live in their owning packages
+ * (consumer-side: Bayaan's playerStore-backed controller in app code).
+ */
+
+import type {BaseTrack, PlaybackState} from '@bayaan/types';
+
+import type {
+  CoordinatorHooks,
+  LockScreenMetadataSource,
+  PlayerController,
+  PlayerEventSink,
+  TimestampProvider,
+} from '../ports';
+import {NullPlayerEventSink} from '../ports';
+import {ExpoAudioPlayerControllerAdapter} from '../adapters/expo-audio-player-controller';
+
+const sampleTrack: BaseTrack = {
+  id: 'track-1',
+  url: 'https://example.invalid/audio.mp3',
+  title: 'Sample',
+  artist: 'Artist',
+  durationMs: 60_000,
+};
+
+describe('NullPlayerEventSink', () => {
+  it('implements every PlayerEventSink method as a no-op', () => {
+    expect(() => NullPlayerEventSink.onPlaybackStarted(sampleTrack)).not.toThrow();
+    expect(() => NullPlayerEventSink.onPlaybackCompleted(sampleTrack, 30_000)).not.toThrow();
+    expect(() => NullPlayerEventSink.onPlaybackPaused(sampleTrack, 15_000)).not.toThrow();
+    expect(() => NullPlayerEventSink.onSkip(sampleTrack, 'forward')).not.toThrow();
+    expect(() => NullPlayerEventSink.onSkip(sampleTrack, 'backward')).not.toThrow();
+    expect(() => NullPlayerEventSink.onRateChange(1, 1.5)).not.toThrow();
+    expect(() => NullPlayerEventSink.onSeek(sampleTrack, 1000, 5000)).not.toThrow();
+    expect(() => NullPlayerEventSink.onError(new Error('x'), {})).not.toThrow();
+  });
+});
+
+describe('ExpoAudioPlayerControllerAdapter — PlayerController contract', () => {
+  let controller: PlayerController<BaseTrack>;
+
+  beforeEach(() => {
+    controller = new ExpoAudioPlayerControllerAdapter<BaseTrack>();
+  });
+
+  it('exposes every required method', () => {
+    expect(typeof controller.onPlaybackStateChange).toBe('function');
+    expect(typeof controller.onProgressUpdate).toBe('function');
+    expect(typeof controller.onTrackChanged).toBe('function');
+    expect(typeof controller.onTrackEnded).toBe('function');
+    expect(typeof controller.onError).toBe('function');
+    expect(typeof controller.onProgressPersist).toBe('function');
+  });
+
+  const states: PlaybackState[] = [
+    'idle',
+    'loading',
+    'ready',
+    'playing',
+    'paused',
+    'error',
+  ];
+
+  it.each(states)('accepts state %s without throwing', (state) => {
+    expect(() => controller.onPlaybackStateChange(state)).not.toThrow();
+  });
+
+  it('accepts progress updates across the duration range and edge cases', () => {
+    expect(() => controller.onProgressUpdate(0, 60_000)).not.toThrow();
+    expect(() => controller.onProgressUpdate(30_000, 60_000)).not.toThrow();
+    expect(() => controller.onProgressUpdate(60_000, 60_000)).not.toThrow();
+    expect(() => controller.onProgressUpdate(-100, 60_000)).not.toThrow();
+    expect(() => controller.onProgressUpdate(70_000, 60_000)).not.toThrow();
+    expect(() => controller.onProgressUpdate(0, 0)).not.toThrow();
+  });
+
+  it('accepts track-changed with track and with null', () => {
+    expect(() => controller.onTrackChanged(sampleTrack)).not.toThrow();
+    expect(() => controller.onTrackChanged(null)).not.toThrow();
+  });
+
+  it('accepts track-ended', () => {
+    expect(() => controller.onTrackEnded(sampleTrack)).not.toThrow();
+  });
+
+  it('accepts error with and without context', () => {
+    expect(() => controller.onError(new Error('boom'), {source: 'test'})).not.toThrow();
+    expect(() => controller.onError(new Error('boom'), {})).not.toThrow();
+  });
+
+  it('accepts progress persist at boundaries', () => {
+    expect(() => controller.onProgressPersist(sampleTrack, 0, 60_000)).not.toThrow();
+    expect(() => controller.onProgressPersist(sampleTrack, 60_000, 60_000)).not.toThrow();
+  });
+
+  it('survives the realistic call ordering during playback', () => {
+    expect(() => {
+      controller.onTrackChanged(sampleTrack);
+      controller.onPlaybackStateChange('loading');
+      controller.onPlaybackStateChange('ready');
+      controller.onPlaybackStateChange('playing');
+      for (let i = 0; i < 10; i++) {
+        controller.onProgressUpdate(i * 1000, 60_000);
+      }
+      controller.onProgressPersist(sampleTrack, 10_000, 60_000);
+      controller.onProgressUpdate(60_000, 60_000);
+      controller.onTrackEnded(sampleTrack);
+      controller.onPlaybackStateChange('paused');
+      controller.onTrackChanged(null);
+    }).not.toThrow();
+  });
+});
+
+describe('Type-shape compile checks', () => {
+  // These exist purely to assert that the public types are referenceable.
+  // If an interface drifts, this file fails to compile — which is the test.
+  it('CoordinatorHooks shape', () => {
+    const hooks: CoordinatorHooks = {
+      pauseMain: () => {},
+      pauseMushaf: () => {},
+      getMainIsPlaying: () => false,
+      getMushafIsPlaying: () => false,
+    };
+    expect(hooks.getMainIsPlaying()).toBe(false);
+  });
+
+  it('TimestampProvider shape', async () => {
+    const provider: TimestampProvider = {
+      fetchTimestamps: async () => [],
+    };
+    await expect(provider.fetchTimestamps('any-key')).resolves.toEqual([]);
+  });
+
+  it('LockScreenMetadataSource shape', () => {
+    const source: LockScreenMetadataSource = {
+      subscribeMain: () => () => {},
+      subscribeMushaf: () => () => {},
+    };
+    const unsubscribe = source.subscribeMain(() => {});
+    expect(typeof unsubscribe).toBe('function');
+    unsubscribe();
+  });
+
+  it('PlayerEventSink shape can be implemented generically', () => {
+    type ConsumerTrack = BaseTrack & {meta: {surahId: number}};
+    const sink: PlayerEventSink<ConsumerTrack> = {
+      onPlaybackStarted: (t) => expect(t.meta.surahId).toBeGreaterThan(0),
+      onPlaybackCompleted: () => {},
+      onPlaybackPaused: () => {},
+      onSkip: () => {},
+      onRateChange: () => {},
+      onSeek: () => {},
+      onError: () => {},
+    };
+    sink.onPlaybackStarted({...sampleTrack, meta: {surahId: 1}});
+  });
+});

--- a/packages/bayaan-audio/src/adapters/expo-audio-player-controller.ts
+++ b/packages/bayaan-audio/src/adapters/expo-audio-player-controller.ts
@@ -1,0 +1,65 @@
+/**
+ * ExpoAudioPlayerControllerAdapter — stub adapter for the PlayerController port.
+ *
+ * THIS IS A SCAFFOLD. RFC-004 ships only the seam (port interfaces) plus
+ * this stub so the package compiles end-to-end and the shape is reviewable
+ * in advance. The real wiring of expo-audio's `AudioPlayer` happens in
+ * RFC-005's audio-services-refactor PRs (PRs 3–6 in ADR-0001's table).
+ *
+ * Why ship a stub now rather than waiting:
+ *  - Demonstrates that the port is implementable as a class wrapping a
+ *    consumer store (Bayaan's `playerStore`) — which is what ADR-0001
+ *    promises for the migration.
+ *  - Lets the package self-contain its tests (the contract suite and the
+ *    `MockAudioPlayer`-driven test both reference this class).
+ *  - Surfaces type-shape problems with the port at review time, not at
+ *    integration time.
+ *
+ * Why no expo-audio coupling yet:
+ *  - The package does not import from `expo-audio` until the move PR
+ *    (ADR-0001 PR 6). Pre-extraction, the audio engine still lives in
+ *    `services/audio/*`. Importing expo-audio here would invert the
+ *    dependency direction the RFC sequence is establishing.
+ */
+
+import type {BaseTrack, PlaybackState} from '@bayaan/types';
+
+import type {PlayerController} from '../ports';
+
+/**
+ * Reference implementation of `PlayerController<TTrack>` against the future
+ * `BayaanAudioProvider`. Behavior is intentionally minimal — every callback
+ * is a no-op the consumer overrides via subclass or composition. The full
+ * implementation arrives with RFC-005.
+ */
+export class ExpoAudioPlayerControllerAdapter<TTrack extends BaseTrack = BaseTrack>
+  implements PlayerController<TTrack>
+{
+  onPlaybackStateChange(_state: PlaybackState): void {
+    // RFC-005: forward state to consumer store.
+  }
+
+  onProgressUpdate(_positionMs: number, _durationMs: number): void {
+    // RFC-005: throttle and forward to consumer store.
+  }
+
+  onTrackChanged(_track: TTrack | null): void {
+    // RFC-005: update consumer's current-track field.
+  }
+
+  onTrackEnded(_track: TTrack): void {
+    // RFC-005: signal consumer; consumer decides repeat / advance / stop.
+  }
+
+  onError(_error: Error, _context: Record<string, unknown>): void {
+    // RFC-005: surface to consumer + analytics sink.
+  }
+
+  onProgressPersist(
+    _track: TTrack,
+    _positionMs: number,
+    _durationMs: number,
+  ): void {
+    // RFC-005: low-cadence persist hook.
+  }
+}

--- a/packages/bayaan-audio/src/index.ts
+++ b/packages/bayaan-audio/src/index.ts
@@ -1,0 +1,14 @@
+// Ports (ADR-0001 — the seam @bayaan/audio exposes to consumers)
+export type {
+  BayaanAudioConfig,
+  CoordinatorHooks,
+  LockScreenMetadataSource,
+  PlayerController,
+  PlayerEventSink,
+  TimestampProvider,
+  Unsubscribe,
+} from './ports';
+export {NullPlayerEventSink} from './ports';
+
+// Adapters (stub today — fully wired in RFC-005)
+export {ExpoAudioPlayerControllerAdapter} from './adapters/expo-audio-player-controller';

--- a/packages/bayaan-audio/src/ports.ts
+++ b/packages/bayaan-audio/src/ports.ts
@@ -1,0 +1,187 @@
+/**
+ * @bayaan/audio ports
+ *
+ * The five interfaces a consumer implements when integrating @bayaan/audio.
+ * Defined in ADR-0001. The package calls into ports; ports never call back
+ * into the package. Flow is one-directional: package → port → consumer.
+ *
+ * Every method is either sync void or returns a Promise. No hidden state.
+ */
+
+import type {
+  AyahTimestamp,
+  BaseTrack,
+  LockScreenMetadata,
+  PlaybackState,
+} from '@bayaan/types';
+
+// ============================================================
+// PlayerController — state + progress + persistence bridge
+// ============================================================
+
+/**
+ * Bridges @bayaan/audio's playback events into the consumer's state model
+ * (Zustand, Redux, signals, anything). Replaces today's bidirectional
+ * coupling between ExpoAudioProvider and playerStore (ADR-0001 §Context.1).
+ *
+ * The package fires events; the consumer decides what to persist, render,
+ * or ignore. Repeat / queue / shuffle logic stays consumer-side — see the
+ * onTrackEnded note below.
+ */
+export interface PlayerController<TTrack extends BaseTrack = BaseTrack> {
+  /** Fired when the underlying AudioPlayer's playback state changes. */
+  onPlaybackStateChange(state: PlaybackState): void;
+
+  /**
+   * Fired on a throttled interval during playback (typically ~500ms).
+   * Consumer decides whether to persist, update UI, or both.
+   */
+  onProgressUpdate(positionMs: number, durationMs: number): void;
+
+  /** Fired when a new track is loaded or the current track is cleared. */
+  onTrackChanged(track: TTrack | null): void;
+
+  /**
+   * Fired when the current track reaches its natural end (the package's
+   * equivalent of expo-audio's `didJustFinish`). The consumer decides what
+   * happens next — repeat, advance, or stop. The package does not make
+   * this decision: repeat modes, queue advance, and shuffle are consumer
+   * concerns (see Bayaan's playerStore and Qariah's queueRecitations).
+   *
+   * Ordering note: after didJustFinish fires, the native player's
+   * currentItem is nil; seekTo(0) + play() on the same source is a no-op.
+   * Consumers that want to repeat must reload the source.
+   */
+  onTrackEnded(track: TTrack): void;
+
+  /** Fired on any playback error. Consumer decides retry policy. */
+  onError(error: Error, context: Record<string, unknown>): void;
+
+  /**
+   * Called by the provider on a lower-frequency cadence (e.g. every 10s,
+   * on pause, on track change) so the consumer can persist progress.
+   * Consumer implements the actual write (AsyncStorage, MMKV, SQLite,
+   * network).
+   *
+   * `durationMs` is included so consumers can compute completion percent
+   * without cross-referencing the current-track state.
+   */
+  onProgressPersist(track: TTrack, positionMs: number, durationMs: number): void;
+}
+
+// ============================================================
+// CoordinatorHooks — how AudioCoordinator pauses consumer-owned players
+// ============================================================
+
+/**
+ * Replaces the lazy `require()` in AudioCoordinator (Bayaan-Architecture
+ * §3.1) that breaks the circular dep between AudioCoordinator ↔
+ * mushafPlayerStore ↔ MushafAudioService.
+ *
+ * Consumer wires this at app startup. AudioCoordinator never imports a
+ * consumer store directly.
+ */
+export interface CoordinatorHooks {
+  pauseMain(): void;
+  pauseMushaf(): void;
+  getMainIsPlaying(): boolean;
+  getMushafIsPlaying(): boolean;
+}
+
+// ============================================================
+// PlayerEventSink — analytics hook
+// ============================================================
+
+/**
+ * Routes analytics events. Generic in TTrack so the sink receives the same
+ * track shape the PlayerController sees, letting consumers read consumer-
+ * specific metadata (surahId, reciterId, rewayahId) directly from the
+ * track without the package caring.
+ *
+ * Lifecycle-computed fields (listenedMs, completion %) are passed as
+ * explicit arguments by the package; domain fields live on the track.
+ */
+export interface PlayerEventSink<TTrack extends BaseTrack = BaseTrack> {
+  onPlaybackStarted(track: TTrack): void;
+  onPlaybackCompleted(track: TTrack, listenedMs: number): void;
+  onPlaybackPaused(track: TTrack, positionMs: number): void;
+  onSkip(track: TTrack, direction: 'forward' | 'backward'): void;
+  onRateChange(oldRate: number, newRate: number): void;
+  onSeek(track: TTrack, fromPositionMs: number, toPositionMs: number): void;
+  onError(error: Error, context: Record<string, unknown>): void;
+}
+
+/**
+ * Ready-made no-op sink for consumers that don't want analytics. Required
+ * to be passed explicitly (rather than implicit-default) so consumers
+ * acknowledge the analytics decision at wire-up time. See ADR-0001 §Decision.6.
+ */
+export const NullPlayerEventSink: PlayerEventSink<BaseTrack> = {
+  onPlaybackStarted: () => {},
+  onPlaybackCompleted: () => {},
+  onPlaybackPaused: () => {},
+  onSkip: () => {},
+  onRateChange: () => {},
+  onSeek: () => {},
+  onError: () => {},
+};
+
+// ============================================================
+// TimestampProvider — consumer-owned ayah timing data
+// ============================================================
+
+/**
+ * The package consumes a Promise; data origin is opaque (Bayaan hosts its
+ * own DB; Qariah uses per-recitation timestamps from its backend).
+ *
+ * Keyed by recitation, not by reciter — both consumers have cases where a
+ * single reciter has multiple recitations of the same surah, so
+ * (surahId, reciterId) under-identifies. `recitationKey` is consumer-
+ * opaque: pass whatever string uniquely identifies the recitation in your
+ * data model.
+ */
+export interface TimestampProvider {
+  fetchTimestamps(recitationKey: string): Promise<AyahTimestamp[]>;
+}
+
+// ============================================================
+// LockScreenMetadataSource — subscription-based lock screen feed
+// ============================================================
+
+/**
+ * LockScreenService today calls `usePlayerStore.subscribe()` and
+ * `useMushafPlayerStore.subscribe()` directly — that's the coupling this
+ * port removes.
+ *
+ * Listener is called with `null` when the source should be cleared (on
+ * stop, or when mushaf takes over from main player).
+ */
+export interface LockScreenMetadataSource {
+  subscribeMain(listener: (metadata: LockScreenMetadata | null) => void): Unsubscribe;
+  subscribeMushaf(listener: (metadata: LockScreenMetadata | null) => void): Unsubscribe;
+}
+
+export type Unsubscribe = () => void;
+
+// ============================================================
+// BayaanAudioConfig — the full consumer config the package takes at init
+// ============================================================
+
+/**
+ * Passed to the (future) `BayaanAudioProvider` once RFC-004's later
+ * extraction PRs land. Surfaced here so consumer apps can prepare their
+ * wire-up shape ahead of the migration.
+ */
+export interface BayaanAudioConfig<TTrack extends BaseTrack = BaseTrack> {
+  controller: PlayerController<TTrack>;
+  coordinator: CoordinatorHooks;
+  /**
+   * Required (not optional). Pass `NullPlayerEventSink` to opt out of
+   * analytics explicitly.
+   */
+  eventSink: PlayerEventSink<TTrack>;
+  /** Required only if mushaf audio is used. */
+  timestamps?: TimestampProvider;
+  /** Required only if lock-screen controls are wanted. */
+  lockScreen?: LockScreenMetadataSource;
+}

--- a/packages/bayaan-audio/tsconfig.json
+++ b/packages/bayaan-audio/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/bayaan-test-utils/src/__tests__/mock-audio-player.test.ts
+++ b/packages/bayaan-test-utils/src/__tests__/mock-audio-player.test.ts
@@ -1,0 +1,83 @@
+import {MockAudioPlayer, type PlaybackStatus} from '../audio/mock-audio-player';
+
+describe('MockAudioPlayer', () => {
+  let player: MockAudioPlayer;
+
+  beforeEach(() => {
+    player = new MockAudioPlayer();
+  });
+
+  it('starts in an empty unloaded state', () => {
+    const status = player.getStatus();
+    expect(status.isLoaded).toBe(false);
+    expect(status.isPlaying).toBe(false);
+    expect(status.positionMillis).toBe(0);
+    expect(status.durationMillis).toBeNull();
+    expect(status.didJustFinish).toBe(false);
+  });
+
+  it('emits status updates to subscribed listeners', () => {
+    const updates: PlaybackStatus[] = [];
+    player.addListener('playbackStatusUpdate', (s) => updates.push(s));
+    player.simulateLoaded({durationMillis: 30_000});
+    player.play();
+    player.simulatePlaybackProgress(5_000);
+
+    expect(updates.length).toBe(3);
+    expect(updates[0].isLoaded).toBe(true);
+    expect(updates[1].isPlaying).toBe(true);
+    expect(updates[2].positionMillis).toBe(5_000);
+  });
+
+  it('removes listeners via the returned subscription', () => {
+    const updates: PlaybackStatus[] = [];
+    const subscription = player.addListener('playbackStatusUpdate', (s) =>
+      updates.push(s),
+    );
+    player.simulateLoaded({durationMillis: 1000});
+    expect(updates).toHaveLength(1);
+
+    subscription.remove();
+    player.simulatePlaybackProgress(500);
+    expect(updates).toHaveLength(1);
+  });
+
+  it('models the natural-end transition with didJustFinish=true', () => {
+    player.simulateLoaded({durationMillis: 10_000});
+    player.play();
+    player.simulateEnded();
+
+    const status = player.getStatus();
+    expect(status.didJustFinish).toBe(true);
+    expect(status.isPlaying).toBe(false);
+    expect(status.positionMillis).toBe(10_000);
+  });
+
+  it('clears state when the source is replaced', async () => {
+    player.simulateLoaded({durationMillis: 30_000});
+    player.play();
+    player.simulatePlaybackProgress(15_000);
+
+    await player.replace({uri: 'https://example.invalid/next.mp3'});
+
+    const status = player.getStatus();
+    expect(status.isLoaded).toBe(false);
+    expect(status.isPlaying).toBe(false);
+    expect(status.positionMillis).toBe(0);
+    expect(status.durationMillis).toBeNull();
+  });
+
+  it('records calls on its surface as jest mocks', () => {
+    player.play();
+    player.pause();
+    player.seekTo(1234);
+    player.setRate(1.5);
+    player.setVolume(0.7);
+
+    expect(player.play).toHaveBeenCalledTimes(1);
+    expect(player.pause).toHaveBeenCalledTimes(1);
+    expect(player.seekTo).toHaveBeenCalledWith(1234);
+    expect(player.setRate).toHaveBeenCalledWith(1.5);
+    expect(player.setVolume).toHaveBeenCalledWith(0.7);
+  });
+});

--- a/packages/bayaan-test-utils/src/audio/mock-audio-player.ts
+++ b/packages/bayaan-test-utils/src/audio/mock-audio-player.ts
@@ -1,0 +1,127 @@
+/**
+ * MockAudioPlayer — drop-in stand-in for expo-audio's AudioPlayer in jest tests.
+ *
+ * expo-audio's real AudioPlayer is bridged to native code and not directly
+ * testable in jest. This double exposes the same surface (play / pause /
+ * seekTo / replace / setRate / setVolume / addListener) plus deterministic
+ * `simulate*` drivers so tests can step through the playback state machine.
+ *
+ * Lives in @bayaan/test-utils so RFC-005's `@bayaan/audio` services tests
+ * can share it without re-importing from app code. The adapter test in
+ * @bayaan/audio uses it today; once the audio services move into the
+ * package (RFC-005 PR 6), every service test reuses this same fixture.
+ */
+
+export type StatusListener = (status: PlaybackStatus) => void;
+
+export interface PlaybackStatus {
+  isLoaded: boolean;
+  isPlaying: boolean;
+  positionMillis: number;
+  durationMillis: number | null;
+  didJustFinish: boolean;
+  rate: number;
+  volume: number;
+}
+
+const EMPTY_STATUS: PlaybackStatus = {
+  isLoaded: false,
+  isPlaying: false,
+  positionMillis: 0,
+  durationMillis: null,
+  didJustFinish: false,
+  rate: 1,
+  volume: 1,
+};
+
+/**
+ * Usage:
+ *   const player = new MockAudioPlayer();
+ *   service.setPlayer(player);
+ *   player.simulateLoaded({durationMillis: 30_000});
+ *   player.simulatePlaybackProgress(5_000);
+ *   player.simulateEnded();
+ */
+export class MockAudioPlayer {
+  private status: PlaybackStatus = {...EMPTY_STATUS};
+  private listeners: Set<StatusListener> = new Set();
+
+  // ----- Surface mirroring expo-audio's AudioPlayer -----
+
+  play = jest.fn(() => {
+    this.status = {...this.status, isPlaying: true};
+    this.emit();
+  });
+
+  pause = jest.fn(() => {
+    this.status = {...this.status, isPlaying: false};
+    this.emit();
+  });
+
+  seekTo = jest.fn((positionMillis: number) => {
+    this.status = {...this.status, positionMillis};
+    this.emit();
+  });
+
+  replace = jest.fn(async (_source: {uri: string}) => {
+    this.status = {...EMPTY_STATUS};
+    this.emit();
+  });
+
+  setRate = jest.fn((rate: number) => {
+    this.status = {...this.status, rate};
+    this.emit();
+  });
+
+  setVolume = jest.fn((volume: number) => {
+    this.status = {...this.status, volume};
+    this.emit();
+  });
+
+  addListener = jest.fn(
+    (_event: 'playbackStatusUpdate', listener: StatusListener) => {
+      this.listeners.add(listener);
+      return {remove: () => this.listeners.delete(listener)};
+    },
+  );
+
+  // ----- Test-only drivers -----
+
+  simulateLoaded(opts: {durationMillis: number}) {
+    this.status = {
+      ...this.status,
+      isLoaded: true,
+      durationMillis: opts.durationMillis,
+    };
+    this.emit();
+  }
+
+  simulatePlaybackProgress(positionMillis: number) {
+    this.status = {...this.status, positionMillis};
+    this.emit();
+  }
+
+  simulateEnded() {
+    this.status = {
+      ...this.status,
+      isPlaying: false,
+      didJustFinish: true,
+      positionMillis: this.status.durationMillis ?? 0,
+    };
+    this.emit();
+  }
+
+  simulateError() {
+    this.status = {...this.status, isLoaded: false, isPlaying: false};
+    this.emit();
+  }
+
+  /** Exposed for assertions in tests. */
+  getStatus(): PlaybackStatus {
+    return {...this.status};
+  }
+
+  private emit() {
+    for (const l of this.listeners) l(this.status);
+  }
+}

--- a/packages/bayaan-test-utils/src/index.ts
+++ b/packages/bayaan-test-utils/src/index.ts
@@ -1,1 +1,3 @@
 export {bayaanErrorMatchers, registerBayaanMatchers} from './error-matchers';
+export {MockAudioPlayer} from './audio/mock-audio-player';
+export type {PlaybackStatus, StatusListener} from './audio/mock-audio-player';


### PR DESCRIPTION
## What this PR is

The fourth in the RFC series and the first to introduce a feature package. Lands ADR-0001's audio seam — five port interfaces plus a stub adapter — as a new `@bayaan/audio` workspace package. **No app code changes.** Services in `services/audio/*` are untouched; this PR sits alongside them.

The actual refactor of `AudioCoordinator`, `ExpoAudioProvider`, and `LockScreenService` to consume these ports is RFC-005, deliberately split off so this PR is reviewable in isolation.

Full RFC: [`docs/rfcs/004-audio-seam.md`](docs/rfcs/004-audio-seam.md). ADR-0001 (the design rationale) lives in the planning repo at [`adr/0001-audio-extraction-seam.md`](https://github.com/omar-zarka/bayaan-platform/blob/main/adr/0001-audio-extraction-seam.md).

## What it adds

### `packages/bayaan-audio/` — new workspace package

- `src/ports.ts` — five port interfaces:
  - `PlayerController<TTrack>` — state / progress / persistence bridge (replaces today's bidirectional `ExpoAudioProvider ↔ playerStore` coupling)
  - `CoordinatorHooks` — replaces the lazy-`require()` smell in `AudioCoordinator`
  - `PlayerEventSink<TTrack>` — analytics hook, with `NullPlayerEventSink` no-op default
  - `TimestampProvider` — ayah-timing fetch
  - `LockScreenMetadataSource` — subscription source for OS lock-screen metadata
  - `BayaanAudioConfig<TTrack>` — the consumer config the future provider takes at init
- `src/adapters/expo-audio-player-controller.ts` — stub `PlayerController` class (no-op bodies; every method has a `// RFC-005: ...` comment naming the migration that fills it in)
- `src/__tests__/ports.test.ts` — 18 tests covering port shape, the `NullPlayerEventSink` no-op, and realistic call ordering through the stub adapter

### `packages/bayaan-test-utils/` — additive

- `src/audio/mock-audio-player.ts` — `MockAudioPlayer` fixture mirroring `expo-audio`'s `AudioPlayer` surface plus deterministic `simulate*` drivers. Used by the adapter tests today; reusable in RFC-005's service-layer tests.
- 6 new tests for the fixture itself.
- `src/index.ts` re-exports `MockAudioPlayer` and its types.

### `package-lock.json`

Workspace symlinks registered at `node_modules/@bayaan/audio -> packages/bayaan-audio` and updated for the test-utils additions.

## What it does not do

- **No `services/audio/*` changes.** Provider, coordinator, services all untouched.
- **No `playerStore` decoupling.** Bidirectional coupling stays; RFC-005 fixes it.
- **No `expo-audio` import in the package.** `services/audio/*` keeps owning the engine until RFC-005 PR 6 (the move).
- **No characterization tests for current audio behavior.** ADR-0001's PR 1 covers those — they need real-device fidelity for some flows (lock-screen metadata sync, AppState transitions, interruption rate-reset) and are best authored against the running app, not a new package. They land alongside RFC-005's first refactor PR.
- **No Qariah adoption.** Qariah's `PlayerController` implementation lives in the Qariah repo and lands when RFC-005 ships.

## Verification

| Check | Result |
| --- | --- |
| `npm install` | Workspace symlink created at `node_modules/@bayaan/audio -> packages/bayaan-audio` |
| `npx jest packages/bayaan-audio packages/bayaan-test-utils` | **33/33 pass in ~0.9s** |
| `npm run test:ci` (full suite) | **8 suites, 77 tests pass in ~1.5s, 0 failures** (53 pre-existing + 18 new ports + 6 new MockAudioPlayer) |
| `npx tsc --noEmit` | **Zero new errors** vs `develop` baseline |
| Local iOS + Android builds | _Verification comment to follow with logs and timing._ |

## One bounded decision called out for review

**Where the stub adapter lives.** ADR-0001 says "package from day one" so the dependency direction is established before any consumer adopts. This PR follows that: the stub lives at `packages/bayaan-audio/src/adapters/expo-audio-player-controller.ts`. Two alternatives if you'd prefer either:

- **(a)** Keep it in-package — what this PR currently does.
- **(b)** Stage in `services/` until RFC-005 fills it in. Trade-off: dependency direction stays unenforced for one extra RFC cycle, but the migration story is "in-place refactor" rather than "match the new shape".
- **(c)** Drop the stub entirely and ship ports-only. Trade-off: package no longer has anything class-based to test against; contract tests would be type-only.

I think (a) is right but happy to redirect.

## Why this is its own PR

Three reasons to land the seam before any refactor that consumes it:

1. **Surface review can happen now.** The five interfaces are the contract that drives every subsequent PR in the audio extraction series. Catching shape problems at the type-only stage is cheap; catching them mid-refactor is expensive.
2. **The diff is bounded and reviewable in isolation.** If a later RFC is rejected, this package keeps compiling and harms nothing.
3. **Tidy First.** Mixing the seam definition with the first refactor would bundle "what shape" with "how to migrate to it" in one diff. Each PR should answer one question.

## Risk if this lands and RFC-005 is rejected

The package contains no app-side imports. If RFC-005 never ships, the only consequence is a small workspace package with port interfaces nobody uses, sitting alongside `@bayaan/types` and `@bayaan/test-utils`. No code outside the package depends on it after this PR.

## Open questions called out in the RFC

- **Adapter location** (a/b/c above).
- **Should `BayaanAudioConfig.eventSink` be required-explicit or optional-with-default?** This RFC ships it as required (forces the consumer to acknowledge the analytics decision; pass `NullPlayerEventSink` to opt out). Easy to flip.
- **Schema version field on `BayaanAudioConfig`?** Probably premature — flagging only.

---

Happy to iterate on the port shapes, the stub adapter location, or the required-vs-optional `eventSink` decision.