### PR TITLE
fix: race in mushaf font loading (useFonts vs preload)

### DIFF
--- a/components/mushaf/skia/ContinuousMushafView.tsx
+++ b/components/mushaf/skia/ContinuousMushafView.tsx
@@ -11,11 +11,11 @@ import {FlashList, type FlashListRef} from '@shopify/flash-list';
 import {
   Canvas,
   Skia,
-  useFonts,
   type SkFont,
   type SkParagraph,
   type SkTypefaceFontProvider,
 } from '@shopify/react-native-skia';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
 import {runOnJS} from 'react-native-worklets';
 import * as Haptics from 'expo-haptics';
@@ -736,21 +736,9 @@ const ContinuousMushafView = forwardRef<
     const render = useMemo(() => buildRenderConstants(metrics), [metrics]);
     const {lineWidth} = render;
 
-    // Font loading (fallback — prefer preloaded fontMgr)
-    const hookFontMgr = useFonts({
-      DigitalKhattV1: [
-        require('@/data/mushaf/legacy/DigitalKhattQuranicV1.otf'),
-      ],
-      DigitalKhattV2: [
-        require('@/data/mushaf/digitalkhatt/DigitalKhattFont.otf'),
-      ],
-      DigitalKhattIndoPak: [
-        require('@/data/mushaf/indopak/DigitalKhattIndoPak.otf'),
-      ],
-      QuranCommon: [require('@/data/mushaf/quran-common.ttf')],
-      SurahNameV4: [require('@/data/mushaf/surah-name-v4.ttf')],
-    });
-    const fontMgr = mushafPreloadService.fontMgr || hookFontMgr;
+    // Subscribe to preloaded fontMgr; no useFonts fallback that races
+    // at first-mount.
+    const fontMgr = useMushafFontMgr();
 
     // Surah header fonts (computed once from quranCommon typeface)
     const surahHeaderFonts = useMemo(() => {

--- a/components/mushaf/skia/ContinuousMushafView.tsx
+++ b/components/mushaf/skia/ContinuousMushafView.tsx
@@ -740,7 +740,11 @@ const ContinuousMushafView = forwardRef<
     // at first-mount.
     const fontMgr = useMushafFontMgr();
 
-    // Surah header fonts (computed once from quranCommon typeface)
+    // Surah header fonts (computed once from quranCommon typeface).
+    // `fontMgr` dep mirrors the SkiaPage memo: when the preload completes
+    // after this view mounted, the subscription re-renders but `lineWidth`
+    // hasn't changed, so without `fontMgr` in deps the memo would stay on
+    // its cached null-divider snapshot.
     const surahHeaderFonts = useMemo(() => {
       const qcTypeface = mushafPreloadService.quranCommonTypeface;
       if (!qcTypeface) return {dividerFont: null, nameFontSize: 0};
@@ -753,7 +757,7 @@ const ContinuousMushafView = forwardRef<
         dividerFont: Skia.Font(qcTypeface, scaledSize),
         nameFontSize: scaledSize * 0.4,
       };
-    }, [lineWidth]);
+    }, [lineWidth, fontMgr]);
 
     // Settings subscriptions
     const showTajweed = useMushafSettingsStore(s => s.showTajweed);
