### PR TITLE
feat(surah-gradient-mesh): add paletteForKey helper

### DIFF
--- a/components/hero/SurahGradientMesh.tsx
+++ b/components/hero/SurahGradientMesh.tsx
@@ -30,6 +30,25 @@ export function paletteForSurah(surahId: number): MeshPalette {
   return MESH_PALETTES[(surahId - 1) % MESH_PALETTES.length];
 }
 
+/**
+ * Deterministic palette for any string key.
+ *
+ * Pairs with `paletteForSurah` for callers keying on something other
+ * than a surah id — e.g. a rewaya display name, an ISO country code, or
+ * a reciter slug — so each tile reads with a distinct color the way
+ * surah tiles already do.
+ *
+ * djb2 hash — cheap, well-distributed for short ASCII keys.
+ */
+export function paletteForKey(key: string): MeshPalette {
+  let hash = 5381;
+  for (let i = 0; i < key.length; i += 1) {
+    hash = (hash * 33) ^ key.charCodeAt(i);
+  }
+  const index = Math.abs(hash) % MESH_PALETTES.length;
+  return MESH_PALETTES[index];
+}
+
 interface SurahGradientMeshProps {
   palette: MeshPalette | readonly string[];
   isDark: boolean;


### PR DESCRIPTION
## Summary

Companion to the existing `paletteForSurah(surahId)`: a djb2-hash-based deterministic palette picker for any string key.

Useful for cards keyed on something other than a surah id — rewaya display name, ISO country code, reciter slug — so each tile reads with a distinct color the way surah tiles already do, without callers having to map strings to surah ids first.

Pure addition; no existing callsite changed. djb2 is cheap and well-distributed for short ASCII keys.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] No runtime callsite change — additive helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)