### PR TITLE
feat(branding): theme color overrides for fork customization

### DIFF
--- a/config/branding.d.ts
+++ b/config/branding.d.ts
@@ -5,6 +5,30 @@ export interface BrandingCatalogConfig {
   fallbackPath?: string;
 }
 
+/**
+ * Optional color overrides applied on top of the chosen mode's palette.
+ * Each key is shallow-merged into lightColors/darkColors inside createTheme.
+ * Forks may override only the keys they care about; unspecified keys fall
+ * through to Bayaan's defaults.
+ */
+export interface BrandingThemeOverrides {
+  background?: string;
+  secondary?: string;
+  card?: string;
+  border?: string;
+  text?: string;
+  accent?: string;
+  error?: string;
+}
+
+/** Branding-level theme customization. All fields optional. */
+export interface BrandingTheme {
+  /** Overrides applied when the active color scheme is 'light'. */
+  lightOverrides?: BrandingThemeOverrides;
+  /** Overrides applied when the active color scheme is 'dark'. */
+  darkOverrides?: BrandingThemeOverrides;
+}
+
 /** App identity values that vary across forks. */
 export interface Branding {
   appName: string;
@@ -17,6 +41,8 @@ export interface Branding {
   shareBaseUrl: string;
   emailProductName: string;
   catalog: BrandingCatalogConfig;
+  /** Optional theming hooks for forks. Bayaan defaults to absent (no overrides). */
+  theme?: BrandingTheme;
 }
 
 declare const branding: Branding;

--- a/utils/themeUtils.ts
+++ b/utils/themeUtils.ts
@@ -6,6 +6,7 @@ import {
 } from '@/styles/colorSchemes';
 import {Dimensions, ColorSchemeName, Appearance} from 'react-native';
 import {PHONE_SCALE_CAP} from '@/utils/responsive';
+import branding from '@/config/branding';
 
 const {width} = Dimensions.get('window');
 // Clamp scaling base so tablets (iPad) do not inflate the theme typography.
@@ -30,9 +31,19 @@ export const createTheme = (
     effectiveColorScheme = colorScheme === 'dark' ? 'dark' : 'light';
   }
 
+  const baseColors =
+    effectiveColorScheme === 'dark' ? darkColors : lightColors;
+  // Optional fork-supplied overrides. Bayaan ships with no `theme` key, so
+  // these are typically undefined and the spread is a no-op.
+  const overrides =
+    effectiveColorScheme === 'dark'
+      ? branding.theme?.darkOverrides
+      : branding.theme?.lightOverrides;
+
   return {
     colors: {
-      ...(effectiveColorScheme === 'dark' ? darkColors : lightColors),
+      ...baseColors,
+      ...(overrides ?? {}),
       primary: primaryColors[primaryColor],
     },
     isDarkMode: effectiveColorScheme === 'dark',


### PR DESCRIPTION
## Summary

Adds an optional `theme` namespace to `config/branding` that lets a fork override the light- and dark-mode color palette without touching `styles/colorSchemes.ts` or `utils/themeUtils.ts`. Today every fork that wants a different color identity has to either patch `colorSchemes.ts` directly (high merge friction) or live with one of the 16 hard-coded `primaryColors`. This PR replaces both with a config-only override, extending the RFC-007 multi-tenancy seam.

## Motivation

RFC-007 established `config/branding.js` as the seam for fork-overridable identity values (app name, bundle id, support URLs, catalog source). Color identity is one of the most visible "is this Bayaan or not?" signals — but currently a fork's only color knob is picking from `primaryColors[16]`, which doesn't cover warm/editorial palettes (terracotta, brass, sage, etc.).

The immediate consumer (Qariah) ships a warm Terracotta & Sage palette that needs custom values for `background`, `text`, `border`, and `accent`. Without this seam, Qariah would have to fork `styles/colorSchemes.ts`, taking on a recurring merge tax on every weekly upstream sync.

The override is purely additive — Bayaan's defaults are unchanged when `branding.theme` is absent or empty.

## Design

`config/branding.d.ts` — new optional types:

```ts
export interface BrandingThemeOverrides {
  background?: string;
  secondary?: string;
  card?: string;
  border?: string;
  text?: string;
  accent?: string;
  error?: string;
}

export interface BrandingTheme {
  lightOverrides?: BrandingThemeOverrides;
  darkOverrides?: BrandingThemeOverrides;
}

export interface Branding {
  // …existing fields…
  theme?: BrandingTheme;  // optional; absent on Bayaan
}
```

`utils/themeUtils.ts` — single shallow-merge inside \`createTheme\`:

```ts
const baseColors = effectiveColorScheme === 'dark' ? darkColors : lightColors;
const overrides = effectiveColorScheme === 'dark'
  ? branding.theme?.darkOverrides
  : branding.theme?.lightOverrides;

return {
  colors: {
    ...baseColors,
    ...(overrides ?? {}),
    primary: primaryColors[primaryColor],
  },
  // …unchanged…
};
```

That's the full change. Three lines added, one removed in \`themeUtils.ts\`; new types in \`branding.d.ts\`. Override > base palette; every key not specified falls through to Bayaan's defaults — meaning a fork can recolor only \`background\` and keep Bayaan's other tokens, no all-or-nothing.

## Why shallow-merge instead of a full ThemeProvider

- **Zero new abstractions.** \`createTheme\` keeps the same signature; \`Theme\` type is unchanged; every consumer (\`useTheme\`, navigation theme builder, ScaledSheet factories) keeps working as-is.
- **Predictable precedence.** Override > base palette. Per-key opt-in.
- **Cheap to reason about.** The diff fits in a screenshot.

## What's NOT in this PR (deferred)

- **Multi-accent palettes** (\`accent2\`/\`accent3\` for category-tile gradients). Forks that need these can override per-tile colors in their own data files. If demand emerges for a typed multi-accent system, that's a follow-up.
- **Custom \`primaryColor\` registry entries.** Forks needing a primary outside the 16 hardcoded options can use \`lightOverrides.accent\`. Adding to \`primaryColors\` is a separate PR.
- **\`branding.theme.defaultPrimaryColor\`.** That seed belongs in \`store/themeStore.ts\` (persisted store init), not \`themeUtils.ts\`. Out of scope here.

## Backward compatibility

- \`branding.theme\` is optional; absent on Bayaan today.
- \`lightOverrides\`/\`darkOverrides\` are both optional sub-fields.
- The \`??\` fallback in \`themeUtils.ts\` ensures \`undefined\` overrides spread to nothing.
- No type breaks, no runtime breaks, no asset changes.

## Test plan

- [x] \`tsc --noEmit\` clean locally.
- [ ] CI lint + tests pass.
- [ ] Bayaan boot-gate (iOS + Android): app launches, theme renders identical to pre-PR (visual diff).
- [ ] Manual smoke: temporarily add \`theme: {lightOverrides: {background: '#ff0000'}}\` to \`config/branding.js\`, confirm light-mode background turns red. Verify removal restores normal appearance.

## Companion fork PR

Qariah will land a no-op shim of this change immediately after merge: removes its local \`QARIAH-PENDING-UPSTREAM\` patch and starts using \`theme.lightOverrides\` directly in its \`config/branding.js\`.