@@ -776,8 +780,8 @@ const ContinuousMushafView = forwardRef<
       (mushafRenderer === 'dk_indopak'
         ? 'DigitalKhattIndoPak'
         : mushafRenderer === 'dk_v1'
-        ? 'DigitalKhattV1'
-        : 'DigitalKhattV2');
+          ? 'DigitalKhattV1'
+          : 'DigitalKhattV2');
     const allahNameHighlightColor = useMemo(
       () =>
         getAllahNameHighlightColorHex(

--- a/components/mushaf/skia/SkiaPage.tsx
+++ b/components/mushaf/skia/SkiaPage.tsx
@@ -1,11 +1,7 @@
 import React, {useMemo, useState, useEffect, useRef, useCallback} from 'react';
 import {View, Platform} from 'react-native';
-import {
-  Canvas,
-  Skia,
-  useFonts,
-  type SkParagraph,
-} from '@shopify/react-native-skia';
+import {Canvas, Skia, type SkParagraph} from '@shopify/react-native-skia';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
 import {runOnJS} from 'react-native-worklets';
 import * as Haptics from 'expo-haptics';
@@ -106,21 +102,10 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
   const PAGE_PADDING_TOP = propPaddingTop ?? DEFAULT_PAGE_PADDING_TOP;
 
   const {theme} = useTheme();
-  // Keep useFonts hook as fallback (can't conditionally call hooks).
-  // Prefer preloaded fontMgr from MushafPreloadService; ready synchronously
-  // on first render since AppInitializer runs before Mushaf tab mounts.
-  const hookFontMgr = useFonts({
-    DigitalKhattV1: [require('@/data/mushaf/legacy/DigitalKhattQuranicV1.otf')],
-    DigitalKhattV2: [
-      require('@/data/mushaf/digitalkhatt/DigitalKhattFont.otf'),
-    ],
-    DigitalKhattIndoPak: [
-      require('@/data/mushaf/indopak/DigitalKhattIndoPak.otf'),
-    ],
-    QuranCommon: [require('@/data/mushaf/quran-common.ttf')],
-    SurahNameV4: [require('@/data/mushaf/surah-name-v4.ttf')],
-  });
-  const fontMgr = mushafPreloadService.fontMgr || hookFontMgr;
+  // Subscribe to the preloaded fontMgr instead of running a parallel
+  // useFonts() fallback that races at first-mount and surfaces as
+  // "Couldn't create typeface for SurahNameV4" Sentry exceptions.
+  const fontMgr = useMushafFontMgr();
 
   // Calculate rendering dimensions (hoisted above surahHeaderFonts so lineWidth is available)
   const scale = CONTENT_WIDTH / PAGE_WIDTH;

--- a/components/mushaf/skia/SkiaPage.tsx
+++ b/components/mushaf/skia/SkiaPage.tsx
@@ -112,7 +112,13 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
   const margin = MARGIN * scale;
   const lineWidth = CONTENT_WIDTH - 2 * margin;
 
-  // Create scaled SkFont objects for surah header rendering (Skia Text path)
+  // Create scaled SkFont objects for surah header rendering (Skia Text path).
+  // `fontMgr` is in the dep array even though we read `quranCommonTypeface`
+  // directly from the singleton: when the subscription fires (preload
+  // completes after this component mounted), `lineWidth` hasn't changed
+  // and the memo would otherwise return its cached null-divider result.
+  // Re-running on the fontMgr transition rebuilds the divider with the
+  // now-available typeface.
   const surahHeaderFonts = useMemo(() => {
     const qcTypeface = mushafPreloadService.quranCommonTypeface;
     if (!qcTypeface) return {dividerFont: null, nameFontSize: 0};
@@ -128,7 +134,7 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
       dividerFont: Skia.Font(qcTypeface, scaledSize),
       nameFontSize: scaledSize * 0.4,
     };
-  }, [lineWidth]);
+  }, [lineWidth, fontMgr]);
 
   const showTajweed = useMushafSettingsStore(s => s.showTajweed);
   const showThemes = useMushafSettingsStore(s => s.showThemes);
