### PR TITLE
chore: route reviewUtils PLAY_STORE_ID + RATED_KEY through branding

### DIFF
--- a/utils/reviewUtils.ts
+++ b/utils/reviewUtils.ts
@@ -1,12 +1,13 @@
 import {Platform, Linking} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import branding from '@/config/branding';
 
 // App Store IDs
 const APP_STORE_ID = '6648769980'; // iOS App Store ID
-const PLAY_STORE_ID = 'com.bayaan.app'; // Android package name
+const PLAY_STORE_ID = branding.bundleId.android; // Android package name
 
 // Storage key for tracking if user has rated the app
-const RATED_KEY = '@Bayaan:hasRated';
+const RATED_KEY = `@${branding.appSlug}:hasRated`;
 
 /**
  * Opens the appropriate app store for the user to write a review


### PR DESCRIPTION
## What

`utils/reviewUtils.ts` had two hardcoded brand strings — lift both through the existing `Branding` fields:

- `PLAY_STORE_ID`: `'com.bayaan.app'` → `branding.bundleId.android`
- `RATED_KEY`: `'@Bayaan:hasRated'` → `` `@${branding.appSlug}:hasRated` ``

Both fields exist on the `Branding` interface today, so this is a pure call-site change — no API surface addition.

## Default-branding parity

Default Bayaan ships `appSlug: 'Bayaan'` and `bundleId.android: 'com.bayaan.app'`, so the emitted values are byte-identical for the upstream app. **No AsyncStorage key migration needed** for existing installs.

## Diff

```diff
 import {Platform, Linking} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import branding from '@/config/branding';

 // App Store IDs
 const APP_STORE_ID = '6648769980'; // iOS App Store ID
-const PLAY_STORE_ID = 'com.bayaan.app'; // Android package name
+const PLAY_STORE_ID = branding.bundleId.android; // Android package name

 // Storage key for tracking if user has rated the app
-const RATED_KEY = '@Bayaan:hasRated';
+const RATED_KEY = `@${branding.appSlug}:hasRated`;
```

## Out of scope

`APP_STORE_ID` (iOS numeric store id) is left hardcoded. Lifting it would require an additive `branding.iosAppStoreId?: string` field — happy to do that in a follow-up if there's appetite, but it's a different shape from this PR's "use what's already there" change.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] Default-branding values byte-identical → no behavior change for upstream.
- [ ] Confirm visually on next build.