### PR TITLE
feat: branding.listenTabTopComponent slot (RFC-008)

### DIFF
--- a/components/RecitersView.tsx
+++ b/components/RecitersView.tsx
@@ -725,6 +725,11 @@ function RecitersView({onReciterPress}: RecitersViewProps) {
 
   const homeRowConfig = branding.homeRowConfig ?? DEFAULT_HOME_ROW_CONFIG;
 
+  // RFC-008 — Listen-tab top-region slot. Forks may replace the default
+  // `RecitersHero` via `branding.listenTabTopComponent`; capitalised here
+  // so it can be used as a JSX element. `undefined` keeps Bayaan's hero.
+  const ListenTabTopComponent = branding.listenTabTopComponent;
+
   return (
     <ScrollView
       style={styles.container}
@@ -736,8 +741,10 @@ function RecitersView({onReciterPress}: RecitersViewProps) {
       contentInsetAdjustmentBehavior={USE_GLASS ? 'automatic' : 'never'}
       showsVerticalScrollIndicator={false}
       removeClippedSubviews={true}>
-      {/* Use the unified RecitersHero component */}
-      <RecitersHero />
+      {/* RFC-008 — Listen-tab top region. Default is the unified
+       * `RecitersHero`; forks may substitute their own via
+       * `branding.listenTabTopComponent`. */}
+      {ListenTabTopComponent ? <ListenTabTopComponent /> : <RecitersHero />}
 
       {homeRowConfig
         .filter(row => row.enabled)

--- a/config/branding.d.ts
+++ b/config/branding.d.ts
@@ -1,3 +1,5 @@
+import type {ComponentType} from 'react';
+
 /** Catalog source config for the active branding. */
 export interface BrandingCatalogConfig {
   source: 'bundled' | 'remote';
@@ -33,6 +35,16 @@ export interface HomeRow {
   /** Whether this row renders. Rows whose data is empty still self-hide. */
   enabled: boolean;
 }
+
+/**
+ * Props passed to a fork's `listenTabTopComponent` (RFC-008).
+ *
+ * Reserved for future extension — the slot starts with no required props
+ * so forks can ship a plain `() => JSX.Element`. Any future additions
+ * (theming context, navigation hooks, …) must default to optional so
+ * existing implementations keep compiling.
+ */
+export interface ListenTabTopComponentProps {}
 
 /** App identity values that vary across forks. */
 export interface Branding {
@@ -81,6 +93,17 @@ export interface Branding {
    * always the source of truth on cold-start.
    */
   catalogVersionEndpoint?: string;
+  /**
+   * RFC-008 — optional component that replaces the Listen-tab top
+   * region (the default `RecitersHero`). Forks return a React
+   * component; `undefined` keeps Bayaan's `RecitersHero` verbatim.
+   *
+   * The component renders directly inside the Listen-tab ScrollView at
+   * the top, above the rows controlled by `homeRowConfig`. It receives
+   * no required props today; `ListenTabTopComponentProps` is a slot for
+   * future extension.
+   */
+  listenTabTopComponent?: ComponentType<ListenTabTopComponentProps>;
 }
 
 declare const branding: Branding;


### PR DESCRIPTION
## Summary

Implements the **RFC-008** component slot (`docs/rfcs/008-listen-tab-top-slot.md`, merged doc-only via #261).

Adds an optional `listenTabTopComponent` to the `Branding` interface. When a fork sets it, it replaces the Listen-tab top region — currently the hardcoded `<RecitersHero />` in `RecitersView.tsx` — with the fork-provided component. `undefined` (Bayaan's default) keeps `RecitersHero` rendering verbatim.

This retires the last merge-conflict-prone hardcoded JSX line in `RecitersView.tsx`, completing what #260 (`branding.homeRowConfig`) started for the rows below the hero.

## Changes

- `config/branding.d.ts` — `import type {ComponentType}`; new `ListenTabTopComponentProps` interface (empty slot for future extension); new optional `Branding.listenTabTopComponent` field.
- `components/RecitersView.tsx` — conditional render: `listenTabTopComponent` when set, else `RecitersHero`.

~20 lines total. Bayaan behaviour is byte-identical when the slot is unset.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Default path unchanged — `RecitersHero` still renders when `listenTabTopComponent` is undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)