### PR TITLE
fix(mushaf-player-options): routes refactor + range ordering + speed binding

### DIFF
--- a/components/sheets/MushafPlayerOptionsSheet.tsx
+++ b/components/sheets/MushafPlayerOptionsSheet.tsx
@@ -1,25 +1,29 @@
 /**
  * MushafPlayerOptionsSheet - Comprehensive playback settings
  *
- * Consolidates reciter selection, verse range, speed, repeat counts,
- * quick-select shortcuts, and a "Play Audio" CTA into a single sheet.
+ * Single sheet, multiple routes:
+ *   - `main` — Playback Settings (rows for verse range / reciter, chip groups
+ *     for speed and repeats, Play CTA).
+ *   - `pick-start-verse` / `pick-end-verse` — Two-step (surah → ayah) verse
+ *     picker. Picking commits to the parent's draft state and routes back.
+ *   - `pick-reciter` — Reciter list. Tapping commits and routes back.
+ *
+ * Each route owns its own single ScrollView so we never nest vertical
+ * scrollables inside the sheet's gesture-bound scroll surface — pickers
+ * slide in/out via the library's `routes` API instead of expanding inline.
  */
 
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {
-  View,
-  Text,
-  Pressable,
-  ScrollView as RNScrollView,
-  StyleSheet,
-} from 'react-native';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
 import {ScaledSheet, moderateScale as ms} from 'react-native-size-matters';
 import {Feather, Ionicons} from '@expo/vector-icons';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-} from 'react-native-reanimated';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useTheme} from '@/hooks/useTheme';
 import {Theme} from '@/utils/themeUtils';
