### PR TITLE
fix(collection-options): await SheetManager.hide before invoking option

### DIFF
--- a/components/sheets/CollectionOptionsSheet.tsx
+++ b/components/sheets/CollectionOptionsSheet.tsx
@@ -48,8 +48,14 @@ export const CollectionOptionsSheet = (
                     pressed && styles.optionPressed,
                     opt.disabled && styles.optionDisabled,
                   ]}
-                  onPress={() => {
-                    SheetManager.hide('collection-options');
+                  onPress={async () => {
+                    // Await the hide before invoking the option's onPress.
+                    // Calling SheetManager.show from inside opt.onPress while
+                    // the previous sheet is still in its dismiss animation
+                    // races the library's mount queue — the new sheet
+                    // flashes open then closes. Awaiting hide first
+                    // serializes the transition.
+                    await SheetManager.hide('collection-options');
                     opt.onPress();
                   }}
                   disabled={opt.disabled}>
@@ -75,8 +81,8 @@ export const CollectionOptionsSheet = (
                 pressed && styles.optionDestructivePressed,
                 opt.disabled && styles.optionDisabled,
               ]}
-              onPress={() => {
-                SheetManager.hide('collection-options');
+              onPress={async () => {
+                await SheetManager.hide('collection-options');
                 opt.onPress();
               }}
               disabled={opt.disabled}>


### PR DESCRIPTION
## Summary

- `CollectionOptionsSheet` invoked `SheetManager.hide('collection-options')` synchronously and then called `opt.onPress()` on the same tick.
- When the option's `onPress` opens another action sheet (e.g. "Edit Note" → opens the note composer sheet), the new sheet races react-native-actions-sheet's mount queue against the still-running dismiss animation of the parent — symptom is the new sheet briefly mounting, flashing visible, and immediately dismissing alongside the parent.
- This switches both `onPress` handlers in the file (normal + destructive option paths) to `async`, awaits the hide, then invokes the callback. Serializes the transition.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Sim/emulator verification deferred to maintainer. Symptom only fires when an option opens another sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)