### PR TITLE
feat(branding): tab label overrides for fork customization

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -14,6 +14,17 @@ import {FloatingPlayer} from '@/components/player/v2/FloatingPlayer';
 import {TabletSidebar} from '@/components/tablet/TabletSidebar';
 import {useResponsive} from '@/hooks/useResponsive';
 import {USE_GLASS} from '@/hooks/useGlassProps';
+import branding from '@/config/branding';
+
+// Resolved once at module load. Bayaan's defaults are used when a fork
+// hasn't supplied a `branding.tabs.<name>.label` override.
+const tabLabels = {
+  home: branding.tabs?.home?.label ?? 'Home',
+  surahs: branding.tabs?.surahs?.label ?? 'Surahs',
+  search: branding.tabs?.search?.label ?? 'Search',
+  collection: branding.tabs?.collection?.label ?? 'Collection',
+  settings: branding.tabs?.settings?.label ?? 'Settings',
+};
 
 // PNG tab icons for NativeTabs (iOS) — template-rendered by the native tab bar
 const tabIcons = {
@@ -66,7 +77,7 @@ function IOSTabs() {
         name="(a.home)"
         contentStyle={{backgroundColor: theme.colors.background}}>
         <NativeTabs.Trigger.Icon src={tabIcons.home} renderingMode="template" />
-        <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
+        <NativeTabs.Trigger.Label>{tabLabels.home}</NativeTabs.Trigger.Label>
       </NativeTabs.Trigger>
 
       <NativeTabs.Trigger
@@ -76,7 +87,7 @@ function IOSTabs() {
           src={tabIcons.surahs}
           renderingMode="template"
         />
-        <NativeTabs.Trigger.Label>Surahs</NativeTabs.Trigger.Label>
+        <NativeTabs.Trigger.Label>{tabLabels.surahs}</NativeTabs.Trigger.Label>
       </NativeTabs.Trigger>
 
       <NativeTabs.Trigger
@@ -87,7 +98,7 @@ function IOSTabs() {
           src={tabIcons.search}
           renderingMode="template"
         />
-        <NativeTabs.Trigger.Label>Search</NativeTabs.Trigger.Label>
+        <NativeTabs.Trigger.Label>{tabLabels.search}</NativeTabs.Trigger.Label>
       </NativeTabs.Trigger>
 
       <NativeTabs.Trigger
@@ -97,7 +108,7 @@ function IOSTabs() {
           src={tabIcons.collection}
           renderingMode="template"
         />
-        <NativeTabs.Trigger.Label>Collection</NativeTabs.Trigger.Label>
+        <NativeTabs.Trigger.Label>{tabLabels.collection}</NativeTabs.Trigger.Label>
       </NativeTabs.Trigger>
 
       <NativeTabs.Trigger
@@ -106,7 +117,7 @@ function IOSTabs() {
         <NativeTabs.Trigger.Icon
           sf={{default: 'gearshape', selected: 'gearshape.fill'}}
         />
-        <NativeTabs.Trigger.Label>Settings</NativeTabs.Trigger.Label>
+        <NativeTabs.Trigger.Label>{tabLabels.settings}</NativeTabs.Trigger.Label>
       </NativeTabs.Trigger>
     </NativeTabs>
   );
@@ -128,11 +139,17 @@ function AndroidTabs() {
           },
         }}
         tabBar={tabBarComponent}>
-        <Tabs.Screen name="(a.home)" options={{title: 'Home'}} />
-        <Tabs.Screen name="(b.surahs)" options={{title: 'Surahs'}} />
-        <Tabs.Screen name="(b.search)" options={{title: 'Search'}} />
-        <Tabs.Screen name="(c.collection)" options={{title: 'Collection'}} />
-        <Tabs.Screen name="(d.settings)" options={{title: 'Settings'}} />
+        <Tabs.Screen name="(a.home)" options={{title: tabLabels.home}} />
+        <Tabs.Screen name="(b.surahs)" options={{title: tabLabels.surahs}} />
+        <Tabs.Screen name="(b.search)" options={{title: tabLabels.search}} />
+        <Tabs.Screen
+          name="(c.collection)"
+          options={{title: tabLabels.collection}}
+        />
+        <Tabs.Screen
+          name="(d.settings)"
+          options={{title: tabLabels.settings}}
+        />
       </Tabs>
       <FloatingPlayer />
     </View>
@@ -160,11 +177,17 @@ function TabletTabs() {
           },
         }}
         tabBar={tabletSidebarComponent}>
-        <Tabs.Screen name="(a.home)" options={{title: 'Home'}} />
-        <Tabs.Screen name="(b.surahs)" options={{title: 'Surahs'}} />
-        <Tabs.Screen name="(b.search)" options={{title: 'Search'}} />
-        <Tabs.Screen name="(c.collection)" options={{title: 'Collection'}} />
-        <Tabs.Screen name="(d.settings)" options={{title: 'Settings'}} />
+        <Tabs.Screen name="(a.home)" options={{title: tabLabels.home}} />
+        <Tabs.Screen name="(b.surahs)" options={{title: tabLabels.surahs}} />
+        <Tabs.Screen name="(b.search)" options={{title: tabLabels.search}} />
+        <Tabs.Screen
+          name="(c.collection)"
+          options={{title: tabLabels.collection}}
+        />
+        <Tabs.Screen
+          name="(d.settings)"
+          options={{title: tabLabels.settings}}
+        />
       </Tabs>
     </View>
   );

