### PR TITLE
chore: document fork-friendly Claude Code tooling convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,11 @@ CLAUDE.md
 GEMINI.md
 AGENTS.md
 .claude/
+# Forks may opt into project-versioned Claude Code skills / scheduled tasks
+# by un-ignoring those subfolders in the fork's own .gitignore (e.g.
+# `!.claude/skills/`, `!.claude/scheduled-tasks/`). Machine-local Claude
+# state — `.claude/settings.local.json`, `scheduled_tasks.lock`,
+# `.claude/projects/` — should always remain ignored.
 
 # Build/release configs (contain owner-specific IDs)
 ExportOptions.plist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,6 +244,18 @@ AI tools (Cursor, Copilot, Claude, etc.) are welcome and encouraged. See [docs/c
 - You are responsible for every line you submit — review and understand AI output before pushing
 - The PR template includes an AI disclosure checkbox
 
+### Forks and Claude Code tooling
+
+Bayaan's `.gitignore` excludes the entire `.claude/` directory because it can contain operational paths private to a maintainer's machine. Forks that want to ship their own project-versioned Claude Code skills or scheduled tasks (so they survive across machines and collaborators) can opt-in by adding negation rules to the fork's own `.gitignore`, e.g.:
+
+```gitignore
+# Un-ignore project-versioned Claude Code tooling
+!.claude/skills/
+!.claude/scheduled-tasks/
+```
+
+Keep machine-local Claude state ignored: `.claude/settings.local.json`, `scheduled_tasks.lock`, `.claude/projects/`. The convention separates project tooling (versioned, shared) from per-developer state (machine-local).
+
 ---
 
 ## Architecture navigation


### PR DESCRIPTION
## Summary

Documentation-only PR that establishes a convention for forks shipping project-versioned Claude Code tooling (skills, scheduled tasks). Zero behavior change for upstream contributors.

### Changes

- `.gitignore`: comment block under the existing `.claude/` rule explains how forks can opt-in by un-ignoring `.claude/skills/` and `.claude/scheduled-tasks/` in their own `.gitignore` while keeping machine-local state (`settings.local.json`, `scheduled_tasks.lock`, `projects/`) ignored.
- `CONTRIBUTING.md`: new "Forks and Claude Code tooling" subsection under "AI-assisted development" with the recommended convention.

## Why upstream

Bayaan's blanket `.claude/` ignore is a defensible default — it can contain operational paths private to a maintainer's machine. But it cuts off a use case any fork (or Bayaan itself, eventually) will hit: project-versioned Claude Code skills that survive across machines and collaborators. The Qariah fork (qariah-v2) ships sprint-kickoff / post-sprint / divergence-audit skills as part of the repo for exactly this reason, and the un-ignore convention works cleanly with Bayaan's blanket rule.

This PR doesn't unignore anything in Bayaan itself — it just documents the convention so any future Bayaan or fork contributor doesn't have to re-derive it.

## Test plan

- [x] `git status` clean after the change
- [x] `git check-ignore -v .claude/skills/` still ignored in upstream (no behavior change)
- [x] `npx tsc --noEmit` clean (no source changes anyway)

## Risk

Zero. Pure documentation.

## Cross-ref

Upstream side of qariah-v2 divergence-ledger row #17 (Q2 2026 audit candidate B).