### PR TITLE
test(audio): RFC-006 — characterization tests for AudioCoordinator (Group B)

### DIFF
--- a/docs/rfcs/006-audio-characterization-tests-group-b.md
+++ b/docs/rfcs/006-audio-characterization-tests-group-b.md
@@ -1,0 +1,57 @@
+# RFC-006: Audio characterization tests — Group B (`AudioCoordinator`)
+
+| Status | Date | Author | Predecessors |
+|---|---|---|---|
+| Proposed | 2026-05-07 | omar-zarka | RFC-005 (Group A), ADR-0001 |
+
+---
+
+## Summary
+
+Lock in the current behavior of `services/audio/AudioCoordinator.ts` — the singleton that mediates mutual exclusion between the main player and the mushaf player — with 4 Jest tests (B1–B4) from the [Characterization Test Plan](https://github.com/omar-zarka/bayaan-platform/blob/main/planning/Characterization-Test-Plan.md). Tests-only — no production code touched.
+
+This is PR #2 of the audio extraction's characterization sweep. RFC-005 locked Group A (`ExpoAudioService` state machine, 9 tests). Group B locks the AudioCoordinator's lazy-`require()` mutual-exclusion behavior so the upcoming RFC-008 refactor (replace lazy-require with `CoordinatorHooks` injection per ADR-0001 §PR-3) can prove parity.
+
+## What's in this PR
+
+| ID | Behavior locked in |
+|---|---|
+| B1 | `mushafWillPlay()` pauses the main player **only** when `activeSource === 'main'` AND main is in `playing` or `buffering` state (state guard) |
+| B2 | `mainWillPlay()` calls `mushafAudioService.pause()` AND `useMushafPlayerStore.getState().setPlaybackState('paused')` via lazy-`require()`, when `activeSource === 'mushaf'` |
+| B3 | `sourceDidStop('mushaf')` followed by `mainWillPlay()` triggers no pause — clean handoff, no recursion |
+| B4 | `mainWillPlay()` lazy-`require()` resolves at function-call time without throwing (baseline before RFC-008 deletes the lazy-require) |
+
+## Note on the Plan's prose vs. actual code
+
+The Plan's B1 prose said "`mainWillPlay()` calls `usePlayerStore.getState().pause()`", but the real code path for that call is `mushafWillPlay()` (mushaf is starting → pause main). Tests lock in actual behavior; the Plan will be updated to match.
+
+## Test design
+
+- **`AudioCoordinator` is a singleton with no public reset.** Each test calls a `freshCoordinator()` helper that uses `jest.isolateModules()` to import a fresh module — keeps tests independent without adding a `__resetForTests` to production code (which would violate Tidy First for a tests-only PR).
+- **Three modules mocked at the top level:** `@/services/player/store/playerStore` (eager import in AudioCoordinator), `@/store/mushafPlayerStore` (lazy require inside `mainWillPlay`), `../MushafAudioService` (lazy require inside `mainWillPlay`). `jest.mock` is hoisted, so the lazy-require sites pick up the mock.
+- **Same style as RFC-005's `ExpoAudioService.test.ts`** — module-level mocks, factory pattern for fakes, in-test assertions on `jest.fn()` mock call history.
+
+## Scope discipline (Tidy First)
+
+- No production code touched — `git diff develop --stat` shows only `docs/rfcs/` and `services/audio/__tests__/`.
+- No new dependencies.
+- Singleton `reset()` not added — would be production-code change.
+
+## Sequence forward
+
+After this merges, the audio extraction series proceeds per ADR-0001:
+- **RFC-008** (RFC-007 skipped): refactor `AudioCoordinator` onto `CoordinatorHooks`, deleting the lazy-`require()` block. Group B tests are the safety net.
+- RFC-009: refactor `ExpoAudioProvider` onto `PlayerController` (preceded by Group C/D characterization tests).
+- RFC-010: refactor `LockScreenService` onto `LockScreenMetadataSource` (preceded by Group H tests).
+
+## Test plan
+
+- [x] `npm run test:ci` — 86 + 4 = 90 passing
+- [x] `npx tsc --noEmit -p .` — clean
+- [x] No production code touched
+
+## References
+
+- ADR-0001 — `bayaan-platform/adr/0001-audio-extraction-seam.md`
+- Characterization Test Plan — `bayaan-platform/planning/Characterization-Test-Plan.md` §Group B
+- RFC-005 (Group A) — `docs/rfcs/005-audio-characterization-tests.md`

--- a/services/audio/__tests__/AudioCoordinator.test.ts
+++ b/services/audio/__tests__/AudioCoordinator.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Characterization tests for AudioCoordinator — Group B from
+ * bayaan-platform/planning/Characterization-Test-Plan.md.
+ *
+ * Locks in mutual-exclusion behavior between the main player and the mushaf
+ * player BEFORE the RFC-008 refactor that replaces the lazy-`require()`
+ * pattern with `CoordinatorHooks` injection. Tests-only — zero production
+ * code touched.
+ *
+ * The lazy `require('./MushafAudioService')` and `require('@/store/mushafPlayerStore')`
+ * inside `mainWillPlay()` are characterized here (B2, B4) so the refactor PR
+ * can prove behavior parity by keeping these tests green.
+ *
+ * See docs/rfcs/006-audio-characterization-tests-group-b.md.
+ */
+
+// Mock the eagerly-imported player store at the top level so AudioCoordinator's
+// `import {usePlayerStore}` resolves to our spy. Lazy-required modules are
+// mocked the same way — jest hoists `jest.mock` so the require() inside
+// `mainWillPlay()` picks up the mock.
+//
+// Variables referenced from inside `jest.mock(...)` factories must be named
+// `mock*` (case insensitive) — babel-jest's hoist guard allows that prefix.
+const mockMainPause = jest.fn(() => Promise.resolve());
+const mockMushafSetPlaybackState = jest.fn();
+const mockMushafServicePause = jest.fn();
+const mockMushafServiceGetIsPlaying = jest.fn(() => true);
+
+jest.mock('@/services/player/store/playerStore', () => ({
+  usePlayerStore: {
+    getState: jest.fn(() => ({
+      playback: {state: 'playing'},
+      pause: mockMainPause,
+    })),
+  },
+}));
+
+jest.mock('@/store/mushafPlayerStore', () => ({
+  useMushafPlayerStore: {
+    getState: jest.fn(() => ({
+      playbackState: 'playing',
+      setPlaybackState: mockMushafSetPlaybackState,
+    })),
+  },
+}));
+
+jest.mock('../MushafAudioService', () => ({
+  mushafAudioService: {
+    pause: mockMushafServicePause,
+    getIsPlaying: mockMushafServiceGetIsPlaying,
+  },
+}));
+
+import {usePlayerStore} from '@/services/player/store/playerStore';
+import {useMushafPlayerStore} from '@/store/mushafPlayerStore';
+
+/**
+ * Helper: re-import AudioCoordinator with a fresh module registry so the
+ * private `activeSource` field starts at `'none'` for every test. The
+ * coordinator is a singleton with no public reset method — `jest.isolateModules`
+ * is the surgical way to get a clean instance without modifying production
+ * code (which would violate Tidy First for a tests-only PR).
+ */
+function freshCoordinator(): typeof import('../AudioCoordinator').audioCoordinator {
+  let instance!: typeof import('../AudioCoordinator').audioCoordinator;
+  jest.isolateModules(() => {
+    instance = require('../AudioCoordinator').audioCoordinator;
+  });
+  return instance;
+}
+
+describe('AudioCoordinator — Group B characterization', () => {
+  beforeEach(() => {
+    mockMainPause.mockClear();
+    mockMushafSetPlaybackState.mockClear();
+    mockMushafServicePause.mockClear();
+    mockMushafServiceGetIsPlaying.mockClear();
+    mockMushafServiceGetIsPlaying.mockReturnValue(true);
+    (usePlayerStore.getState as jest.Mock).mockReturnValue({
+      playback: {state: 'playing'},
+      pause: mockMainPause,
+    });
+    (useMushafPlayerStore.getState as jest.Mock).mockReturnValue({
+      playbackState: 'playing',
+      setPlaybackState: mockMushafSetPlaybackState,
+    });
+  });
+
+  // ---------------------------------------------------------------- B1 ---
+  // NOTE: the Plan's prose for B1 swapped the method/store pairing. The
+  // actual code path that touches `usePlayerStore.getState().pause()` is
+  // `mushafWillPlay()` (mushaf is starting → pause main). Locking in the
+  // real behavior, not the prose.
+  it('B1: mushafWillPlay() pauses the main player only when activeSource === "main" and main is playing/buffering', () => {
+    // From a clean coordinator (activeSource = 'none'): no pause.
+    const c1 = freshCoordinator();
+    c1.mushafWillPlay();
+    expect(mockMainPause).not.toHaveBeenCalled();
+    expect(c1.getActiveSource()).toBe('mushaf');
+
+    // activeSource = 'main', main is 'playing' → pause.
+    const c2 = freshCoordinator();
+    c2.mainWillPlay();
+    expect(c2.getActiveSource()).toBe('main');
+    mockMainPause.mockClear();
+    c2.mushafWillPlay();
+    expect(mockMainPause).toHaveBeenCalledTimes(1);
+    expect(c2.getActiveSource()).toBe('mushaf');
+
+    // activeSource = 'main', main is 'paused' → no pause (state guard).
+    const c3 = freshCoordinator();
+    c3.mainWillPlay();
+    (usePlayerStore.getState as jest.Mock).mockReturnValueOnce({
+      playback: {state: 'paused'},
+      pause: mockMainPause,
+    });
+    mockMainPause.mockClear();
+    c3.mushafWillPlay();
+    expect(mockMainPause).not.toHaveBeenCalled();
+    expect(c3.getActiveSource()).toBe('mushaf');
+
+    // activeSource = 'main', main is 'buffering' → pause (buffering counts as active).
+    const c4 = freshCoordinator();
+    c4.mainWillPlay();
+    (usePlayerStore.getState as jest.Mock).mockReturnValueOnce({
+      playback: {state: 'buffering'},
+      pause: mockMainPause,
+    });
+    mockMainPause.mockClear();
+    c4.mushafWillPlay();
+    expect(mockMainPause).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------- B2 ---
+  it('B2: mainWillPlay() pauses mushaf via lazy-required mushafAudioService AND sets mushaf store to "paused"', () => {
+    const c = freshCoordinator();
+
+    // Get into activeSource = 'mushaf' first.
+    c.mushafWillPlay();
+    expect(c.getActiveSource()).toBe('mushaf');
+
+    // Lazy require + pause path.
+    c.mainWillPlay();
+
+    expect(mockMushafServiceGetIsPlaying).toHaveBeenCalledTimes(1);
+    expect(mockMushafServicePause).toHaveBeenCalledTimes(1);
+    expect(mockMushafSetPlaybackState).toHaveBeenCalledWith('paused');
+    expect(c.getActiveSource()).toBe('main');
+  });
+
+  // ---------------------------------------------------------------- B3 ---
+  it('B3: sourceDidStop("mushaf") followed by mainWillPlay() triggers no pause (clean handoff, no recursion)', () => {
+    const c = freshCoordinator();
+
+    c.mushafWillPlay();
+    expect(c.getActiveSource()).toBe('mushaf');
+
+    c.sourceDidStop('mushaf');
+    expect(c.getActiveSource()).toBe('none');
+
+    mockMushafServicePause.mockClear();
+    mockMushafSetPlaybackState.mockClear();
+
+    c.mainWillPlay();
+
+    // No pause-mushaf path because activeSource was already 'none'.
+    expect(mockMushafServiceGetIsPlaying).not.toHaveBeenCalled();
+    expect(mockMushafServicePause).not.toHaveBeenCalled();
+    expect(mockMushafSetPlaybackState).not.toHaveBeenCalled();
+    expect(c.getActiveSource()).toBe('main');
+  });
+
+  // ---------------------------------------------------------------- B4 ---
+  // Smoke test for the lazy-`require()` hack that the RFC-008 refactor will
+  // delete. Confirms the require resolves at function-call time without
+  // throwing a synchronous-import-cycle error. After the refactor, this
+  // test is expected to be deleted (the code path it covers no longer exists).
+  it('B4: mainWillPlay() lazy-require resolves without throwing (baseline before RFC-008 deletion)', () => {
+    const c = freshCoordinator();
+    c.mushafWillPlay();
+
+    // mushaf is "playing" per the default mock — the lazy-require path runs
+    // end to end. The assertion is "does not throw", plus confirmation that
+    // both lazy-required exports were actually consumed.
+    expect(() => c.mainWillPlay()).not.toThrow();
+    expect(mockMushafServiceGetIsPlaying).toHaveBeenCalledTimes(1);
+    expect(mockMushafSetPlaybackState).toHaveBeenCalledTimes(1);
+
+    // Also confirm the activeSource transitioned, proving the function
+    // ran past the lazy-require block (didn't bail at a require error).
+    expect(c.getActiveSource()).toBe('main');
+  });
+});


### PR DESCRIPTION
## Summary

Lands 4 characterization tests (B1–B4) for `AudioCoordinator` — the singleton that mediates mutual exclusion between the main player and the mushaf player. **Tests-only — no production code touched.**

This is PR #2 of the audio extraction's characterization sweep. RFC-005 ([#238](https://github.com/thebayaan/Bayaan/pull/238)) locked Group A on `ExpoAudioService` (9 tests). Group B locks the AudioCoordinator's lazy-`require()` mutual-exclusion behavior so the upcoming refactor PR (which deletes the lazy-require) can prove parity.

Test count: **86 → 90, all green.**

## A note on numbering (RFC-007 is skipped)

The next refactor RFC — `AudioCoordinator` onto `CoordinatorHooks` per ADR-0001 §PR-3 — will open as **RFC-008**, not RFC-007. RFC-007 is reserved for the already-merged cross-fork pilot at `docs/rfcs/007-app-layer-multi-tenancy.md` ([#235](https://github.com/thebayaan/Bayaan/pull/235)).

## What's in this PR

**Group B** from the [Characterization Test Plan](https://github.com/omar-zarka/bayaan-platform/blob/main/planning/Characterization-Test-Plan.md):

| ID | Behavior locked in |
|---|---|
| B1 | `mushafWillPlay()` pauses the main player **only** when `activeSource === 'main'` AND main is in `playing` or `buffering` state |
| B2 | `mainWillPlay()` calls `mushafAudioService.pause()` AND `useMushafPlayerStore.getState().setPlaybackState('paused')` via lazy-`require()` |
| B3 | `sourceDidStop('mushaf')` followed by `mainWillPlay()` triggers no pause — clean handoff, no recursion |
| B4 | `mainWillPlay()` lazy-`require()` resolves at function-call time without throwing (baseline before RFC-008 deletes the lazy-require block) |

> The Plan's prose for B1 swapped the method/store pairing (it said `mainWillPlay()` calls `usePlayerStore.pause()`); the actual code path that touches `usePlayerStore.getState().pause()` is `mushafWillPlay()`. The tests lock in real behavior; the Plan will be corrected to match.

## Test design

- **`AudioCoordinator` is a singleton with no public reset.** Each test calls a `freshCoordinator()` helper that uses `jest.isolateModules()` to import a fresh module — keeps tests independent without adding a `__resetForTests` to production code (Tidy First).
- **Three modules mocked at the top level:** `@/services/player/store/playerStore` (eager import in AudioCoordinator), `@/store/mushafPlayerStore` (lazy-required inside `mainWillPlay`), `../MushafAudioService` (lazy-required inside `mainWillPlay`). `jest.mock` is hoisted, so the lazy-require sites pick up the mock.
- **Same style as RFC-005's `ExpoAudioService.test.ts`** — module-level mocks, factory pattern, in-test assertions on `jest.fn()` mock-call history.

## Tidy First framing

Tests-only. Zero production code touched. `git diff develop --stat` shows only `docs/rfcs/006-...md` and `services/audio/__tests__/AudioCoordinator.test.ts`.

## Sequence forward

After this merges, the audio extraction series proceeds per ADR-0001:
- **RFC-008** — `AudioCoordinator` refactor onto `CoordinatorHooks` (deletes the lazy-`require()`). Group B is the safety net.
- **RFC-009** — `ExpoAudioProvider` refactor onto `PlayerController` (preceded by Group C/D characterization tests).
- **RFC-010** — `LockScreenService` refactor onto `LockScreenMetadataSource` (preceded by Group H tests).

## Test plan

- [x] `npm run test:ci` — 90/90 passing
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx prettier --check` — clean
- [x] `npx eslint` — clean
- [x] No production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)