--- a/config/branding.d.ts
+++ b/config/branding.d.ts
@@ -5,6 +5,29 @@ export interface BrandingCatalogConfig {
   fallbackPath?: string;
 }
 
+/**
+ * Optional per-tab overrides. Currently labels only.
+ *
+ * Icons are intentionally not part of this seam — Bayaan's tab icons span
+ * three rendering surfaces (iOS NativeTabs PNG `require()`, Android
+ * `BottomTabBar` component switch, tablet sidebar same switch) and a
+ * fork-overridable icon registry that preserves Metro static analysis is
+ * a substantially larger refactor that should land via its own RFC.
+ */
+export interface BrandingTab {
+  /** Display label. Defaults to Bayaan's hardcoded value. */
+  label?: string;
+}
+
+/** Per-tab branding for the bottom tab bar / tablet sidebar. */
+export interface BrandingTabs {
+  home?: BrandingTab;
+  surahs?: BrandingTab;
+  search?: BrandingTab;
+  collection?: BrandingTab;
+  settings?: BrandingTab;
+}
+
 /** App identity values that vary across forks. */
 export interface Branding {
   appName: string;
@@ -17,6 +40,8 @@ export interface Branding {
   shareBaseUrl: string;
   emailProductName: string;
   catalog: BrandingCatalogConfig;
+  /** Optional tab-bar customization for forks. Bayaan defaults to absent. */
+  tabs?: BrandingTabs;
 }
 
 declare const branding: Branding;


### PR DESCRIPTION
## Summary

Adds an optional `tabs` namespace to `config/branding` so a fork can rename the bottom tabs (Home / Surahs / Search / Collection / Settings) without patching `app/(tabs)/_layout.tsx`. Today these labels are hardcoded in three places (iOS NativeTabs, Android `Tabs.Screen`, tablet sidebar `Tabs.Screen`) and any rename produces an 8-line diff that conflicts on every upstream merge.

Extends RFC-007 (App-layer multi-tenancy seams). Zero behavior change for Bayaan.

## Motivation

RFC-007 covered identity strings (`appName`, support URLs, etc.) but didn't extend to in-app navigation copy. Forks regularly want different framing — Qariah is renaming "Home" to "Listen" (audio-focused product) and "Surahs" to "Mushaf" (Arabic-first audience), and other forks have asked about similar tweaks.

The current alternative is a local patch to 15 string literals across `_layout.tsx` (5 in `IOSTabs`, 5 in `AndroidTabs`, 5 in `TabletTabs`). And `_layout.tsx` is exactly the file that gets touched whenever upstream adds a tab feature (mini-player, tablet sidebar, etc.), maximizing conflict risk.

The override is purely additive — every label falls back to Bayaan's current string when the config key is absent.

## Scope: labels only, not icons

This PR intentionally **does not** add icon overrides. Bayaan's tab icons are wired through three different surfaces:

- iOS NativeTabs: PNG `require()` calls bundled at compile time (Metro static-analysis requirement).
- Android `BottomTabBar`: switch on `routeName` returning React component (`HomeIcon`, `QuranIcon`, …).
- Tablet sidebar: same switch as Android.

Refactoring to a fork-overridable icon registry while preserving NativeTabs' template rendering and Metro's static `require()` discovery is a substantially larger change that would benefit from its own RFC. Forks needing a different icon (Qariah wants headphones for the renamed "Listen" tab) can do a small local edit to the three switch cases — much narrower than the 15-string label changes this PR addresses.

## Design

`config/branding.d.ts`:

```ts
export interface BrandingTab {
  label?: string;
}

export interface BrandingTabs {
  home?: BrandingTab;
  surahs?: BrandingTab;
  search?: BrandingTab;
  collection?: BrandingTab;
  settings?: BrandingTab;
}

export interface Branding {
  // …existing fields…
  tabs?: BrandingTabs;  // optional; absent on Bayaan
}
```

`app/(tabs)/_layout.tsx`:

```ts
import branding from '@/config/branding';

const tabLabels = {
  home: branding.tabs?.home?.label ?? 'Home',
  surahs: branding.tabs?.surahs?.label ?? 'Surahs',
  search: branding.tabs?.search?.label ?? 'Search',
  collection: branding.tabs?.collection?.label ?? 'Collection',
  settings: branding.tabs?.settings?.label ?? 'Settings',
};

// IOSTabs:   <NativeTabs.Trigger.Label>{tabLabels.home}</NativeTabs.Trigger.Label>
// AndroidTabs / TabletTabs:   <Tabs.Screen … options={{title: tabLabels.home}} />
```

That's the entire diff: one import, one constant table, and search-and-replace of 15 string literals across three layout components. `BottomTabBar` and `TabletSidebar` both already read `options.title` from React Navigation, so they pick up the override automatically without further changes.

## Why labels-only and not a full tab registry

A fully generic tab system (`branding.tabs = [...]` with arbitrary route names, ordering, hide/show flags) sounds tempting but blows up scope:

- Route names are filesystem-bound (`app/(tabs)/(a.home)` etc.); reordering or hiding requires Expo Router config + screen reachability handling.
- `BottomTabBar`'s icon switch + navigation hooks would need to become dynamic.
- Tablet sidebar has additional layout logic (rail vs. labeled, mini-player dock).

**Labels-only is the 80/20** — covers every fork-renaming use case I've heard, with a ~60-line diff and zero structural change. If/when there's clear demand for tab reordering or hide flags, that's a separate RFC.

## Backward compatibility

- `branding.tabs` is optional; absent on Bayaan today.
- Each `tabs.<name>.label` is optional; nullish-coalesces to the current hardcoded string.
- No type breaks, no runtime breaks, no asset changes.
- Tablet sidebar inherits via React Navigation `options.title` — no separate override path needed.

## Test plan

- [x] `tsc --noEmit` clean locally.
- [ ] CI lint + tests pass.
- [ ] Bayaan boot-gate (iOS + Android + iPad): all five tab labels render as "Home / Surahs / Search / Collection / Settings" — visual regression check.
- [ ] Manual smoke: temporarily add `tabs: {home: {label: 'TEST'}}` to `config/branding.js`, confirm label updates on iOS NativeTabs, Android BottomTabBar, and tablet sidebar. Verify removal restores normal appearance.

## Companion fork PR

Qariah will land a no-op shim of this change immediately after merge: removes its local `QARIAH-PENDING-UPSTREAM` patch and starts using `tabs: {home: {label: 'Listen'}, surahs: {label: 'Mushaf'}}` directly in its `config/branding.js`.