### PR TITLE
fix: render FollowAlongBadge on Browse + Circular reciter cards

### DIFF
--- a/components/browse/BrowseReciterCard.tsx
+++ b/components/browse/BrowseReciterCard.tsx
@@ -4,6 +4,7 @@ import {moderateScale} from 'react-native-size-matters';
 import {Reciter} from '@/data/reciterData';
 import {Theme} from '@/utils/themeUtils';
 import {ReciterImage} from '@/components/ReciterImage';
+import {FollowAlongBadge} from '@/components/badges/FollowAlongBadge';
 import Color from 'color';
 import {GlassView} from 'expo-glass-effect';
 import {Link} from 'expo-router';
@@ -60,6 +61,12 @@ function createStyles(theme: Theme, width: number, height: number) {
       color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
       lineHeight: moderateScale(12),
       includeFontPadding: false,
+      flexShrink: 1,
+    },
+    secondaryRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: moderateScale(4),
     },
     glassContainer: {
       borderWidth: 0,
@@ -80,6 +87,7 @@ const BrowseReciterCard = React.memo(
     height,
     theme,
     rewayatId,
+    showFollowAlong,
   }: BrowseReciterCardProps) => {
     const glassColorScheme = useGlassColorScheme();
     const styles = useMemo(
@@ -107,11 +115,14 @@ const BrowseReciterCard = React.memo(
           <Text style={styles.reciterName} numberOfLines={1}>
             {reciter.name}
           </Text>
-          <Text style={styles.reciterInfo} numberOfLines={1}>
-            {uniqueRewayatNames.length > 1
-              ? `${uniqueRewayatNames.length} rewayat available`
-              : getDisplayLabelFromName(reciter.rewayat[0]?.name)}
-          </Text>
+          <View style={styles.secondaryRow}>
+            <Text style={styles.reciterInfo} numberOfLines={1}>
+              {uniqueRewayatNames.length > 1
+                ? `${uniqueRewayatNames.length} rewayat available`
+                : getDisplayLabelFromName(reciter.rewayat[0]?.name)}
+            </Text>
+            {showFollowAlong && <FollowAlongBadge />}
+          </View>
         </View>
       </>
     );
@@ -154,6 +165,7 @@ const BrowseReciterCard = React.memo(
     prevProps.width === nextProps.width &&
     prevProps.height === nextProps.height &&
     prevProps.theme === nextProps.theme &&
+    prevProps.showFollowAlong === nextProps.showFollowAlong &&
     prevProps.onLongPress === nextProps.onLongPress,
 );
 

--- a/components/cards/CircularReciterCard.tsx
+++ b/components/cards/CircularReciterCard.tsx
@@ -10,6 +10,7 @@ import {
 import {useTheme} from '@/hooks/useTheme';
 import {moderateScale, verticalScale} from 'react-native-size-matters';
 import {ReciterImage} from '@/components/ReciterImage';
+import {FollowAlongBadge} from '@/components/badges/FollowAlongBadge';
 import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {Link} from 'expo-router';
@@ -42,6 +43,7 @@ export const CircularReciterCard: React.FC<CircularReciterCardProps> = ({
   addTextStyle,
   width,
   height,
+  showFollowAlong,
 }) => {
   const {theme} = useTheme();
 
@@ -96,6 +98,10 @@ export const CircularReciterCard: React.FC<CircularReciterCardProps> = ({
           textAlign: 'center',
           width: imageSize,
           marginTop: moderateScale(1),
+        },
+        subtitleRow: {
+          marginTop: moderateScale(2),
+          alignItems: 'center',
         },
         addContainer: {
           width: imageSize,
@@ -154,9 +160,15 @@ export const CircularReciterCard: React.FC<CircularReciterCardProps> = ({
           <Text style={styles.name} numberOfLines={1}>
             {name}
           </Text>
-          <Text style={styles.subtitle} numberOfLines={1}>
-            Reciter
-          </Text>
+          {showFollowAlong ? (
+            <View style={styles.subtitleRow}>
+              <FollowAlongBadge />
+            </View>
+          ) : (
+            <Text style={styles.subtitle} numberOfLines={1}>
+              Reciter
+            </Text>
+          )}
         </>
       )}
     </>


### PR DESCRIPTION
## Summary

Both `components/browse/BrowseReciterCard.tsx` and `components/cards/CircularReciterCard.tsx` declare `showFollowAlong?: boolean` in their props interface but never destructure or render it. When a caller passes `showFollowAlong={true}` (e.g. via the `useReciterFollowAlong` hook surfaced through `RecitersView.tsx`), the badge silently disappears on both card variants — only the list-row variant (`components/ReciterItem.tsx`) renders it.

Same shape as the `imageUrl` prop drop fixed in #244.

## Changes

- `components/browse/BrowseReciterCard.tsx`: destructure `showFollowAlong`; render `<FollowAlongBadge />` in a new flex row alongside the rewayat label. Added `showFollowAlong` to the `React.memo` comparison so toggles re-render.
- `components/cards/CircularReciterCard.tsx`: destructure `showFollowAlong`; render `<FollowAlongBadge />` in the subtitle slot when true, replacing the static "Reciter" label.

## How I found it

`react/no-unused-prop-types` ESLint rule (landed via #248) — both cards showed up as findings. 2 real bugs in the inherited 236-finding count. The remaining ones are mostly RN `renderItem` `ListRenderItemInfo<T>` false positives and some IconProps shared-interface stylistic choices.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Tested on Qariah fork with `useReciterFollowAlong(reciterId)` returning true; badge now renders on both card variants in the home grid + reciter carousel.
- [ ] Visual regression: when `showFollowAlong={false}` (default), card layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)