### PR TITLE
chore(eslint): enable react/no-unused-prop-types as warn

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,11 @@ module.exports = {
       },
     ],
     'react/prop-types': 'off',
+    // Catch a silent-bug class where a component declares a prop in its
+    // TypeScript interface but never destructures / uses it, so callers
+    // pass values that get silently dropped. Set to 'warn' to avoid
+    // breaking pre-existing findings; flip to 'error' once triaged.
+    'react/no-unused-prop-types': 'warn',
     'react/react-in-jsx-scope': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',


### PR DESCRIPTION
## Summary

Enables the `react/no-unused-prop-types` ESLint rule at `'warn'` level.

This rule catches a silent-bug class where a component declares a prop in its TypeScript interface (or PropTypes) but never destructures / uses it, so callers pass values that get silently dropped at runtime. TypeScript does not catch this — optional props are not required to be consumed.

### Example of the bug class

```tsx
interface Props {
  imageUrl?: string;  // declared but never used below
  name: string;
}

function Avatar({name}: Props) {  // imageUrl silently dropped
  return <DefaultIcon label={name} />;
}

// Caller:
<Avatar imageUrl={user.photoUrl} name={user.name} />  // photoUrl never renders
```

A real-world instance of exactly this bug exists in `components/ReciterImage.tsx` and was fixed in #244 — that fix patches the call site, this rule prevents recurrence at the rule level.

### Why `'warn'` not `'error'`

Pre-existing findings in this codebase: **236** (mostly benign over-typing — `filled` on icon components, `item`/`index` on `FlatList renderItem` children, etc.). Setting to `'warn'` is non-breaking and surfaces real signals for future PRs without forcing a triage sprint up front. Once those are audited and addressed, the rule can be promoted to `'error'`.

The `lint.yml` workflow already runs with `continue-on-error: true`, so warnings stay informational.

## Test plan

- [x] `.eslintrc.cjs` updated with the rule + brief comment
- [x] `npx eslint .` runs (exit 1 due to warnings, expected — 236 inherited findings)
- [x] `npx tsc --noEmit` clean (no type regressions)