@@ -27,6 +31,9 @@ import ActionSheet, {
   SheetProps,
   SheetManager,
   ScrollView,
+  type Route,
+  type RouteScreenProps,
+  type Router,
 } from 'react-native-actions-sheet';
 import {
   useMushafPlayerStore,
@@ -56,439 +63,171 @@ const RANGE_REPEAT_OPTIONS = [
   {label: 'Loop', value: 0},
 ];
 
-type AccordionSection = 'startVerse' | 'endVerse' | 'reciter' | null;
-type VersePick = 'surahList' | 'ayahGrid';
+// ---------------------------------------------------------------------------
+// Verse-key helpers
+// ---------------------------------------------------------------------------
 
-// ---------------------------------------------------------------------------
-// Helper: format verse key to display string
-// ---------------------------------------------------------------------------
+function parseVerseKey(key: string): {surah: number; ayah: number} {
+  const [s, a] = key.split(':').map(Number);
+  return {surah: s, ayah: a};
+}
+
 function formatVerseKey(verseKey: string): string {
-  const [s, a] = verseKey.split(':').map(Number);
-  if (s < 1 || s > 114) return verseKey;
-  return `${SURAHS[s - 1].name} ${s}:${a}`;
+  const {surah, ayah} = parseVerseKey(verseKey);
+  if (surah < 1 || surah > 114) return verseKey;
+  return `${SURAHS[surah - 1].name} ${surah}:${ayah}`;
+}
+
+// Returns negative if a < b, zero if equal, positive if a > b. Used to keep
+// the range from going backwards: a new start that's past the current end
+// drags end forward, and a new end that's before the current start drags
+// start back.
+function compareVerseKeys(a: string, b: string): number {
+  const ap = parseVerseKey(a);
+  const bp = parseVerseKey(b);
+  return ap.surah !== bp.surah ? ap.surah - bp.surah : ap.ayah - bp.ayah;
 }
 
 // ---------------------------------------------------------------------------
-// Accordion Chevron
+// Sheet-scoped state (shared across routes)
 // ---------------------------------------------------------------------------
-const AnimatedChevron: React.FC<{expanded: boolean; color: string}> = ({
-  expanded,
-  color,
+
+interface SheetState {
+  startVerseKey: string;
+  endVerseKey: string;
+  selectedRewayatId: string | null;
+  selectedReciterName: string | null;
+  verseRepeat: number;
+  rangeRepeat: number;
+  setStartVerseKey: (key: string) => void;
+  setEndVerseKey: (key: string) => void;
+  setReciter: (rewayatId: string, name: string) => void;
+  setVerseRepeat: (count: number) => void;
+  setRangeRepeat: (count: number) => void;
+  canPlay: boolean;
+  handlePlayAudio: () => void;
+}
+
+const SheetStateContext = createContext<SheetState | null>(null);
+
+function useSheetState(): SheetState {
+  const ctx = useContext(SheetStateContext);
+  if (!ctx) {
+    throw new Error(
+      'useSheetState must be used inside MushafPlayerOptionsSheet',
+    );
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Header (back chevron + title) shared by picker routes
+// ---------------------------------------------------------------------------
+
+const RouteHeader: React.FC<{title: string; onBack: () => void}> = ({
+  title,
+  onBack,
 }) => {
-  const rotation = useSharedValue(0);
-  useEffect(() => {
-    rotation.value = withTiming(expanded ? 180 : 0, {duration: 200});
-  }, [expanded, rotation]);
-  const animStyle = useAnimatedStyle(() => ({
-    transform: [{rotate: `${rotation.value}deg`}],
-  }));
+  const {theme} = useTheme();
+  const styles = createStyles(theme);
   return (
-    <Animated.View style={animStyle}>
-      <Ionicons name="chevron-down" size={ms(16)} color={color} />
-    </Animated.View>
+    <View style={styles.routeHeader}>
+      <Pressable
+        onPress={onBack}
+        hitSlop={12}
+        style={styles.routeHeaderBackButton}>
+        <Ionicons name="chevron-back" size={ms(20)} color={theme.colors.text} />
+      </Pressable>
+      <Text style={styles.routeHeaderTitle}>{title}</Text>
+      <View style={styles.routeHeaderSpacer} />
+    </View>
   );
 };
 
 // ---------------------------------------------------------------------------
-// FadedScrollList — fixed-height scrollable area with bottom fade
-// ---------------------------------------------------------------------------
-const ACCORDION_MAX_HEIGHT = ms(240);
-
-const AccordionScrollList: React.FC<{children: React.ReactNode}> = ({
-  children,
-}) => (
-  <RNScrollView
-    style={{maxHeight: ACCORDION_MAX_HEIGHT}}
-    nestedScrollEnabled
-    showsVerticalScrollIndicator={false}
-    bounces={false}>
-    {children}
-  </RNScrollView>
-);
-
-// ---------------------------------------------------------------------------
-// Component
+// Row button (used on main route for the verse / reciter nav rows)
 // ---------------------------------------------------------------------------
 
-export const MushafPlayerOptionsSheet = (
-  props: SheetProps<'mushaf-player-options'>,
-) => {
+const RowButton: React.FC<{
+  label?: string;
+  value: string;
+  onPress: () => void;
+}> = ({label, value, onPress}) => {
+  const {theme} = useTheme();
+  const styles = createStyles(theme);
+  return (
+    <Pressable
+      style={({pressed}) => [
+        styles.dropdownRow,
+        pressed && styles.dropdownRowPressed,
+      ]}
+      onPress={onPress}>
+      {label ? <Text style={styles.dropdownLabel}>{label}</Text> : null}
+      <Text
+        style={[styles.dropdownValue, !label && {textAlign: 'left'}]}
+        numberOfLines={1}>
+        {value}
+      </Text>
+      <Ionicons
+        name="chevron-forward"
+        size={ms(16)}
+        color={theme.colors.textSecondary}
+      />
+    </Pressable>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Main route — Playback Settings
+// ---------------------------------------------------------------------------
+
+const MainRoute: React.FC<RouteScreenProps> = ({router}) => {
   const {theme} = useTheme();
   const styles = createStyles(theme);
   const insets = useSafeAreaInsets();
+  const state = useSheetState();
+  // Reactive store binding — no local copy, so persisted rate is reflected
+  // as soon as zustand/persist rehydrates from AsyncStorage.
+  const rate = useMushafPlayerStore(s => s.rate);
 
-  const currentPage = props.payload?.currentPage ?? 1;
-
-  // Store selectors
-  const storeRewayatId = useMushafPlayerStore(s => s.rewayatId);
-  const storeReciterName = useMushafPlayerStore(s => s.reciterName);
-  const storeRate = useMushafPlayerStore(s => s.rate);
-  const storeVerseRepeat = useMushafPlayerStore(s => s.verseRepeatCount);
-  const storeRangeRepeat = useMushafPlayerStore(s => s.rangeRepeatCount);
-  const availableReciters = useMushafPlayerStore(s => s.availableReciters);
-
-  // Compute defaults for this page, falling back to store range if available
-  const storeRangeStart = useMushafPlayerStore(s => s.rangeStart);
-  const storeRangeEnd = useMushafPlayerStore(s => s.rangeEnd);
-  const pageVerseKeys = useMemo(
-    () => mushafVerseMapService.getOrderedVerseKeysForPage(currentPage),
-    [currentPage],
-  );
-  const defaultStart = storeRangeStart
-    ? `${storeRangeStart.surah}:${storeRangeStart.ayah}`
-    : (pageVerseKeys[0] ?? '1:1');
-  const defaultEnd = storeRangeEnd
-    ? `${storeRangeEnd.surah}:${storeRangeEnd.ayah}`
-    : (pageVerseKeys[pageVerseKeys.length - 1] ?? '1:7');
-
-  // Local state — applied only on "Play Audio"
-  const [startVerseKey, setStartVerseKey] = useState(defaultStart);
-  const [endVerseKey, setEndVerseKey] = useState(defaultEnd);
-  const [selectedRewayatId, setSelectedRewayatId] = useState<string | null>(
-    storeRewayatId,
-  );
-  const [selectedReciterName, setSelectedReciterName] = useState<string | null>(
-    storeReciterName,
-  );
-  const [rate, setRate] = useState(storeRate);
-  const [verseRepeat, setVerseRepeat] = useState(storeVerseRepeat);
-  const [rangeRepeat, setRangeRepeat] = useState(storeRangeRepeat);
-
-  // Accordion
-  const [expandedSection, setExpandedSection] =
-    useState<AccordionSection>(null);
-
-  // Verse picker sub-state
-  const [startPickStep, setStartPickStep] = useState<VersePick>('surahList');
-  const [endPickStep, setEndPickStep] = useState<VersePick>('surahList');
-  const [startPickSurah, setStartPickSurah] = useState<number | null>(null);
-  const [endPickSurah, setEndPickSurah] = useState<number | null>(null);
-
-  // Pre-populate from pending start verse if set
-  useEffect(() => {
-    const pending = useMushafPlayerStore.getState().pendingStartVerseKey;
-    if (pending) {
-      setStartVerseKey(pending);
-    }
-  }, []);
-
-  // Compute reciters on mount
-  useEffect(() => {
-    if (availableReciters.length === 0) {
-      useMushafPlayerStore.getState().computeAvailableReciters();
-    }
-  }, [availableReciters.length]);
-
-  // Apply rate change immediately for live preview
   const handleRateChange = useCallback((newRate: number) => {
-    setRate(newRate);
     useMushafPlayerStore.getState().setRate(newRate);
   }, []);
 
-  const toggleSection = useCallback(
-    (section: AccordionSection) => {
-      setExpandedSection(prev => {
-        if (prev === section) return null;
-        // Pre-select the already-chosen surah so the picker opens to the ayah grid
-        if (section === 'startVerse') {
-          const [s] = startVerseKey.split(':').map(Number);
-          if (s >= 1 && s <= 114) {
-            setStartPickSurah(s);
-            setStartPickStep('ayahGrid');
-          } else {
-            setStartPickStep('surahList');
-            setStartPickSurah(null);
-          }
-        }
-        if (section === 'endVerse') {
-          const [s] = endVerseKey.split(':').map(Number);
-          if (s >= 1 && s <= 114) {
-            setEndPickSurah(s);
-            setEndPickStep('ayahGrid');
-          } else {
-            setEndPickStep('surahList');
-            setEndPickSurah(null);
-          }
-        }
-        return section;
-      });
-    },
-    [startVerseKey, endVerseKey],
-  );
-
-  // Handle surah selection in verse picker
-  const handleStartSurahPick = useCallback((surahId: number) => {
-    setStartPickSurah(surahId);
-    setStartPickStep('ayahGrid');
-  }, []);
-
-  const handleEndSurahPick = useCallback((surahId: number) => {
-    setEndPickSurah(surahId);
-    setEndPickStep('ayahGrid');
-  }, []);
-
-  const handleStartAyahPick = useCallback(
-    (ayah: number) => {
-      if (!startPickSurah) return;
-      setStartVerseKey(`${startPickSurah}:${ayah}`);
-      setExpandedSection(null);
-    },
-    [startPickSurah],
-  );
-
-  const handleEndAyahPick = useCallback(
-    (ayah: number) => {
-      if (!endPickSurah) return;
-      setEndVerseKey(`${endPickSurah}:${ayah}`);
-      setExpandedSection(null);
-    },
-    [endPickSurah],
-  );
-
-  // Reciter selection
-  const handleReciterSelect = useCallback((reciter: AvailableReciter) => {
-    setSelectedRewayatId(reciter.rewayatId);
-    setSelectedReciterName(reciter.reciterName);
-    setExpandedSection(null);
-  }, []);
-
-  // Play Audio
-  const canPlay = !!selectedRewayatId;
-
-  const handlePlayAudio = useCallback(() => {
-    if (!selectedRewayatId || !selectedReciterName) return;
-
-    const store = useMushafPlayerStore.getState();
-    store.stop();
-
-    // Apply settings
-    store.setReciter(selectedRewayatId, selectedReciterName);
-
-    const [startS, startA] = startVerseKey.split(':').map(Number);
-    const [endS, endA] = endVerseKey.split(':').map(Number);
-    store.setRange({surah: startS, ayah: startA}, {surah: endS, ayah: endA});
-
-    store.setRate(rate);
-    store.setVerseRepeatCount(verseRepeat);
-    store.setRangeRepeatCount(rangeRepeat);
-
-    store.startPlayback(currentPage, startVerseKey);
-    SheetManager.hide('mushaf-player-options');
-  }, [
-    selectedRewayatId,
-    selectedReciterName,
-    startVerseKey,
-    endVerseKey,
-    rate,
-    verseRepeat,
-    rangeRepeat,
-    currentPage,
-  ]);
-
-  // ---------------------------------------------------------------------------
-  // Render helpers
-  // ---------------------------------------------------------------------------
-
-  const renderSurahList = (onSelect: (surahId: number) => void) => (
-    <View>
-      {SURAHS.map(item => (
-        <Pressable
-          key={item.id}
-          style={({pressed}) => [
-            styles.pickerRow,
-            pressed && styles.pickerRowPressed,
-          ]}
-          onPress={() => onSelect(item.id)}>
-          <Text style={styles.pickerRowNumber}>{item.id}</Text>
-          <Text style={styles.pickerRowText}>{item.name}</Text>
-          <Ionicons
-            name="chevron-forward"
-            size={ms(14)}
-            color={theme.colors.textSecondary}
-          />
-        </Pressable>
-      ))}
-    </View>
-  );
-
-  const renderAyahGrid = (
-    surahId: number,
-    onSelect: (ayah: number) => void,
-    onBack: () => void,
-  ) => {
-    const versesCount = SURAHS[surahId - 1]?.verses_count ?? 1;
-    const ayahs = Array.from({length: versesCount}, (_, i) => i + 1);
-    return (
-      <View>
-        <Pressable style={styles.pickerBackRow} onPress={onBack}>
-          <Ionicons
-            name="chevron-back"
-            size={ms(16)}
-            color={theme.colors.text}
-          />
-          <Text style={styles.pickerBackText}>{SURAHS[surahId - 1].name}</Text>
-        </Pressable>
-        <View style={styles.ayahGrid}>
-          {ayahs.map(a => (
-            <Pressable
-              key={a}
-              style={({pressed}) => [
-                styles.ayahChip,
-                pressed && styles.ayahChipPressed,
-              ]}
-              onPress={() => onSelect(a)}>
-              <Text style={styles.ayahChipText}>{a}</Text>
-            </Pressable>
-          ))}
-        </View>
-      </View>
-    );
-  };
-
   return (
-    <ActionSheet
-      id={props.sheetId}
-      containerStyle={styles.sheetContainer}
-      indicatorStyle={styles.indicator}
-      gestureEnabled={true}>
+    <View style={styles.routeContainer}>
       <ScrollView
         style={styles.scrollView}
-        contentContainerStyle={styles.container}
+        contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
         bounces={true}>
-        {/* Title */}
         <Text style={styles.title}>Playback Settings</Text>
 
-        {/* ============================================================== */}
-        {/* Select Range                                                   */}
-        {/* ============================================================== */}
+        {/* Select Range */}
         <View style={styles.section}>
           <Text style={styles.sectionLabel}>Select Range</Text>
-
-          {/* Starting Verse */}
-          <Pressable
-            style={({pressed}) => [
-              styles.dropdownRow,
-              pressed && styles.dropdownRowPressed,
-            ]}
-            onPress={() => toggleSection('startVerse')}>
-            <Text style={styles.dropdownLabel}>Starting Verse</Text>
-            <Text style={styles.dropdownValue} numberOfLines={1}>
-              {formatVerseKey(startVerseKey)}
-            </Text>
-            <AnimatedChevron
-              expanded={expandedSection === 'startVerse'}
-              color={theme.colors.textSecondary}
-            />
-          </Pressable>
-          {expandedSection === 'startVerse' && (
-            <View style={styles.accordionContent}>
-              <AccordionScrollList>
-                {startPickStep === 'surahList'
-                  ? renderSurahList(handleStartSurahPick)
-                  : startPickSurah
-                    ? renderAyahGrid(startPickSurah, handleStartAyahPick, () =>
-                        setStartPickStep('surahList'),
-                      )
-                    : null}
-              </AccordionScrollList>
-            </View>
-          )}
-
-          {/* Ending Verse */}
-          <Pressable
-            style={({pressed}) => [
-              styles.dropdownRow,
-              pressed && styles.dropdownRowPressed,
-            ]}
-            onPress={() => toggleSection('endVerse')}>
-            <Text style={styles.dropdownLabel}>Ending Verse</Text>
-            <Text style={styles.dropdownValue} numberOfLines={1}>
-              {formatVerseKey(endVerseKey)}
-            </Text>
-            <AnimatedChevron
-              expanded={expandedSection === 'endVerse'}
-              color={theme.colors.textSecondary}
-            />
-          </Pressable>
-          {expandedSection === 'endVerse' && (
-            <View style={styles.accordionContent}>
-              <AccordionScrollList>
-                {endPickStep === 'surahList'
-                  ? renderSurahList(handleEndSurahPick)
-                  : endPickSurah
-                    ? renderAyahGrid(endPickSurah, handleEndAyahPick, () =>
-                        setEndPickStep('surahList'),
-                      )
-                    : null}
-              </AccordionScrollList>
-            </View>
-          )}
+          <RowButton
+            label="Starting Verse"
+            value={formatVerseKey(state.startVerseKey)}
+            onPress={() => router.navigate('pick-start-verse')}
+          />
+          <RowButton
+            label="Ending Verse"
+            value={formatVerseKey(state.endVerseKey)}
+            onPress={() => router.navigate('pick-end-verse')}
+          />
         </View>
 
-        {/* ============================================================== */}
-        {/* Reciter                                                        */}
-        {/* ============================================================== */}
+        {/* Reciter */}
         <View style={styles.section}>
           <Text style={styles.sectionLabel}>Reciter</Text>
-          <Pressable
-            style={({pressed}) => [
-              styles.dropdownRow,
-              pressed && styles.dropdownRowPressed,
-            ]}
-            onPress={() => toggleSection('reciter')}>
-            <Text
-              style={[styles.dropdownValue, {textAlign: 'left'}]}
-              numberOfLines={1}>
-              {selectedReciterName || 'Select Reciter'}
-            </Text>
-            <AnimatedChevron
-              expanded={expandedSection === 'reciter'}
-              color={theme.colors.textSecondary}
-            />
-          </Pressable>
-          {expandedSection === 'reciter' && (
-            <View style={styles.accordionContent}>
-              <AccordionScrollList>
-                <View>
-                  {availableReciters.map(item => {
-                    const isSelected = item.rewayatId === selectedRewayatId;
-                    return (
-                      <Pressable
-                        key={item.rewayatId}
-                        style={({pressed}) => [
-                          styles.reciterRow,
-                          isSelected && styles.reciterRowSelected,
-                          pressed && styles.pickerRowPressed,
-                        ]}
-                        onPress={() => handleReciterSelect(item)}>
-                        <View style={styles.reciterInfo}>
-                          <Text style={styles.reciterName} numberOfLines={1}>
-                            {item.reciterName}
-                          </Text>
-                          <Text style={styles.reciterStyle} numberOfLines={1}>
-                            {item.style}
-                          </Text>
-                        </View>
-                        {isSelected && (
-                          <Feather
-                            name="check"
-                            size={ms(16)}
-                            color={theme.colors.text}
-                          />
-                        )}
-                      </Pressable>
-                    );
-                  })}
-                </View>
-              </AccordionScrollList>
-            </View>
-          )}
+          <RowButton
+            value={state.selectedReciterName ?? 'Select Reciter'}
+            onPress={() => router.navigate('pick-reciter')}
+          />
         </View>
 
-        {/* ============================================================== */}
-        {/* Play speed                                                     */}
-        {/* ============================================================== */}
+        {/* Play speed */}
         <View style={styles.section}>
           <Text style={styles.sectionLabel}>Play speed</Text>
           <View style={styles.chipRowFlex}>
@@ -512,19 +251,17 @@ export const MushafPlayerOptionsSheet = (
           </View>
         </View>
 
-        {/* ============================================================== */}
-        {/* Play each verse                                                */}
-        {/* ============================================================== */}
+        {/* Verse repeat */}
         <View style={styles.section}>
           <Text style={styles.sectionLabel}>Play each verse</Text>
           <View style={styles.chipRowFlex}>
             {VERSE_REPEAT_OPTIONS.map(opt => {
-              const isActive = verseRepeat === opt.value;
+              const isActive = state.verseRepeat === opt.value;
               return (
                 <Pressable
                   key={opt.value}
                   style={[styles.chipFlex, isActive && styles.chipActive]}
-                  onPress={() => setVerseRepeat(opt.value)}>
+                  onPress={() => state.setVerseRepeat(opt.value)}>
                   <Text
                     style={[
                       styles.chipText,
@@ -538,19 +275,17 @@ export const MushafPlayerOptionsSheet = (
           </View>
         </View>
 
-        {/* ============================================================== */}
-        {/* Play the range                                                 */}
-        {/* ============================================================== */}
+        {/* Range repeat */}
         <View style={styles.section}>
           <Text style={styles.sectionLabel}>Play the range</Text>
           <View style={styles.chipRowFlex}>
             {RANGE_REPEAT_OPTIONS.map(opt => {
-              const isActive = rangeRepeat === opt.value;
+              const isActive = state.rangeRepeat === opt.value;
               return (
                 <Pressable
                   key={opt.value}
                   style={[styles.chipFlex, isActive && styles.chipActive]}
-                  onPress={() => setRangeRepeat(opt.value)}>
+                  onPress={() => state.setRangeRepeat(opt.value)}>
                   <Text
                     style={[
                       styles.chipText,
@@ -565,18 +300,21 @@ export const MushafPlayerOptionsSheet = (
         </View>
       </ScrollView>
 
-      {/* Sticky Play Audio CTA — pinned outside scroll */}
+      {/* Sticky Play CTA */}
       <View
         style={[styles.stickyFooter, {paddingBottom: insets.bottom + ms(4)}]}>
         <Pressable
-          style={[styles.playButton, !canPlay && styles.playButtonDisabled]}
-          onPress={handlePlayAudio}
-          disabled={!canPlay}>
+          style={[
+            styles.playButton,
+            !state.canPlay && styles.playButtonDisabled,
+          ]}
+          onPress={state.handlePlayAudio}
+          disabled={!state.canPlay}>
           <Ionicons
             name="play"
             size={ms(16)}
             color={
-              canPlay
+              state.canPlay
                 ? theme.colors.text
                 : Color(theme.colors.text).alpha(0.25).toString()
             }
@@ -584,13 +322,382 @@ export const MushafPlayerOptionsSheet = (
           <Text
             style={[
               styles.playButtonText,
-              !canPlay && styles.playButtonTextDisabled,
+              !state.canPlay && styles.playButtonTextDisabled,
             ]}>
             Play
           </Text>
         </Pressable>
       </View>
-    </ActionSheet>
+    </View>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Verse picker (used by both pick-start-verse and pick-end-verse routes)
+// ---------------------------------------------------------------------------
+
+const VersePickerRoute: React.FC<{
+  router: Router;
+  endpoint: 'start' | 'end';
+}> = ({router, endpoint}) => {
+  const {theme} = useTheme();
+  const styles = createStyles(theme);
+  const state = useSheetState();
+
+  const currentKey =
+    endpoint === 'start' ? state.startVerseKey : state.endVerseKey;
+  const commit =
+    endpoint === 'start' ? state.setStartVerseKey : state.setEndVerseKey;
+  const title = endpoint === 'start' ? 'Starting Verse' : 'Ending Verse';
+
+  // Two-step state: pick surah → pick ayah. Initialized from the current
+  // selection so the picker opens to the matching surah's ayah grid by
+  // default (matches the previous accordion behaviour).
+  const initial = parseVerseKey(currentKey);
+  const inRange = initial.surah >= 1 && initial.surah <= 114;
+  const [step, setStep] = useState<'surahList' | 'ayahGrid'>(
+    inRange ? 'ayahGrid' : 'surahList',
+  );
+  const [pickedSurah, setPickedSurah] = useState<number | null>(
+    inRange ? initial.surah : null,
+  );
+
+  // Reset two-step state to track the current selection whenever this
+  // route is re-entered (e.g. user goes back to main, opens it again).
+  // Without this, the picker would still be on whatever step it was last
+  // left in for the wrong endpoint.
+  useEffect(() => {
+    const parsed = parseVerseKey(currentKey);
+    const valid = parsed.surah >= 1 && parsed.surah <= 114;
+    setPickedSurah(valid ? parsed.surah : null);
+    setStep(valid ? 'ayahGrid' : 'surahList');
+  }, [currentKey]);
+
+  const handleSurahPick = useCallback((surahId: number) => {
+    setPickedSurah(surahId);
+    setStep('ayahGrid');
+  }, []);
+
+  const handleAyahPick = useCallback(
+    (ayah: number) => {
+      if (!pickedSurah) return;
+      commit(`${pickedSurah}:${ayah}`);
+      router.goBack();
+    },
+    [pickedSurah, commit, router],
+  );
+
+  const handleBack = useCallback(() => {
+    if (step === 'ayahGrid') {
+      setStep('surahList');
+      return;
+    }
+    router.goBack();
+  }, [step, router]);
+
+  return (
+    <View style={styles.routeContainer}>
+      <RouteHeader
+        title={
+          step === 'ayahGrid' && pickedSurah
+            ? SURAHS[pickedSurah - 1].name
+            : title
+        }
+        onBack={handleBack}
+      />
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        bounces={true}>
+        {step === 'surahList' ? (
+          <View>
+            {SURAHS.map(item => (
+              <Pressable
+                key={item.id}
+                style={({pressed}) => [
+                  styles.pickerRow,
+                  pressed && styles.pickerRowPressed,
+                ]}
+                onPress={() => handleSurahPick(item.id)}>
+                <Text style={styles.pickerRowNumber}>{item.id}</Text>
+                <Text style={styles.pickerRowText}>{item.name}</Text>
+                <Ionicons
+                  name="chevron-forward"
+                  size={ms(14)}
+                  color={theme.colors.textSecondary}
+                />
+              </Pressable>
+            ))}
+          </View>
+        ) : pickedSurah ? (
+          <View style={styles.ayahGrid}>
+            {Array.from(
+              {length: SURAHS[pickedSurah - 1]?.verses_count ?? 1},
+              (_, i) => i + 1,
+            ).map(a => (
+              <Pressable
+                key={a}
+                style={({pressed}) => [
+                  styles.ayahChip,
+                  pressed && styles.ayahChipPressed,
+                ]}
+                onPress={() => handleAyahPick(a)}>
+                <Text style={styles.ayahChipText}>{a}</Text>
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
+      </ScrollView>
+    </View>
+  );
+};
+
+const PickStartVerseRoute: React.FC<RouteScreenProps> = ({router}) => (
+  <VersePickerRoute router={router} endpoint="start" />
+);
+
+const PickEndVerseRoute: React.FC<RouteScreenProps> = ({router}) => (
+  <VersePickerRoute router={router} endpoint="end" />
+);
+
+// ---------------------------------------------------------------------------
+// Reciter picker route
+// ---------------------------------------------------------------------------
+
+const PickReciterRoute: React.FC<RouteScreenProps> = ({router}) => {
+  const {theme} = useTheme();
+  const styles = createStyles(theme);
+  const state = useSheetState();
+  const availableReciters = useMushafPlayerStore(s => s.availableReciters);
+
+  const handleSelect = useCallback(
+    (reciter: AvailableReciter) => {
+      state.setReciter(reciter.rewayatId, reciter.reciterName);
+      router.goBack();
+    },
+    [state, router],
+  );
+
+  return (
+    <View style={styles.routeContainer}>
+      <RouteHeader title="Reciter" onBack={() => router.goBack()} />
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        bounces={true}>
+        <View>
+          {availableReciters.map(item => {
+            const isSelected = item.rewayatId === state.selectedRewayatId;
+            return (
+              <Pressable
+                key={item.rewayatId}
+                style={({pressed}) => [
+                  styles.reciterRow,
+                  isSelected && styles.reciterRowSelected,
+                  pressed && styles.pickerRowPressed,
+                ]}
+                onPress={() => handleSelect(item)}>
+                <View style={styles.reciterInfo}>
+                  <Text style={styles.reciterName} numberOfLines={1}>
+                    {item.reciterName}
+                  </Text>
+                  <Text style={styles.reciterStyle} numberOfLines={1}>
+                    {item.style}
+                  </Text>
+                </View>
+                {isSelected && (
+                  <Feather
+                    name="check"
+                    size={ms(16)}
+                    color={theme.colors.text}
+                  />
+                )}
+              </Pressable>
+            );
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Route table (declared at module scope so identities are stable across renders)
+// ---------------------------------------------------------------------------
+
+const ROUTES: Route[] = [
+  {name: 'main', component: MainRoute},
+  {name: 'pick-start-verse', component: PickStartVerseRoute},
+  {name: 'pick-end-verse', component: PickEndVerseRoute},
+  {name: 'pick-reciter', component: PickReciterRoute},
+];
+
+// ---------------------------------------------------------------------------
+// Sheet entry point
+// ---------------------------------------------------------------------------
+
+export const MushafPlayerOptionsSheet = (
+  props: SheetProps<'mushaf-player-options'>,
+) => {
+  const {theme} = useTheme();
+  const styles = createStyles(theme);
+  const currentPage = props.payload?.currentPage ?? 1;
+
+  // Persisted store fields read once for initialising local drafts. The
+  // persisted `rate` is read reactively inside the main route so it
+  // reflects post-rehydration values automatically.
+  const storeRewayatId = useMushafPlayerStore(s => s.rewayatId);
+  const storeReciterName = useMushafPlayerStore(s => s.reciterName);
+  const storeVerseRepeat = useMushafPlayerStore(s => s.verseRepeatCount);
+  const storeRangeRepeat = useMushafPlayerStore(s => s.rangeRepeatCount);
+  const storeRangeStart = useMushafPlayerStore(s => s.rangeStart);
+  const storeRangeEnd = useMushafPlayerStore(s => s.rangeEnd);
+  const availableReciters = useMushafPlayerStore(s => s.availableReciters);
+
+  const pageVerseKeys = useMemo(
+    () => mushafVerseMapService.getOrderedVerseKeysForPage(currentPage),
+    [currentPage],
+  );
+  const defaultStart = storeRangeStart
+    ? `${storeRangeStart.surah}:${storeRangeStart.ayah}`
+    : (pageVerseKeys[0] ?? '1:1');
+  const defaultEnd = storeRangeEnd
+    ? `${storeRangeEnd.surah}:${storeRangeEnd.ayah}`
+    : (pageVerseKeys[pageVerseKeys.length - 1] ?? '1:7');
+
+  const [startVerseKey, setStartVerseKeyRaw] = useState(defaultStart);
+  const [endVerseKey, setEndVerseKeyRaw] = useState(defaultEnd);
+  const [selectedRewayatId, setSelectedRewayatId] = useState<string | null>(
+    storeRewayatId,
+  );
+  const [selectedReciterName, setSelectedReciterName] = useState<string | null>(
+    storeReciterName,
+  );
+  const [verseRepeat, setVerseRepeat] = useState(storeVerseRepeat);
+  const [rangeRepeat, setRangeRepeat] = useState(storeRangeRepeat);
+
+  // Range-ordering enforcement: a new start past the current end drags end
+  // forward; a new end before the current start drags start back. Prevents
+  // backwards ranges that the playback logic in mushafPlayerStore.startPlayback
+  // doesn't handle.
+  const setStartVerseKey = useCallback(
+    (key: string) => {
+      setStartVerseKeyRaw(key);
+      if (compareVerseKeys(key, endVerseKey) > 0) {
+        setEndVerseKeyRaw(key);
+      }
+    },
+    [endVerseKey],
+  );
+
+  const setEndVerseKey = useCallback(
+    (key: string) => {
+      setEndVerseKeyRaw(key);
+      if (compareVerseKeys(key, startVerseKey) < 0) {
+        setStartVerseKeyRaw(key);
+      }
+    },
+    [startVerseKey],
+  );
+
+  const setReciter = useCallback((rewayatId: string, name: string) => {
+    setSelectedRewayatId(rewayatId);
+    setSelectedReciterName(name);
+  }, []);
+
+  // Pre-populate from a pending start verse if one was queued before opening.
+  useEffect(() => {
+    const pending = useMushafPlayerStore.getState().pendingStartVerseKey;
+    if (pending) {
+      setStartVerseKeyRaw(pending);
+    }
+  }, []);
+
+  // Compute reciters on mount if not already done.
+  useEffect(() => {
+    if (availableReciters.length === 0) {
+      useMushafPlayerStore.getState().computeAvailableReciters();
+    }
+  }, [availableReciters.length]);
+
+  const canPlay = !!selectedRewayatId;
+
+  const handlePlayAudio = useCallback(() => {
+    if (!selectedRewayatId || !selectedReciterName) return;
+
+    const store = useMushafPlayerStore.getState();
+    store.stop();
+    store.setReciter(selectedRewayatId, selectedReciterName);
+
+    const start = parseVerseKey(startVerseKey);
+    const end = parseVerseKey(endVerseKey);
+    store.setRange(
+      {surah: start.surah, ayah: start.ayah},
+      {surah: end.surah, ayah: end.ayah},
+    );
+
+    // rate is bound directly to the store via the speed chips, so it's
+    // already current; only the repeat counts need explicit commits.
+    store.setVerseRepeatCount(verseRepeat);
+    store.setRangeRepeatCount(rangeRepeat);
+
+    store.startPlayback(currentPage, startVerseKey);
+    SheetManager.hide('mushaf-player-options');
+  }, [
+    selectedRewayatId,
+    selectedReciterName,
+    startVerseKey,
+    endVerseKey,
+    verseRepeat,
+    rangeRepeat,
+    currentPage,
+  ]);
+
+  const value = useMemo<SheetState>(
+    () => ({
+      startVerseKey,
+      endVerseKey,
+      selectedRewayatId,
+      selectedReciterName,
+      verseRepeat,
+      rangeRepeat,
+      setStartVerseKey,
+      setEndVerseKey,
+      setReciter,
+      setVerseRepeat,
+      setRangeRepeat,
+      canPlay,
+      handlePlayAudio,
+    }),
+    [
+      startVerseKey,
+      endVerseKey,
+      selectedRewayatId,
+      selectedReciterName,
+      verseRepeat,
+      rangeRepeat,
+      setStartVerseKey,
+      setEndVerseKey,
+      setReciter,
+      canPlay,
+      handlePlayAudio,
+    ],
+  );
+
+  return (
+    <SheetStateContext.Provider value={value}>
+      <ActionSheet
+        id={props.sheetId}
+        containerStyle={styles.sheetContainer}
+        indicatorStyle={styles.indicator}
+        gestureEnabled
+        enableRouterBackNavigation
+        routes={ROUTES}
+        initialRoute="main"
+      />
+    </SheetStateContext.Provider>
   );
 };
 
@@ -616,15 +723,43 @@ const createStyles = (theme: Theme) =>
       width: ms(40),
       height: 2.5,
     },
+
+    routeContainer: {
+      flex: 1,
+      minHeight: ms(420),
+    },
     scrollView: {
       flexGrow: 0,
     },
-    container: {
+    scrollContent: {
       paddingHorizontal: ms(20),
       paddingTop: ms(12),
     },
 
-    // Title
+    // Picker header
+    routeHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: ms(8),
+      paddingVertical: ms(8),
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: Color(theme.colors.text).alpha(0.06).toString(),
+    },
+    routeHeaderBackButton: {
+      padding: ms(6),
+    },
+    routeHeaderTitle: {
+      flex: 1,
+      textAlign: 'center',
+      fontSize: ms(15),
+      fontFamily: 'Manrope-SemiBold',
+      color: theme.colors.text,
+    },
+    routeHeaderSpacer: {
+      width: ms(32),
+    },
+
+    // Title (main route)
     title: {
       fontSize: ms(20),
       fontFamily: 'Manrope-Bold',
@@ -643,7 +778,7 @@ const createStyles = (theme: Theme) =>
       marginBottom: ms(10),
     },
 
-    // Dropdown rows
+    // Row buttons (main route)
     dropdownRow: {
       flexDirection: 'row',
       alignItems: 'center',
@@ -671,20 +806,12 @@ const createStyles = (theme: Theme) =>
       marginRight: ms(8),
     },
 
-    // Accordion content
-    accordionContent: {
-      backgroundColor: Color(theme.colors.text).alpha(0.03).toString(),
-      borderRadius: ms(12),
-      marginBottom: ms(8),
-      overflow: 'hidden',
-    },
-
-    // Verse picker rows
+    // Picker rows
     pickerRow: {
       flexDirection: 'row',
       alignItems: 'center',
       paddingVertical: ms(12),
-      paddingHorizontal: ms(16),
+      paddingHorizontal: ms(4),
     },
     pickerRowPressed: {
       backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
@@ -702,30 +829,18 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.text,
     },
 
-    // Verse picker back button + ayah grid
-    pickerBackRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: ms(10),
-      paddingHorizontal: ms(12),
-      gap: ms(4),
-    },
-    pickerBackText: {
-      fontSize: ms(14),
-      fontFamily: 'Manrope-SemiBold',
-      color: theme.colors.text,
-    },
+    // Ayah grid
     ayahGrid: {
       flexDirection: 'row',
       flexWrap: 'wrap',
-      paddingHorizontal: ms(12),
+      paddingTop: ms(4),
       paddingBottom: ms(12),
       gap: ms(8),
     },
     ayahChip: {
-      width: ms(36),
-      height: ms(36),
-      borderRadius: ms(8),
+      width: ms(44),
+      height: ms(44),
+      borderRadius: ms(10),
       backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
       justifyContent: 'center',
       alignItems: 'center',
@@ -734,17 +849,17 @@ const createStyles = (theme: Theme) =>
       backgroundColor: Color(theme.colors.text).alpha(0.12).toString(),
     },
     ayahChipText: {
-      fontSize: ms(13),
+      fontSize: ms(14),
       fontFamily: 'Manrope-SemiBold',
       color: theme.colors.text,
     },
 
-    // Reciter picker rows
+    // Reciter rows
     reciterRow: {
       flexDirection: 'row',
       alignItems: 'center',
       paddingVertical: ms(12),
-      paddingHorizontal: ms(16),
+      paddingHorizontal: ms(12),
       borderRadius: ms(8),
     },
     reciterRowSelected: {
@@ -766,17 +881,17 @@ const createStyles = (theme: Theme) =>
       textTransform: 'capitalize',
     },
 
-    // Chips (wrap)
-    chipRow: {
+    // Chips
+    chipRowFlex: {
       flexDirection: 'row',
-      flexWrap: 'wrap',
       gap: ms(8),
     },
-    chip: {
+    chipFlex: {
+      flex: 1,
       paddingVertical: ms(8),
-      paddingHorizontal: ms(16),
       borderRadius: ms(20),
       backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+      alignItems: 'center',
     },
     chipActive: {
       backgroundColor: Color(theme.colors.text).alpha(0.15).toString(),
@@ -790,19 +905,6 @@ const createStyles = (theme: Theme) =>
       color: theme.colors.text,
     },
 
-    // Chips (flex: 1 row)
-    chipRowFlex: {
-      flexDirection: 'row',
-      gap: ms(8),
-    },
-    chipFlex: {
-      flex: 1,
-      paddingVertical: ms(8),
-      borderRadius: ms(20),
-      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
-      alignItems: 'center',
-    },
-
     // Sticky footer
     stickyFooter: {
       paddingHorizontal: ms(20),
@@ -810,8 +912,6 @@ const createStyles = (theme: Theme) =>
       borderTopWidth: StyleSheet.hairlineWidth,
       borderTopColor: Color(theme.colors.text).alpha(0.1).toString(),
     },
-
-    // Play Audio button
     playButton: {
       flexDirection: 'row',
       alignItems: 'center',


### PR DESCRIPTION
## Summary
Three related fixes to the Playback Settings sheet (opened from the mushaf player bar), all in `components/sheets/MushafPlayerOptionsSheet.tsx`.

### 1. Sheet scrollability (systematic, not just a one-off patch)
The previous sheet nested a plain `react-native` `ScrollView` (capped at 240px, with Android-only `nestedScrollEnabled`) inside `react-native-actions-sheet`'s gesture-bound `ScrollView`. The two scroll surfaces and the sheet's drag-to-dismiss gesture fought each other; on iOS the inner accordion barely scrolled at all.

The fix uses the library's first-class `routes` API: the sheet now has named routes (`main`, `pick-start-verse`, `pick-end-verse`, `pick-reciter`) that slide horizontally inside the same sheet instance (the Apple Music "Add to a Playlist" pattern). Each route owns a single `ScrollView`. No nested vertical scrollables, no `nestedScrollEnabled` hacks, no `gestureEnabled` toggling. The pattern is reusable for any future sheet that needs sub-flows.

### 2. Range ordering enforcement
Picking a Starting Verse that's past the current End now drags End forward to match. Picking an Ending Verse before the current Start drags Start back. The range can no longer go backwards (which the playback logic in `mushafPlayerStore.startPlayback` had no sane path for).

### 3. Playback speed binding
The speed chips now read `rate` directly via `useMushafPlayerStore(s => s.rate)` and write through `store.setRate` on press. The previous `useState(storeRate)` latched at mount, which on cold-start raced with AsyncStorage rehydration:
- the chip showed 1x regardless of the persisted value (stale activation)
- tapping Play wrote that stale 1x back to the store, overwriting the persisted rate (reset to 1x on restart)

## Test plan
- [ ] Open the Playback Settings sheet from the mushaf player bar.
- [ ] Tap **Starting Verse**: the sheet slides to a surah-list picker with a back chevron, then to an ayah grid. Picking commits and slides back to main.
- [ ] Same for **Ending Verse** and **Reciter**.
- [ ] Pick a starting verse past the current end (e.g. start=`Al-Fatiha 1:5`, then pick end=`Al-Baqarah 2:3`, then pick a new start=`Al-Baqarah 2:50`): ending verse should auto-update to match the new start.
- [ ] Pick an ending verse before the current start: starting verse should auto-update.
- [ ] Set speed to 1.5x. Kill app. Re-open mushaf, open sheet: the **1.5x** chip is active.
- [ ] Tap Play: audio plays at 1.5x (not 1x).
- [ ] Verify back-chevron in a picker, hardware back button (Android), and backdrop tap all behave sensibly.
- [ ] Long surah picker (Al-Baqarah, 286 ayahs) scrolls smoothly inside the ayah grid route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)