### PR TITLE
test(audio): RFC-005 — characterization tests for ExpoAudioService (Group A)

### DIFF
--- a/docs/rfcs/005-audio-characterization-tests.md
+++ b/docs/rfcs/005-audio-characterization-tests.md
@@ -1,0 +1,75 @@
+# RFC-005 — Audio characterization tests
+
+| Status | Open |
+| --- | --- |
+| Author | omar-zarka |
+| Created | 2026-05-06 |
+| Series | Audio extraction (ADR-0001) |
+
+## Summary
+
+Land the test harness and Group A characterization tests for the audio services. **No production code changes.** This is "PR #1" of the audio extraction series in ADR-0001 — characterization tests come before any refactor so subsequent refactor PRs can prove behavior parity with `npm test`.
+
+This PR ships:
+- `docs/rfcs/005-audio-characterization-tests.md` (this file).
+- `services/audio/__tests__/ExpoAudioService.test.ts` — 9 tests covering Group A from the bayaan-platform [Characterization Test Plan](https://github.com/omar-zarka/bayaan-platform/blob/main/planning/Characterization-Test-Plan.md), exercising `ExpoAudioService`'s state machine: initialization idempotence, player set/replace, `loadTrack` happy path + error, play/pause/seek transitions, rate changes, listener subscribe/unsubscribe.
+
+## Why characterization tests now
+
+The audio extraction (ADR-0001) plans 8 PRs that culminate in `services/audio/` moving into `@bayaan/audio`. PRs 2–8 mutate `AudioCoordinator`, `ExpoAudioProvider`, and `LockScreenService` to consume the `PlayerController` port that landed in [#236](https://github.com/thebayaan/Bayaan/pull/236). Without behavior-locking tests, every refactor reviewer is on the hook for "does this preserve subtle behavior?" — which neither scales nor sleeps well at night.
+
+Per ADR-0001 §"Sequencing": **PR #1 = characterization tests. PRs #2–8 = refactors that keep the tests green.** Bayaan currently has zero tests on `services/audio/`, `services/mushaf/`, `services/player/`. This PR seeds that test surface for audio specifically.
+
+## A note on RFC numbering
+
+PR #236 (RFC-004) said "the actual refactor of `AudioCoordinator`, `ExpoAudioProvider`, and `LockScreenService` to consume these ports is RFC-005." Per ADR-0001, characterization tests must precede that refactor. Re-numbering: **RFC-005 = characterization tests (this PR), RFC-006 = the AudioCoordinator/ExpoAudioProvider/LockScreenService refactor RFC-004's body called RFC-005.** Same content, sequencing preserved, one extra precondition PR.
+
+## What's in scope (this PR)
+
+**Group A — `ExpoAudioService` state machine** (9 tests). All tests use a local `FakeAudioPlayer` that mirrors the slice of `expo-audio`'s `AudioPlayer` surface that `ExpoAudioService.ts` actually consumes. The fake stays per-test for now; if subsequent groups (B–I) re-use it, it gets promoted into `@bayaan/test-utils`.
+
+| ID | Behavior |
+| --- | --- |
+| A1 | `initialize()` is idempotent — second call is a no-op. |
+| A2 | `setPlayer()` accepts the hook output once; second call replaces. |
+| A3 | `loadTrack(url)` happy path → state machine `idle → loading → ready`. |
+| A4 | `loadTrack(url)` error path → state `error`, `lastError` set, listeners notified. |
+| A5 | `play()` from `ready` → `playing`; `pause()` from `playing` → `paused`. |
+| A6 | `seekTo(seconds)` calls `player.seekTo` and does NOT change playback state. |
+| A7 | `setRate(rate)` clamps to [0.5, 2.0] and calls `player.setPlaybackRate(rate, 'high')`. |
+| A8 | State listeners receive correct state objects on each transition. |
+| A9 | Listener unsubscribe works — no further notifications after unsubscribe. |
+
+## What's out of scope (queued for follow-up PRs in this series)
+
+- **Group B** — `AudioCoordinator` mutual exclusion (4 tests). Requires Zustand store mocking + lazy-`require()` probing. Separate PR to keep mock complexity isolated.
+- **Group C** — `ExpoAudioProvider` lifecycle (5 tests). Component tests requiring `@testing-library/react-native` (not currently in deps). Adds the dep + the tests in one PR.
+- **Group D** — `handleTrackEnd` repeat-mode branching (6 tests). The simulated-review surprise flagged in the original audit; high-value, depends on Group C harness.
+- **Groups E–I** — Analytics call points, `MushafAudioService`, `AmbientAudioService`, `LockScreenService`, integration. Sequenced after the refactor sub-PRs they unblock.
+
+Each follow-up PR cites this RFC and adds tests in `services/audio/__tests__/`. The full inventory and reasoning live in [Characterization-Test-Plan.md](https://github.com/omar-zarka/bayaan-platform/blob/main/planning/Characterization-Test-Plan.md).
+
+## Test design notes
+
+- **Singleton handling.** `ExpoAudioService` exports both the singleton instance (`expoAudioService`) and the class (`ExpoAudioService`). Tests use the class export with `getInstance()` plus `reset()` between cases — same pattern as the analytics tests.
+- **`expo-audio` mock.** Only `setAudioModeAsync` is mocked at the module level (it's the side-effecting native call in `initialize()`); everything else flows through the injected `FakeAudioPlayer`.
+- **`__DEV__` guard.** Tests run with `__DEV__ = true` so the dev-only logs run; this catches accidental crashes inside `console.log` interpolations.
+- **No fake timers** for Group A (all transitions are synchronous or single-await). Group C will need fake timers for the throttled progress persistence test.
+
+## Tidy First framing
+
+- This PR is **tests only**. Zero production code touched. No refactor, no behavior change.
+- The fake-player approach is intentionally per-test — moving it to `@bayaan/test-utils` is a future Tidy step once a second test file needs it.
+
+## Acceptance criteria
+
+- [ ] All 9 tests pass on first run.
+- [ ] Test suite adds ≥9 to the project's test count visible in CI.
+- [ ] `npm run test:ci` is green.
+- [ ] No new lint or TypeScript errors.
+
+## References
+
+- ADR-0001: audio extraction seam (`bayaan-platform/adr/0001-audio-extraction-seam.md`)
+- Characterization Test Plan: full inventory of Groups A–I
+- PR #236: `PlayerController` port + `ExpoAudioPlayerControllerAdapter` scaffold (RFC-004)

--- a/services/audio/__tests__/ExpoAudioService.test.ts
+++ b/services/audio/__tests__/ExpoAudioService.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Characterization tests for ExpoAudioService — Group A from
+ * bayaan-platform/planning/Characterization-Test-Plan.md.
+ *
+ * These tests lock in current state-machine behavior before any
+ * AudioCoordinator / ExpoAudioProvider / LockScreenService refactor begins
+ * (RFC-006 onward). They use a per-test `FakeAudioPlayer` that mirrors the
+ * slice of expo-audio's AudioPlayer surface that ExpoAudioService.ts actually
+ * touches. Once Group B reuses the same fake, it gets promoted into
+ * @bayaan/test-utils.
+ *
+ * See docs/rfcs/005-audio-characterization-tests.md.
+ */
+
+// Mock setAudioModeAsync — the only native call ExpoAudioService.initialize()
+// makes. The rest of the service flows through the injected FakeAudioPlayer.
+jest.mock('expo-audio', () => ({
+  setAudioModeAsync: jest.fn(() => Promise.resolve()),
+}));
+
+import {setAudioModeAsync} from 'expo-audio';
+import {ExpoAudioService} from '../ExpoAudioService';
+import type {ExpoAudioServiceState} from '../ExpoAudioService';
+
+/**
+ * Test double for expo-audio's AudioPlayer. Exposes the slice of the surface
+ * ExpoAudioService.ts uses (replace, play, pause, seekTo, setPlaybackRate,
+ * volume, muted, currentTime, duration, playing, isLoaded, isBuffering,
+ * playbackRate). Adds `simulate*` drivers for deterministic state changes.
+ */
+class FakeAudioPlayer {
+  // expo-audio AudioPlayer surface (only what ExpoAudioService consumes)
+  isLoaded = false;
+  playing = false;
+  isBuffering = false;
+  currentTime = 0;
+  duration = 0;
+  playbackRate = 1;
+  volume = 1;
+  muted = false;
+
+  replace = jest.fn(async (_source: {uri: string}) => {
+    // Mimic expo-audio: replace() resets isLoaded then loads the new source.
+    // Tests drive the loaded state via simulateLoaded().
+    this.isLoaded = false;
+    this.currentTime = 0;
+    this.duration = 0;
+  });
+
+  play = jest.fn(async () => {
+    this.playing = true;
+  });
+
+  pause = jest.fn(async () => {
+    this.playing = false;
+  });
+
+  seekTo = jest.fn(async (positionSec: number) => {
+    this.currentTime = positionSec;
+  });
+
+  setPlaybackRate = jest.fn(
+    (rate: number, _quality: 'low' | 'medium' | 'high') => {
+      this.playbackRate = rate;
+    },
+  );
+
+  // Test driver: mark the player as loaded with a duration. Mirrors
+  // expo-audio firing `playbackStatusUpdate { isLoaded: true }`.
+  simulateLoaded(durationSec: number) {
+    this.isLoaded = true;
+    this.duration = durationSec;
+  }
+}
+
+/**
+ * Helper: instantiate the singleton, set a fake player, and return both.
+ * `reset()` clears state between tests; the singleton itself can't be
+ * re-newed cheaply, so reset+re-setup is the supported pattern (the service
+ * exposes `reset()` for exactly this use case — see ExpoAudioService.ts:454).
+ */
+function makeService(): {service: ExpoAudioService; player: FakeAudioPlayer} {
+  const service = ExpoAudioService.getInstance();
+  service.reset();
+  const player = new FakeAudioPlayer();
+  service.setPlayer(player as unknown as Parameters<typeof service.setPlayer>[0]);
+  return {service, player};
+}
+
+describe('ExpoAudioService — Group A characterization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------- A1 ---
+  it('A1: initialize() is idempotent — second call no-ops', async () => {
+    const {service} = makeService();
+
+    await service.initialize();
+    expect(service.getIsInitialized()).toBe(true);
+    expect(setAudioModeAsync).toHaveBeenCalledTimes(1);
+
+    await service.initialize();
+    expect(service.getIsInitialized()).toBe(true);
+    expect(setAudioModeAsync).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------- A2 ---
+  it('A2: setPlayer() stores the player; calling twice replaces it', () => {
+    const service = ExpoAudioService.getInstance();
+    service.reset();
+
+    const first = new FakeAudioPlayer();
+    service.setPlayer(first as unknown as Parameters<typeof service.setPlayer>[0]);
+    expect(service.getPlayer()).toBe(first);
+    expect(service.hasPlayer()).toBe(true);
+
+    const second = new FakeAudioPlayer();
+    service.setPlayer(second as unknown as Parameters<typeof service.setPlayer>[0]);
+    expect(service.getPlayer()).toBe(second);
+    expect(service.getPlayer()).not.toBe(first);
+  });
+
+  // ---------------------------------------------------------------- A3 ---
+  it('A3: loadTrack(url) happy path — state idle → loading → ready', async () => {
+    const {service, player} = makeService();
+    const states: ExpoAudioServiceState['playbackState'][] = [];
+    service.addStateListener(s => states.push(s.playbackState));
+
+    expect(service.getPlaybackState()).toBe('idle');
+
+    // Simulate the player completing the load shortly after replace() is called.
+    player.replace.mockImplementationOnce(async () => {
+      player.isLoaded = false;
+      // Schedule the loaded transition so waitForLoaded() observes the
+      // false→true edge. Microtask is enough since the poll uses setTimeout.
+      setTimeout(() => player.simulateLoaded(60), 0);
+    });
+
+    await service.loadTrack('https://example.test/track.mp3');
+
+    expect(service.getPlaybackState()).toBe('ready');
+    expect(service.getCurrentUrl()).toBe('https://example.test/track.mp3');
+    expect(player.replace).toHaveBeenCalledWith({uri: 'https://example.test/track.mp3'});
+    // Listeners observed loading then ready (idle is the pre-listener baseline).
+    expect(states).toContain('loading');
+    expect(states[states.length - 1]).toBe('ready');
+  });
+
+  // ---------------------------------------------------------------- A4 ---
+  it('A4: loadTrack(url) error — state error, lastError set, listeners notified', async () => {
+    const {service, player} = makeService();
+    const states: ExpoAudioServiceState['playbackState'][] = [];
+    service.addStateListener(s => states.push(s.playbackState));
+
+    const networkErr = new Error('network down');
+    player.replace.mockRejectedValueOnce(networkErr);
+
+    await expect(
+      service.loadTrack('https://example.test/track.mp3'),
+    ).rejects.toThrow('network down');
+
+    expect(service.getPlaybackState()).toBe('error');
+    expect(service.getLastError()).toBe(networkErr);
+    expect(states[states.length - 1]).toBe('error');
+  });
+
+  // ---------------------------------------------------------------- A5 ---
+  it('A5: play() from ready → playing; pause() from playing → paused', async () => {
+    const {service, player} = makeService();
+
+    // Manually drive into 'ready' state without going through loadTrack
+    // (covered by A3) — direct test of play/pause transitions.
+    player.simulateLoaded(60);
+    player.replace.mockImplementationOnce(async () => {
+      player.isLoaded = false;
+      setTimeout(() => player.simulateLoaded(60), 0);
+    });
+    await service.loadTrack('https://example.test/x.mp3');
+    expect(service.getPlaybackState()).toBe('ready');
+
+    await service.play();
+    expect(service.getPlaybackState()).toBe('playing');
+    expect(player.play).toHaveBeenCalledTimes(1);
+
+    await service.pause();
+    expect(service.getPlaybackState()).toBe('paused');
+    expect(player.pause).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------- A6 ---
+  it('A6: seekTo(seconds) calls player.seekTo and does NOT change playback state', async () => {
+    const {service, player} = makeService();
+
+    // Get into 'playing'.
+    player.replace.mockImplementationOnce(async () => {
+      player.isLoaded = false;
+      setTimeout(() => player.simulateLoaded(60), 0);
+    });
+    await service.loadTrack('https://example.test/x.mp3');
+    await service.play();
+    expect(service.getPlaybackState()).toBe('playing');
+
+    await service.seekTo(15);
+
+    expect(player.seekTo).toHaveBeenCalledWith(15);
+    expect(service.getPlaybackState()).toBe('playing'); // unchanged
+  });
+
+  // ---------------------------------------------------------------- A7 ---
+  it('A7: setRate clamps to [0.5, 2.0] and calls player.setPlaybackRate(rate, "high")', () => {
+    const {service, player} = makeService();
+
+    service.setRate(1.25);
+    expect(player.setPlaybackRate).toHaveBeenLastCalledWith(1.25, 'high');
+
+    // Below clamp range — should clamp up to 0.5.
+    service.setRate(0.1);
+    expect(player.setPlaybackRate).toHaveBeenLastCalledWith(0.5, 'high');
+
+    // Above clamp range — should clamp down to 2.0.
+    service.setRate(5.0);
+    expect(player.setPlaybackRate).toHaveBeenLastCalledWith(2.0, 'high');
+  });
+
+  // ---------------------------------------------------------------- A8 ---
+  it('A8: state listeners receive correct state objects on each transition', async () => {
+    const {service, player} = makeService();
+    const observed: ExpoAudioServiceState[] = [];
+    service.addStateListener(s => observed.push({...s}));
+
+    player.replace.mockImplementationOnce(async () => {
+      player.isLoaded = false;
+      setTimeout(() => player.simulateLoaded(60), 0);
+    });
+    await service.loadTrack('https://example.test/x.mp3');
+    await service.play();
+
+    // At minimum: loading, ready, playing — plus any intermediate notifications.
+    const states = observed.map(s => s.playbackState);
+    expect(states).toEqual(expect.arrayContaining(['loading', 'ready', 'playing']));
+
+    // Every notification carries the full state shape.
+    for (const s of observed) {
+      expect(s).toHaveProperty('isInitialized');
+      expect(s).toHaveProperty('playbackState');
+      expect(s).toHaveProperty('error');
+    }
+  });
+
+  // ---------------------------------------------------------------- A9 ---
+  it('A9: listener unsubscribe stops further notifications', async () => {
+    const {service, player} = makeService();
+    const listener = jest.fn();
+    const unsubscribe = service.addStateListener(listener);
+
+    player.replace.mockImplementationOnce(async () => {
+      player.isLoaded = false;
+      setTimeout(() => player.simulateLoaded(60), 0);
+    });
+    await service.loadTrack('https://example.test/x.mp3');
+    expect(listener).toHaveBeenCalled();
+    const callCountBeforeUnsubscribe = listener.mock.calls.length;
+
+    unsubscribe();
+
+    await service.play();
+    await service.pause();
+
+    expect(listener).toHaveBeenCalledTimes(callCountBeforeUnsubscribe);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the test harness and 9 characterization tests for `ExpoAudioService`. **Tests-only — no production code touched.**

This is PR #1 of the audio extraction series per ADR-0001: characterization tests come *before* any AudioCoordinator / ExpoAudioProvider / LockScreenService refactor, so subsequent refactor PRs can prove behavior parity by keeping these tests green.

Test count: **77 → 86, all green** (including the 9 new tests; existing 77 unchanged).

## A note on numbering

[#236](https://github.com/thebayaan/Bayaan/pull/236) (RFC-004) said \"the actual refactor of \`AudioCoordinator\`, \`ExpoAudioProvider\`, and \`LockScreenService\` to consume these ports is RFC-005.\" Per ADR-0001 sequencing, characterization tests must precede that refactor — without them, every reviewer of the refactor PRs is on the hook for \"does this preserve subtle behavior?\". So:

- **RFC-005 (this PR):** characterization tests for `ExpoAudioService`.
- **RFC-006 (next):** the AudioCoordinator/ExpoAudioProvider/LockScreenService refactor onto `PlayerController` — same content RFC-004's body called RFC-005, just one PR later in the sequence.

One extra precondition PR; same end state.

## What's in this PR

**Group A** from the [Characterization Test Plan](https://github.com/omar-zarka/bayaan-platform/blob/main/planning/Characterization-Test-Plan.md): the `ExpoAudioService` state machine.

| ID | Behavior locked in |
|---|---|
| A1 | \`initialize()\` is idempotent |
| A2 | \`setPlayer()\` stores; second call replaces |
| A3 | \`loadTrack(url)\` happy path: state \`idle → loading → ready\` |
| A4 | \`loadTrack(url)\` error: state \`error\`, \`lastError\` set, listeners notified |
| A5 | \`play()\` from \`ready\` → \`playing\`; \`pause()\` from \`playing\` → \`paused\` |
| A6 | \`seekTo(seconds)\` calls \`player.seekTo\` and does NOT change playback state |
| A7 | \`setRate\` clamps to [0.5, 2.0] and calls \`setPlaybackRate(rate, 'high')\` |
| A8 | State listeners receive correct state objects on each transition |
| A9 | Listener unsubscribe stops further notifications |

The full Plan inventory + reasoning lives in `bayaan-platform/planning/Characterization-Test-Plan.md`. Groups B–I queue as follow-up PRs in this same series; each will cite RFC-005 and add to `services/audio/__tests__/`.

## Test design

- **`expo-audio` mock:** only `setAudioModeAsync` is mocked at the module level (it's the side-effecting native call in `initialize()`); everything else flows through an injected `FakeAudioPlayer`.
- **`FakeAudioPlayer`:** local class in the test file — mirrors the slice of `expo-audio`'s `AudioPlayer` surface that `ExpoAudioService.ts` actually consumes (`replace`, `play`, `pause`, `seekTo`, `setPlaybackRate`, `currentTime`, `duration`, `playing`, `isLoaded`, `isBuffering`, `playbackRate`, `volume`, `muted`). Lives per-test for now; promotes to `@bayaan/test-utils` once Group B reuses it.
- **Singleton handling:** uses the exported `ExpoAudioService` class with `getInstance()` plus `reset()` between tests — same pattern as the existing `services/analytics/__tests__/` tests.

## Tidy First framing

Tests-only. Zero production code touched. No refactor, no behavior change. This is the safety net the next 6–7 audio PRs lean on.

## Test plan

- [x] \`npm run test:ci\` — 86/86 passing
- [x] \`npx tsc --noEmit -p .\` — clean
- [x] No new lint errors (test file follows existing pattern in \`services/analytics/__tests__/\`)
- [x] No production code touched (\`git diff develop --stat\` shows only \`docs/rfcs/\` + \`services/audio/__tests__/\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)