### PR TITLE
docs: note the spawnSync({input}) pipe-deadlock anti-pattern

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,6 +196,29 @@ export const MyComponent: React.FC<MyComponentProps> = ({ title, onPress }) => {
 - Use `usePlayerActions` for audio controls, not the deprecated `useUnifiedPlayer`
 - Name variables/functions camelCase, components PascalCase, directories lowercase-with-hyphens
 
+### Scripts: common pitfalls
+
+When writing Node scripts under `scripts/` that shell out to binaries (`ffmpeg`, `sharp`, `imagemagick`, etc.), avoid passing large binary buffers via `child_process.spawnSync(cmd, args, { input: bigBuffer })`. Once `input` exceeds the OS pipe buffer (~64 KB on macOS / Linux), `spawnSync` deadlocks: the child blocks waiting for stdin to drain while Node blocks waiting for the child to exit. The script appears to "succeed" — the child emits a tiny empty output and no error is raised — which makes the failure mode silent and easy to ship.
+
+Safer pattern: write the input to a temp file, pass the path as an argument, and clean up in `finally`:
+
+```js
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const tmp = join(tmpdir(), `script-${process.pid}-${Date.now()}.bin`);
+writeFileSync(tmp, bigBuffer);
+try {
+  spawnSync('ffmpeg', ['-i', tmp, /* ... */ outPath], { stdio: 'inherit' });
+} finally {
+  try { unlinkSync(tmp); } catch {}
+}
+```
+
+For streaming use cases, prefer the async `spawn` with an explicit `child.stdin.end(buffer)` and an awaited `'close'` event — `spawnSync` is the wrong primitive for >64 KB of stdin. See the [Node `child_process` docs](https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options) for the underlying buffer behavior.
+
 ---
 
 ## Design system


### PR DESCRIPTION
## Summary

Adds a short "Scripts: common pitfalls" subsection to `CONTRIBUTING.md` (under Code standards) documenting a silent failure mode in Node scripts that pipe large binary buffers into child binaries via `child_process.spawnSync(cmd, args, { input: bigBuffer })`. Once `input` exceeds the OS pipe buffer (~64 KB on macOS / Linux), the call deadlocks: the child blocks waiting for stdin to drain while Node blocks waiting for the child to exit, and the script appears to "succeed" with a tiny empty output and no thrown error. The note covers the temp-file fix (write to `os.tmpdir()`, pass the path, clean up in `finally`) and points to async `spawn` for streaming cases.

## Why this is safe

- Pure documentation — no source, config, or dependency changes.
- Bayaan's current `scripts/` do not contain an instance of this anti-pattern. The note is preventative for future contributors writing media-processing or asset-generation scripts.
- Placed inline in `CONTRIBUTING.md` rather than a new doc file to keep contributor-facing tips discoverable in one place.

## Test plan

- [x] No source code changes — typecheck / lint / build are unaffected.
- [x] Markdown renders correctly (verified locally).
- [x] No new dependencies introduced.