### PR TITLE
chore: route brand strings through branding.appName

### DIFF
--- a/app/(tabs)/(a.home)/adhkar/[superId]/[dhikrId].tsx
+++ b/app/(tabs)/(a.home)/adhkar/[superId]/[dhikrId].tsx
@@ -30,6 +30,7 @@ import {useAdhkarAudioStore} from '@/store/adhkarAudioStore';
 import {useAdhkarPlayAllStore} from '@/store/adhkarPlayAllStore';
 import {useHeaderHeight} from '@react-navigation/elements';
 import {dhikrShareUrl, shareUrl} from '@/utils/shareUtils';
+import branding from '@/config/branding';
 
 const {width: SCREEN_WIDTH} = Dimensions.get('window');
 
@@ -186,7 +187,7 @@ const DhikrReaderScreen: React.FC = () => {
   const handleShareDhikr = useCallback(() => {
     if (!superId || !currentDhikr) return;
     const url = dhikrShareUrl(superId, currentDhikr.id);
-    shareUrl(url, `Check out this dhikr on Bayaan`);
+    shareUrl(url, `Check out this dhikr on ${branding.appName}`);
   }, [superId, currentDhikr]);
 
   // Set native header with title + position subtitle

--- a/app/(tabs)/(a.home)/adhkar/[superId]/index.tsx
+++ b/app/(tabs)/(a.home)/adhkar/[superId]/index.tsx
@@ -38,6 +38,7 @@ import {useAdhkarPlayAllStore} from '@/store/adhkarPlayAllStore';
 import {useHeaderHeight} from '@react-navigation/elements';
 import {adhkarShareUrl, shareUrl} from '@/utils/shareUtils';
 import {analyticsService} from '@/services/analytics/AnalyticsService';
+import branding from '@/config/branding';
 
 interface DhikrItem {
   dhikr: Dhikr;
@@ -172,7 +173,7 @@ const SuperCategoryListScreen: React.FC = () => {
   const handleShare = useCallback(() => {
     if (!superId) return;
     const url = adhkarShareUrl(superId);
-    shareUrl(url, `Check out ${displayTitle} on Bayaan`);
+    shareUrl(url, `Check out ${displayTitle} on ${branding.appName}`);
   }, [superId, displayTitle]);
 
   // Play All handler

--- a/app/(tabs)/(d.settings)/_layout.tsx
+++ b/app/(tabs)/(d.settings)/_layout.tsx
@@ -2,6 +2,7 @@ import {Stack} from 'expo-router';
 import {useTheme} from '@/hooks/useTheme';
 import {USE_GLASS} from '@/hooks/useGlassProps';
 import {MaxWidthContainer} from '@/components/layout/MaxWidthContainer';
+import branding from '@/config/branding';
 
 export default function SettingsLayout() {
   const {theme} = useTheme();
@@ -9,45 +10,51 @@ export default function SettingsLayout() {
   return (
     <MaxWidthContainer>
       <Stack
-      screenOptions={{
-        headerShown: true,
-        freezeOnBlur: true,
-        headerTintColor: theme.colors.text,
-        ...(USE_GLASS
-          ? {
-              headerTransparent: true,
-              headerStyle: {backgroundColor: 'transparent'},
-            }
-          : {
-              headerStyle: {backgroundColor: theme.colors.background},
-            }),
-        headerTitleStyle: {
-          fontFamily: 'Manrope-SemiBold',
-          color: theme.colors.text,
-        },
-        headerShadowVisible: false,
-        headerBackButtonDisplayMode: 'minimal',
-      }}>
-      <Stack.Screen name="index" options={{headerShown: false}} />
-      <Stack.Screen name="storage" options={{title: 'Storage'}} />
-      <Stack.Screen name="about" options={{title: 'About Bayaan'}} />
-      <Stack.Screen name="credits" options={{title: 'Credits'}} />
-      <Stack.Screen
-        name="mushaf-settings"
-        options={{title: 'Mushaf Settings'}}
-      />
-      <Stack.Screen
-        name="default-reciter"
-        options={{title: 'Default Reciter'}}
-      />
-      <Stack.Screen name="reciter-choice" options={{title: 'Reciter Choice'}} />
-      <Stack.Screen name="account" options={{title: 'Account'}} />
-      <Stack.Screen
-        name="translations"
-        options={{title: 'Translations & Tafaseer'}}
-      />
-      <Stack.Screen name="reading-theme" options={{title: 'Reading Theme'}} />
-      <Stack.Screen name="whats-new" options={{title: "What's New"}} />
+        screenOptions={{
+          headerShown: true,
+          freezeOnBlur: true,
+          headerTintColor: theme.colors.text,
+          ...(USE_GLASS
+            ? {
+                headerTransparent: true,
+                headerStyle: {backgroundColor: 'transparent'},
+              }
+            : {
+                headerStyle: {backgroundColor: theme.colors.background},
+              }),
+          headerTitleStyle: {
+            fontFamily: 'Manrope-SemiBold',
+            color: theme.colors.text,
+          },
+          headerShadowVisible: false,
+          headerBackButtonDisplayMode: 'minimal',
+        }}>
+        <Stack.Screen name="index" options={{headerShown: false}} />
+        <Stack.Screen name="storage" options={{title: 'Storage'}} />
+        <Stack.Screen
+          name="about"
+          options={{title: `About ${branding.appName}`}}
+        />
+        <Stack.Screen name="credits" options={{title: 'Credits'}} />
+        <Stack.Screen
+          name="mushaf-settings"
+          options={{title: 'Mushaf Settings'}}
+        />
+        <Stack.Screen
+          name="default-reciter"
+          options={{title: 'Default Reciter'}}
+        />
+        <Stack.Screen
+          name="reciter-choice"
+          options={{title: 'Reciter Choice'}}
+        />
+        <Stack.Screen name="account" options={{title: 'Account'}} />
+        <Stack.Screen
+          name="translations"
+          options={{title: 'Translations & Tafaseer'}}
+        />
+        <Stack.Screen name="reading-theme" options={{title: 'Reading Theme'}} />
+        <Stack.Screen name="whats-new" options={{title: "What's New"}} />
       </Stack>
     </MaxWidthContainer>
   );

--- a/components/MushafSettingsContent.tsx
+++ b/components/MushafSettingsContent.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/constants/mushafAllahHighlight';
 import {getRewayahShortLabel} from '@/utils/rewayahLabels';
 import {showToast} from '@/utils/toastUtils';
+import branding from '@/config/branding';
 import {
   ALL_REWAYAH_IDS,
   getDescription,
@@ -676,7 +677,7 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
       if (switchingToQCF) {
         Alert.alert(
           'Mushaf 1440 Beta',
-          'Mushaf 1440 is Bayaan’s most modern mushaf pipeline, but it is still in beta. Some features are currently disabled, including tajweed coloring and rewayah switching.',
+          `Mushaf 1440 is ${branding.appName}’s most modern mushaf pipeline, but it is still in beta. Some features are currently disabled, including tajweed coloring and rewayah switching.`,
         );
       }
     },

--- a/components/mushaf/main.tsx
+++ b/components/mushaf/main.tsx
@@ -25,6 +25,7 @@ import {useTheme} from '@/hooks/useTheme';
 import {useReadingThemeColors} from '@/hooks/useReadingThemeColors';
 import {Ionicons, Feather} from '@expo/vector-icons';
 import {mushafShareUrl, shareUrl} from '@/utils/shareUtils';
+import branding from '@/config/branding';
 import {SheetManager} from 'react-native-actions-sheet';
 import {GlassView} from 'expo-glass-effect';
 import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
@@ -218,18 +219,18 @@ const DKPageView: React.FC<{
                     borderBottomRightRadius: EDGE_BORDER_RADIUS,
                   }
                 : isRightPage
-                ? {
-                    left: 0,
-                    right: EDGE_HORIZONTAL_INSET,
-                    borderTopRightRadius: EDGE_BORDER_RADIUS,
-                    borderBottomRightRadius: EDGE_BORDER_RADIUS,
-                  }
-                : {
-                    left: EDGE_HORIZONTAL_INSET,
-                    right: 0,
-                    borderTopLeftRadius: EDGE_BORDER_RADIUS,
-                    borderBottomLeftRadius: EDGE_BORDER_RADIUS,
-                  },
+                  ? {
+                      left: 0,
+                      right: EDGE_HORIZONTAL_INSET,
+                      borderTopRightRadius: EDGE_BORDER_RADIUS,
+                      borderBottomRightRadius: EDGE_BORDER_RADIUS,
+                    }
+                  : {
+                      left: EDGE_HORIZONTAL_INSET,
+                      right: 0,
+                      borderTopLeftRadius: EDGE_BORDER_RADIUS,
+                      borderBottomLeftRadius: EDGE_BORDER_RADIUS,
+                    },
             ]}
           />
         </>
@@ -687,7 +688,10 @@ export default function MushafViewer({
 
   const handleSharePage = useCallback(() => {
     const url = mushafShareUrl(currentPage, isDarkMode ? 'dark' : 'light');
-    shareUrl(url, `Check out page ${currentPage} of the Quran on Bayaan`);
+    shareUrl(
+      url,
+      `Check out page ${currentPage} of the Quran on ${branding.appName}`,
+    );
   }, [currentPage, isDarkMode]);
 
   // iOS 26: configure Stack navigator header based on current mode

--- a/components/reciter-profile/ReciterProfile.tsx
+++ b/components/reciter-profile/ReciterProfile.tsx
@@ -64,6 +64,7 @@ import {useNavigation} from 'expo-router';
 import {useHeaderHeight} from '@react-navigation/elements';
 import {USE_GLASS} from '@/hooks/useGlassProps';
 import {reciterShareUrl, shareUrl} from '@/utils/shareUtils';
+import branding from '@/config/branding';
 import {analyticsService} from '@/services/analytics/AnalyticsService';
 import {getDisplayLabelFromName} from '@/services/rewayah/RewayahIdentity';
 
@@ -290,7 +291,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                   const slug = reciter?.slug ?? currentReciterId;
                   shareUrl(
                     reciterShareUrl(slug),
-                    `Listen to ${reciter?.name ?? 'this reciter'} on Bayaan`,
+                    `Listen to ${reciter?.name ?? 'this reciter'} on ${branding.appName}`,
                   );
                 }}
                 hitSlop={8}>
@@ -1162,7 +1163,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                 const slug = reciter?.slug ?? currentReciterId;
                 shareUrl(
                   reciterShareUrl(slug),
-                  `Listen to ${reciter?.name ?? 'this reciter'} on Bayaan`,
+                  `Listen to ${reciter?.name ?? 'this reciter'} on ${branding.appName}`,
                 );
               }}
             />

--- a/components/share/ShareCardPreview.tsx
+++ b/components/share/ShareCardPreview.tsx
@@ -188,7 +188,7 @@ const ShareCardPreview: React.FC<ShareCardPreviewProps> = ({
           y += elements.rewayahLabelHeight;
         }
 
-        // Watermark: squircle logo + "made with Bayaan" (centered)
+        // Watermark: squircle logo + "made with {appName}" (centered)
         if (elements.watermarkParagraph) {
           const iconSize = elements.watermarkIconSize;
           const gap = elements.watermarkGap;

--- a/components/share/buildShareCardParagraphs.ts
+++ b/components/share/buildShareCardParagraphs.ts
@@ -39,6 +39,7 @@ import {
 } from '@/services/mushaf/DigitalKhattDataService';
 import {getRewayahShortLabel} from '@/utils/rewayahLabels';
 import type {RewayahId} from '@/store/mushafSettingsStore';
+import branding from '@/config/branding';
 
 interface QuranEntry {
   verse_key: string;
@@ -314,7 +315,7 @@ export function buildShareCardParagraphs(
     rewayahLabelHeight = rewayahLabelParagraph.getHeight();
   }
 
-  // Watermark: logo + "made with Bayaan" (left-aligned, manually centered in canvas)
+  // Watermark: logo + "made with {appName}" (left-aligned, manually centered in canvas)
   let watermarkParagraph: SkParagraph | null = null;
   let watermarkHeight = 0;
   let watermarkTextWidth = 0;
@@ -330,7 +331,7 @@ export function buildShareCardParagraphs(
       fontFamilies: ['ManropeSemiBold'],
       fontSize: watermarkFontSize,
     });
-    wmBuilder.addText('made with Bayaan');
+    wmBuilder.addText(`made with ${branding.appName}`);
     wmBuilder.pop();
     watermarkParagraph = wmBuilder.build();
     watermarkParagraph.layout(contentWidth);

--- a/components/sheets/HomeCardOptionsSheet.tsx
+++ b/components/sheets/HomeCardOptionsSheet.tsx
@@ -29,6 +29,7 @@ import {
   reciterShareUrl,
   shareUrl,
 } from '@/utils/shareUtils';
+import branding from '@/config/branding';
 
 export const HomeCardOptionsSheet = (
   props: SheetProps<'home-card-options'>,
@@ -138,11 +139,14 @@ export const HomeCardOptionsSheet = (
         const surahLabel = surahName ?? `surah ${surahId}`;
         shareUrl(
           url,
-          `Listen to ${displayName} reciting ${surahLabel} on Bayaan`,
+          `Listen to ${displayName} reciting ${surahLabel} on ${branding.appName}`,
         );
         return;
       }
-      shareUrl(reciterShareUrl(slug), `Listen to ${displayName} on Bayaan`);
+      shareUrl(
+        reciterShareUrl(slug),
+        `Listen to ${displayName} on ${branding.appName}`,
+      );
     }, 300);
   }, [
     reciterId,

--- a/components/sheets/PlayerOptionsSheet.tsx
+++ b/components/sheets/PlayerOptionsSheet.tsx
@@ -32,6 +32,7 @@ import {CircularProgress} from '@/components/CircularProgress';
 import {usePlayerStore} from '@/services/player/store/playerStore';
 import {getReciterByIdSync} from '@/services/dataService';
 import {recitationShareUrl, shareUrl} from '@/utils/shareUtils';
+import branding from '@/config/branding';
 import RenderHtml, {
   MixedStyleDeclaration,
   RenderHTMLProps,
@@ -274,7 +275,7 @@ export const PlayerOptionsSheet = (props: SheetProps<'player-options'>) => {
       rewayat.id,
       timestampSec,
     );
-    shareUrl(url, `Listen to Surah ${surahNum} on Bayaan`);
+    shareUrl(url, `Listen to Surah ${surahNum} on ${branding.appName}`);
   }, [reciterId, rewayatId, surah]);
 
   const handleSheetChange = useCallback((index: number) => {

--- a/components/sheets/SurahOptionsSheet.tsx
+++ b/components/sheets/SurahOptionsSheet.tsx
@@ -38,6 +38,7 @@ import Color from 'color';
 import {CircularProgress} from '@/components/CircularProgress';
 import {getReciterByIdSync} from '@/services/dataService';
 import {recitationShareUrl, shareUrl} from '@/utils/shareUtils';
+import branding from '@/config/branding';
 import RenderHtml, {
   MixedStyleDeclaration,
   RenderHTMLProps,
@@ -259,7 +260,7 @@ export const SurahOptionsSheet = (props: SheetProps<'surah-options'>) => {
     const rewayat = reciter.rewayat.find(rw => rw.id === rewayatId);
     if (!rewayat) return;
     const url = recitationShareUrl(reciter.slug, surah.id, rewayat.id);
-    shareUrl(url, `Listen to ${surah.name} on Bayaan`);
+    shareUrl(url, `Listen to ${surah.name} on ${branding.appName}`);
   }, [reciterId, rewayatId, surah]);
 
   const handleSheetChange = useCallback((index: number) => {

--- a/components/system-playlist/SystemPlaylistHeader.tsx
+++ b/components/system-playlist/SystemPlaylistHeader.tsx
@@ -14,6 +14,7 @@ import Animated, {
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
+import branding from '@/config/branding';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 const isGlass = USE_GLASS;
@@ -98,7 +99,7 @@ export const SystemPlaylistHeader: React.FC<SystemPlaylistHeaderProps> = ({
         <View style={styles.contentContainer}>
           {/* System Playlist Badge */}
           <View style={styles.badge}>
-            <Text style={styles.badgeText}>Bayaan Curated</Text>
+            <Text style={styles.badgeText}>{`${branding.appName} Curated`}</Text>
           </View>
 
           {/* Title and Description */}


### PR DESCRIPTION
## What

Four user-facing literals hardcoded `"Bayaan"` — replace each with `${branding.appName}` so forks pick up their own name without having to fork the entire file. Default branding ships `"Bayaan"`, so output is byte-identical for the upstream app.

## Files touched

- `components/sheets/SurahOptionsSheet.tsx` — share copy (`"Listen to … on Bayaan"`)
- `components/reciter-profile/ReciterProfile.tsx` — share copy, both call sites
- `components/system-playlist/SystemPlaylistHeader.tsx` — `"Bayaan Curated"` badge
- `components/MushafSettingsContent.tsx` — Mushaf 1440 beta alert body

## Example diff

```diff
-    shareUrl(url, `Listen to ${surah.name} on Bayaan`);
+    shareUrl(url, `Listen to ${surah.name} on ${branding.appName}`);
```

## Why

Continuation of the RFC-007 cross-fork seams thread. These four files are the last small-surface holdouts where the fork has to maintain a whole-file copy just to swap a single literal — lifting through `branding.appName` retires that without changing default behavior.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] No call-site behavior change for default branding (literal `"Bayaan"` returns from `branding.appName`).
- [ ] Confirm visually on next build (mechanical change; no runtime branching).

Mechanical change; no native build needed.