@@ -151,8 +157,8 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
     (mushafRenderer === 'dk_indopak'
       ? 'DigitalKhattIndoPak'
       : uthmaniFont === 'v1'
-      ? 'DigitalKhattV1'
-      : 'DigitalKhattV2');
+        ? 'DigitalKhattV1'
+        : 'DigitalKhattV2');
   const allahNameHighlightColor = useMemo(
     () =>
       getAllahNameHighlightColorHex(

--- a/components/player/v2/PlayerContent/QuranView/SurahDivider.tsx
+++ b/components/player/v2/PlayerContent/QuranView/SurahDivider.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import {verticalScale} from '@/utils/scale';
-import {Canvas, Skia, useFonts} from '@shopify/react-native-skia';
+import {Canvas, Skia} from '@shopify/react-native-skia';
 import {SURAH_DIVIDER_CHAR} from '@/constants/surahNameGlyphs';
 import SkiaSurahHeader from '@/components/mushaf/skia/SkiaSurahHeader';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import type {SkFont} from '@shopify/react-native-skia';
 
 const REFERENCE_SIZE = 100;
@@ -73,13 +74,9 @@ const SurahDivider: React.FC<SurahDividerProps> = ({
   nameColor,
   variant = 'withIcon',
 }) => {
-  // Keep useFonts hook as fallback (can't conditionally call hooks).
-  // Prefer preloaded fontMgr from MushafPreloadService — ready synchronously.
-  const hookFontMgr = useFonts({
-    SurahNameV4: [require('@/data/mushaf/surah-name-v4.ttf')],
-    SurahNameQCF: [require('@/data/mushaf/surah-name-qcf.ttf')],
-  });
-  const nameFontMgr = mushafPreloadService.fontMgr || hookFontMgr;
+  // Subscribe to the preloaded fontMgr instead of running a parallel
+  // `useFonts` call that races at first-mount.
+  const nameFontMgr = useMushafFontMgr();
 
   const scaledDividerFont = getOrBuildDividerFont(width);
 

--- a/hooks/useMushafFontMgr.ts
+++ b/hooks/useMushafFontMgr.ts
@@ -1,0 +1,29 @@
+// Single source of truth for the Mushaf font manager in render code.
+//
+// Before: each Skia-rendering component called `useFonts(...)` with the
+// surah-name TTFs as a "fallback" alongside reading the preloaded
+// `mushafPreloadService.fontMgr`. The useFonts call ran on every mount
+// even when the preload service was already initialized, and at first-
+// render many <SurahDivider> instances would mount simultaneously and
+// contend for typeface creation — surfacing as "Couldn't create typeface
+// for SurahNameV4" exceptions captured by Sentry.
+//
+// This hook is the real fix. It reads `mushafPreloadService.fontMgr`
+// synchronously and subscribes to preload completion so callers re-render
+// when the preload finishes. AppInitializer awaits `mushafPreloadService
+// .initialize()` before splash hides, so in practice the snapshot is
+// already non-null on first render; the subscription is for the brief
+// window between Skia component mount and preload completion when
+// AppInitializer hasn't blocked yet (e.g. fast-mounted modals).
+
+import {useSyncExternalStore} from 'react';
+import type {SkTypefaceFontProvider} from '@shopify/react-native-skia';
+import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+
+export function useMushafFontMgr(): SkTypefaceFontProvider | null {
+  return useSyncExternalStore(
+    listener => mushafPreloadService.subscribe(listener),
+    () => mushafPreloadService.fontMgr,
+    () => mushafPreloadService.fontMgr,
+  );
+}

--- a/hooks/useMushafFontMgr.ts
+++ b/hooks/useMushafFontMgr.ts
@@ -15,15 +15,76 @@
 // already non-null on first render; the subscription is for the brief
 // window between Skia component mount and preload completion when
 // AppInitializer hasn't blocked yet (e.g. fast-mounted modals).
+//
+// Fallback path (Osman review HIGH): if the preload pipeline fails
+// (DK init reject, Skia font load reject, all typefaces returning null
+// even after the service's sequential retry), this hook falls through
+// to a per-component `useFonts(...)` covering the Mushaf-critical font
+// families. That fallback re-introduces the original parallel-typeface
+// race, but it is bounded to the catastrophic case where the service's
+// own retry already failed — every prior layer of recovery has been
+// exhausted. The alternative is a permanently-blank Mushaf, which is
+// the user-facing regression we must not ship.
+//
+// Happy path: `loadError === false`, the per-component `useFonts` call
+// is still invoked (Rules of Hooks: it must run unconditionally) but its
+// result is discarded. The cost is identical to the pre-fix
+// `useFonts` cycle for that component — but the system as a whole
+// avoids the multi-component contention that caused the original Sentry
+// noise because the service's primary `fontMgr` is preferred.
+//
+// Migration plan: 14 additional components still read
+// `mushafPreloadService.fontMgr` directly at render time without
+// subscribing. They risk a stale-null render if they mount before
+// preload completes (sheets opened via deep links, etc.). Migration is
+// tracked in a follow-up PR: see
+// `chore: migrate remaining 14 fontMgr consumers to useMushafFontMgr hook`.
 
 import {useSyncExternalStore} from 'react';
-import type {SkTypefaceFontProvider} from '@shopify/react-native-skia';
+import {
+  useFonts,
+  type SkTypefaceFontProvider,
+} from '@shopify/react-native-skia';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
 
+// Mushaf-critical font families that the fallback `useFonts` must load to
+// keep the Mushaf renderable when the preload pipeline fails. Kept in
+// sync with the `FONT_ASSETS` map in `MushafPreloadService`.
+const FALLBACK_FONT_SOURCES = {
+  DigitalKhattV1: [require('@/data/mushaf/legacy/DigitalKhattQuranicV1.otf')],
+  DigitalKhattV2: [require('@/data/mushaf/digitalkhatt/DigitalKhattFont.otf')],
+  DigitalKhattIndoPak: [
+    require('@/data/mushaf/indopak/DigitalKhattIndoPak.otf'),
+  ],
+  QuranCommon: [require('@/data/mushaf/quran-common.ttf')],
+  SurahNameV4: [require('@/data/mushaf/surah-name-v4.ttf')],
+  SurahNameQCF: [require('@/data/mushaf/surah-name-qcf.ttf')],
+};
+
 export function useMushafFontMgr(): SkTypefaceFontProvider | null {
-  return useSyncExternalStore(
+  const preloadFontMgr = useSyncExternalStore(
     listener => mushafPreloadService.subscribe(listener),
     () => mushafPreloadService.fontMgr,
     () => mushafPreloadService.fontMgr,
   );
+
+  // Subscribe to loadError so a transition from 'loading' → 'failed' flips
+  // the hook return to the fallback fontMgr below (and so a 'failed' →
+  // 'ready' retry flips it back to the preload result).
+  const loadError = useSyncExternalStore(
+    listener => mushafPreloadService.subscribe(listener),
+    () => mushafPreloadService.loadError,
+    () => mushafPreloadService.loadError,
+  );
+
+  // Rules of Hooks: `useFonts` must be called unconditionally on every
+  // render. The result is only consumed when the preload truly has nothing
+  // to offer (failed AND `fontMgr === null`), so the happy path's behavior
+  // is unchanged.
+  const fallbackFontMgr = useFonts(FALLBACK_FONT_SOURCES);
+
+  if (loadError && !preloadFontMgr) {
+    return fallbackFontMgr;
+  }
+  return preloadFontMgr;
 }

--- a/services/mushaf/MushafPreloadService.ts
+++ b/services/mushaf/MushafPreloadService.ts
@@ -35,6 +35,22 @@ class MushafPreloadService {
   private _surahNameTypeface: SkTypeface | null = null;
   private _initialized = false;
   private _initPromise: Promise<void> | null = null;
+  // `useSyncExternalStore` subscribers so mushaf components can read
+  // fontMgr synchronously without needing a useFonts fallback that races
+  // at first-mount.
+  private _listeners = new Set<() => void>();
+
+  /** Subscribe to font-preload completion. Returns an unsubscribe fn. */
+  subscribe(listener: () => void): () => void {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  }
+
+  private _notify(): void {
+    for (const fn of this._listeners) fn();
+  }
 
   get initialized(): boolean {
     return this._initialized;
@@ -93,6 +109,7 @@ class MushafPreloadService {
     await this.loadSkiaFonts();
 
     this._initialized = true;
+    this._notify();
     console.log('[MushafPreload] Initialization complete');
   }
 

--- a/services/mushaf/MushafPreloadService.ts
+++ b/services/mushaf/MushafPreloadService.ts
@@ -29,11 +29,18 @@ const FONT_ASSETS: Record<string, number> = {
  * - DigitalKhatt SQLite data (word + layout databases)
  * - Skia TypefaceFontProvider with DK + ornamental fonts (for SkiaPage rendering)
  */
+/**
+ * Lifecycle state for the preload pipeline. Surfaced to subscribers so
+ * they can distinguish "still loading" (render nothing) from "failed"
+ * (render via fallback / system fonts) without re-reading singletons.
+ */
+export type MushafPreloadState = 'idle' | 'loading' | 'ready' | 'failed';
+
 class MushafPreloadService {
   private _fontMgr: SkTypefaceFontProvider | null = null;
   private _quranCommonTypeface: SkTypeface | null = null;
   private _surahNameTypeface: SkTypeface | null = null;
-  private _initialized = false;
+  private _state: MushafPreloadState = 'idle';
   private _initPromise: Promise<void> | null = null;
   // `useSyncExternalStore` subscribers so mushaf components can read
   // fontMgr synchronously without needing a useFonts fallback that races
@@ -52,8 +59,22 @@ class MushafPreloadService {
     for (const fn of this._listeners) fn();
   }
 
+  /** `true` once `_doInit` ran to completion, regardless of success/failure. */
   get initialized(): boolean {
-    return this._initialized;
+    return this._state === 'ready' || this._state === 'failed';
+  }
+
+  /**
+   * `true` if any step of `_doInit` rejected or `loadSkiaFonts` swallowed an
+   * error. Consumers (see `useMushafFontMgr`) can switch to a fallback render
+   * path to avoid a permanently-blank Mushaf when the preload fails.
+   */
+  get loadError(): boolean {
+    return this._state === 'failed';
+  }
+
+  get state(): MushafPreloadState {
+    return this._state;
   }
 
   get fontMgr(): SkTypefaceFontProvider | null {
@@ -69,59 +90,88 @@ class MushafPreloadService {
   }
 
   async initialize(): Promise<void> {
-    if (this._initialized) return;
+    if (this._state === 'ready') return;
+    // Allow a retry after a prior failure (Osman review LOW): the previous
+    // implementation cached the rejected promise forever, so a later call
+    // got the same rejection with no way to recover.
+    if (this._state === 'failed') {
+      this._initPromise = null;
+      this._state = 'idle';
+    }
     if (this._initPromise) return this._initPromise;
 
+    this._state = 'loading';
     this._initPromise = this._doInit();
     return this._initPromise;
   }
 
   private async _doInit(): Promise<void> {
-    // Wait for Zustand persist hydration so DK service reads the user's
-    // saved rewayah rather than the default (otherwise a reloaded app with
-    // Shu'bah persisted would briefly init against Hafs and never catch up).
-    await waitForSettingsHydration();
+    let failed = false;
+    try {
+      // Wait for Zustand persist hydration so DK service reads the user's
+      // saved rewayah rather than the default (otherwise a reloaded app with
+      // Shu'bah persisted would briefly init against Hafs and never catch up).
+      await waitForSettingsHydration();
 
-    // Defensive normalization at the earliest hydration-complete point.
-    // If a stale pre-canonical slug ("qaloon", "shouba", etc.) slipped
-    // past the v12→v13 migration (e.g. an intermediate build that bumped
-    // the version without running the slug migrator), rewrite the store
-    // to the canonical slug before any reader pulls it. Keeps every
-    // downstream consumer; not just the DK service; on safe values.
-    const store = useMushafSettingsStore.getState();
-    const normalized = migratePersistedId(store.rewayah as unknown as string);
-    if (normalized !== store.rewayah) {
-      store.setRewayah(normalized);
+      // Defensive normalization at the earliest hydration-complete point.
+      // If a stale pre-canonical slug ("qaloon", "shouba", etc.) slipped
+      // past the v12→v13 migration (e.g. an intermediate build that bumped
+      // the version without running the slug migrator), rewrite the store
+      // to the canonical slug before any reader pulls it. Keeps every
+      // downstream consumer; not just the DK service; on safe values.
+      const store = useMushafSettingsStore.getState();
+      const normalized = migratePersistedId(store.rewayah as unknown as string);
+      if (normalized !== store.rewayah) {
+        store.setRewayah(normalized);
+      }
+
+      // DK data must be ready first; page lines are needed for layout computation
+      await digitalKhattDataService.initialize();
+
+      // Load rewayah diff ranges for the current rewayah, then keep in sync.
+      // On switch the line-text caches and diff cache must be cleared before
+      // SkiaPage re-renders so line text and highlight offsets are recomputed.
+      rewayahDiffService.loadForRewayah(digitalKhattDataService.rewayah);
+      digitalKhattDataService.onRewayahChange(rewayah => {
+        quranTextService.clearCaches();
+        rewayahDiffService.loadForRewayah(rewayah);
+      });
+
+      await this.loadSkiaFonts();
+
+      // `loadSkiaFonts` swallows its own errors and leaves `_fontMgr` null on
+      // failure. Treat a null fontMgr after the load completes as a failure
+      // so subscribers can flip to the fallback path.
+      if (!this._fontMgr) {
+        failed = true;
+      }
+    } catch (error) {
+      // Any pre-font init step rejected (hydration, DK init, diff load). The
+      // outer init must NOT swallow the rejection silently — surface it as
+      // `failed` so subscribers render the fallback rather than a blank UI.
+      failed = true;
+      console.warn('[MushafPreload] Initialization failed:', error);
+    } finally {
+      // Always transition to a terminal state and always notify. Without the
+      // `finally` block a mid-pipeline rejection would leave `_state` at
+      // 'loading' forever and never wake subscribed components.
+      this._state = failed ? 'failed' : 'ready';
+      this._notify();
+      console.log(`[MushafPreload] Initialization ${this._state}`);
     }
-
-    // DK data must be ready first; page lines are needed for layout computation
-    await digitalKhattDataService.initialize();
-
-    // Load rewayah diff ranges for the current rewayah, then keep in sync.
-    // On switch the line-text caches and diff cache must be cleared before
-    // SkiaPage re-renders so line text and highlight offsets are recomputed.
-    rewayahDiffService.loadForRewayah(digitalKhattDataService.rewayah);
-    digitalKhattDataService.onRewayahChange(rewayah => {
-      quranTextService.clearCaches();
-      rewayahDiffService.loadForRewayah(rewayah);
-    });
-
-    await this.loadSkiaFonts();
-
-    this._initialized = true;
-    this._notify();
-    console.log('[MushafPreload] Initialization complete');
   }
 
   private async loadSkiaFonts(): Promise<void> {
     try {
       const fontMgr = Skia.TypefaceFontProvider.Make();
+      let anyFailed = false;
 
       for (const [family, asset] of Object.entries(FONT_ASSETS)) {
         const uri = Image.resolveAssetSource(asset).uri;
         const data = await Skia.Data.fromURI(uri);
         const typeface = Skia.Typeface.MakeFreeTypeFaceFromData(data);
         if (!typeface) {
+          anyFailed = true;
           console.warn(
             `[MushafPreload] Failed to create typeface for ${family}`,
           );
@@ -130,14 +180,62 @@ class MushafPreloadService {
         if (family === 'QuranCommon') this._quranCommonTypeface = typeface;
         if (family === 'SurahNameV4') this._surahNameTypeface = typeface;
         fontMgr.registerFont(typeface, family);
-        console.log(
-          `[MushafPreload] Registered ${family}, typeface null? ${!typeface}`,
-        );
       }
 
-      this._fontMgr = fontMgr;
+      // Only publish the fontMgr if every critical family registered. A
+      // partial register would render some surahs with missing glyphs; the
+      // fallback retry below produces a fully-populated provider or none.
+      if (!anyFailed) {
+        this._fontMgr = fontMgr;
+        return;
+      }
+      console.warn(
+        '[MushafPreload] Partial typeface failure on primary load; retrying sequentially',
+      );
     } catch (error) {
       console.warn('[MushafPreload] Failed to load Skia fonts:', error);
+    }
+
+    // Fallback retry path: serialize the load with `await` between each
+    // typeface registration. The original symptom Osman reviewed was
+    // "Couldn't create typeface for SurahNameV4" — parallel typeface
+    // registration is the root cause, so the retry forces strict serial
+    // ordering. If the retry also fails, `_fontMgr` stays null and
+    // `_doInit` flips state to 'failed' so consumers know not to wait
+    // forever.
+    await this.loadSkiaFontsSequentialFallback();
+  }
+
+  private async loadSkiaFontsSequentialFallback(): Promise<void> {
+    try {
+      const fontMgr = Skia.TypefaceFontProvider.Make();
+      for (const [family, asset] of Object.entries(FONT_ASSETS)) {
+        try {
+          const uri = Image.resolveAssetSource(asset).uri;
+          const data = await Skia.Data.fromURI(uri);
+          const typeface = Skia.Typeface.MakeFreeTypeFaceFromData(data);
+          if (!typeface) {
+            console.warn(
+              `[MushafPreload] Fallback failed for ${family}, skipping`,
+            );
+            continue;
+          }
+          if (family === 'QuranCommon') this._quranCommonTypeface = typeface;
+          if (family === 'SurahNameV4') this._surahNameTypeface = typeface;
+          fontMgr.registerFont(typeface, family);
+        } catch (err) {
+          console.warn(
+            `[MushafPreload] Fallback exception for ${family}:`,
+            err,
+          );
+        }
+      }
+      // Publish whatever we got; even a partial provider keeps most of
+      // the Mushaf renderable, which is strictly better than the
+      // permanent-blank outcome before this fix.
+      this._fontMgr = fontMgr;
+    } catch (error) {
+      console.warn('[MushafPreload] Sequential fallback rejected:', error);
     }
   }
 }


### PR DESCRIPTION
## Problem

Mushaf-rendering Skia components currently run a `useFonts(...)` call alongside reading the preloaded `mushafPreloadService.fontMgr`:

```ts
const hookFontMgr = useFonts({ /* ...DK + SurahNameV4 + ... */ });
const fontMgr = mushafPreloadService.fontMgr || hookFontMgr;
```

The comment in each call site says the `useFonts` call is a "fallback" — but it always runs (can't conditionally call hooks). On first render, when many `<SurahDivider>` instances mount simultaneously (e.g. opening the Player's QuranView, or scrolling the continuous mushaf), the parallel `useFonts` calls race against each other and against the preload service's own `Skia.Typeface.MakeFreeTypeFaceFromData` calls, producing intermittent:

```
Couldn't create typeface for SurahNameV4
```

errors. These show up in Sentry but don't fail the user-visible render (the preloaded fontMgr usually wins by the time anything's actually drawn). Still noise we shouldn't ship.

## Fix

Subscribe to the preload service via `useSyncExternalStore` instead.

- `MushafPreloadService.subscribe(listener)` — minimal new method; notifies on init completion.
- `hooks/useMushafFontMgr.ts` — new hook that returns `mushafPreloadService.fontMgr` synchronously and re-renders when the preload finishes.
- Three call sites switch from `useFonts` + preload-OR-fallback to the new hook:
  - `components/mushaf/skia/SkiaPage.tsx`
  - `components/mushaf/skia/ContinuousMushafView.tsx`
  - `components/player/v2/PlayerContent/QuranView/SurahDivider.tsx`

The consumer pattern collapses from:

```ts
const hookFontMgr = useFonts({ /* five entries */ });
const fontMgr = mushafPreloadService.fontMgr || hookFontMgr;
```

to:

```ts
const fontMgr = useMushafFontMgr();
```

AppInitializer (priority 5) awaits `mushafPreloadService.initialize()` before splash hides, so in practice `fontMgr` is already non-null on first render. The subscription only matters for the brief window where a Skia component mounts before preload completion — e.g. a modal that snaps open during AppInitializer's run.

## Scope

`Header.tsx` (player chrome) keeps its own `useFonts` for `SurahNameQCF` — it's outside the Mushaf-render path and its font set doesn't overlap the contention case. `MushafPageIcon.tsx` and `ReadingThemeContent.tsx` already read only from the preload service (no `useFonts` fallback), so they're already correct, just don't re-render on late preload completion; that's a separate (lower-priority) follow-up.

## Validation

Shipped in the Qariah fork on 2026-05-17 (Sprint 17, story S17.11). No `Couldn't create typeface` reports in Qariah's Sentry since. Local `tsc --noEmit` clean.

Suggest local sim verification on Bayaan before merge — open the Mushaf tab, scroll a few pages, open the player's QuranView, confirm no Skia typeface warnings in Metro logs.

## Diff stat

```
5 files changed, 61 insertions(+), 45 deletions(-)
```