### PR TITLE
chore: migrate remaining 13 fontMgr consumers to useMushafFontMgr hook (follow-up to #273)

### DIFF
--- a/components/MushafPageIcon.tsx
+++ b/components/MushafPageIcon.tsx
@@ -12,6 +12,7 @@ import {
 } from '@shopify/react-native-skia';
 import {moderateScale} from 'react-native-size-matters';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {
   quranTextService,
   PAGE_WIDTH,
@@ -50,7 +51,7 @@ const MushafPageIcon: React.FC<MushafPageIconProps> = ({
   color,
   borderColor,
 }) => {
-  const fontMgr = mushafPreloadService.fontMgr;
+  const fontMgr = useMushafFontMgr();
   const uthmaniFont = useMushafSettingsStore(s => s.uthmaniFont);
   const mushafRenderer = useMushafSettingsStore(s => s.mushafRenderer);
   const fontFamily =

--- a/components/MushafSettingsContent.tsx
+++ b/components/MushafSettingsContent.tsx
@@ -22,6 +22,7 @@ import FormattedTextRenderer from '@/components/utils/FormattedText';
 import {LinearGradient} from 'expo-linear-gradient';
 import SkiaVerseText from '@/components/player/v2/PlayerContent/QuranView/SkiaVerseText';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
 import type {SkTypefaceFontProvider} from '@shopify/react-native-skia';
 import type {IndexedTajweedData} from '@/utils/tajweedLoader';
@@ -613,11 +614,12 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
     mushafRenderer === 'dk_indopak'
       ? 'DigitalKhattIndoPak'
       : mushafRenderer === 'dk_v1'
-      ? 'DigitalKhattV1'
-      : 'DigitalKhattV2';
+        ? 'DigitalKhattV1'
+        : 'DigitalKhattV2';
+  const subscribedFontMgr = useMushafFontMgr();
   const fontMgr =
     mushafPreloadService.initialized && digitalKhattDataService.initialized
-      ? mushafPreloadService.fontMgr
+      ? subscribedFontMgr
       : null;
 
   const actualTranslationText = useMemo(() => {
@@ -669,7 +671,10 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
         try {
           await digitalKhattDataService.switchRewayah('hafs');
         } catch (error) {
-          console.error('[MushafSettings] Failed to reset rewayah for QCF:', error);
+          console.error(
+            '[MushafSettings] Failed to reset rewayah for QCF:',
+            error,
+          );
         }
         setRewayah('hafs');
       }
@@ -861,9 +866,9 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
           <Text style={styles.settingRowLabel}>
             {themeMode === 'system'
               ? 'System'
-              : getReadingThemeById(
+              : (getReadingThemeById(
                   themeMode === 'light' ? lightThemeId : darkThemeId,
-                )?.name ?? 'System'}
+                )?.name ?? 'System')}
           </Text>
           <Feather
             name="chevron-right"
@@ -1139,15 +1144,17 @@ export const MushafSettingsContent: React.FC<MushafSettingsContentProps> = ({
             Rewayah switching is disabled in Mushaf 1440 beta.
           </Text>
         </View>
-      ) : hasDiffData(rewayah) && (
-        <RewayahDiffCard
-          rewayah={rewayah}
-          showRewayahDiffs={showRewayahDiffs}
-          toggleRewayahDiffs={toggleRewayahDiffs}
-          trackColor={trackColor}
-          styles={styles}
-          theme={theme}
-        />
+      ) : (
+        hasDiffData(rewayah) && (
+          <RewayahDiffCard
+            rewayah={rewayah}
+            showRewayahDiffs={showRewayahDiffs}
+            toggleRewayahDiffs={toggleRewayahDiffs}
+            trackColor={trackColor}
+            styles={styles}
+            theme={theme}
+          />
+        )
       )}
       <RewayahAccordion
         selectedId={rewayah}

--- a/components/ReadingThemeContent.tsx
+++ b/components/ReadingThemeContent.tsx
@@ -37,6 +37,7 @@ import {
   getQCFSurahNameChar,
 } from '@/constants/surahNameGlyphs';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {
   digitalKhattDataService,
   BASMALLAH_TEXT,
@@ -190,7 +191,8 @@ export const ReadingThemeContent: React.FC<ReadingThemeContentProps> = ({
         : 'DigitalKhattV2';
   const fontsReady =
     mushafPreloadService.initialized && digitalKhattDataService.initialized;
-  const fontMgr = fontsReady ? mushafPreloadService.fontMgr : null;
+  const subscribedFontMgr = useMushafFontMgr();
+  const fontMgr = fontsReady ? subscribedFontMgr : null;
 
   return (
     <ScrollView

--- a/components/mushaf/qcf/QCFPage.tsx
+++ b/components/mushaf/qcf/QCFPage.tsx
@@ -54,6 +54,7 @@ import {
 } from '@/services/mushaf/QCFFontLoader';
 import {qcfLayoutCacheService} from '@/services/mushaf/QCFLayoutCacheService';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {getTextAllahNameCharMap} from '@/services/mushaf/AllahNameHighlightService';
 import {themeDataService} from '@/services/mushaf/ThemeDataService';
 import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
@@ -134,7 +135,7 @@ const QCFPage: React.FC<QCFPageProps> = ({
   onTap,
 }) => {
   const {theme} = useTheme();
-  const fontMgr = mushafPreloadService.fontMgr;
+  const fontMgr = useMushafFontMgr();
   const arabicTextWeight = useMushafSettingsStore(s => s.arabicTextWeight);
   const showThemes = useMushafSettingsStore(s => s.showThemes);
   const showAllahNameHighlight = useMushafSettingsStore(
@@ -361,7 +362,14 @@ const QCFPage: React.FC<QCFPageProps> = ({
       }
 
       qcfFontLoader.prefetch(
-        [pageNumber - 1, pageNumber + 1, pageNumber - 2, pageNumber + 2, pageNumber - 3, pageNumber + 3],
+        [
+          pageNumber - 1,
+          pageNumber + 1,
+          pageNumber - 2,
+          pageNumber + 2,
+          pageNumber - 3,
+          pageNumber + 3,
+        ],
         fontMgr,
       );
     })();
@@ -804,7 +812,15 @@ const QCFPage: React.FC<QCFPageProps> = ({
               />
             ))}
           {renderEntries.map(
-            ({key, lineIndex, paragraph, strokeParagraph, boldOffset, yPos, width}) => (
+            ({
+              key,
+              lineIndex,
+              paragraph,
+              strokeParagraph,
+              boldOffset,
+              yPos,
+              width,
+            }) => (
               <Group key={key}>
                 {(lineBackgroundHighlights.get(lineIndex) ?? []).map(
                   (highlight, index) => {

--- a/components/mushaf/reading/ContinuousListView.tsx
+++ b/components/mushaf/reading/ContinuousListView.tsx
@@ -14,6 +14,7 @@ import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import {useTajweedStore} from '@/store/tajweedStore';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
 import {mushafVerseMapService} from '@/services/mushaf/MushafVerseMapService';
 import {
@@ -244,7 +245,8 @@ const ContinuousListView = forwardRef<
         mushafRenderer === 'dk_indopak') &&
       mushafPreloadService.initialized &&
       digitalKhattDataService.initialized;
-    const fontMgr = isDK ? mushafPreloadService.fontMgr : null;
+    const subscribedFontMgr = useMushafFontMgr();
+    const fontMgr = isDK ? subscribedFontMgr : null;
     const indexedTajweedData = useTajweedStore(s => s.indexedTajweedData);
 
     const items = useMemo(() => buildContinuousListItems(), []);

--- a/components/mushaf/reading/ReadingPageView.tsx
+++ b/components/mushaf/reading/ReadingPageView.tsx
@@ -13,6 +13,7 @@ import {useMushafPlayerStore} from '@/store/mushafPlayerStore';
 import {useTajweedStore} from '@/store/tajweedStore';
 import {useVerseAnnotationsStore} from '@/store/verseAnnotationsStore';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
 import {
   getReadingPageItems,
@@ -126,7 +127,8 @@ const ReadingPageView: React.FC<ReadingPageViewProps> = ({
       mushafRenderer === 'dk_indopak') &&
     mushafPreloadService.initialized &&
     digitalKhattDataService.initialized;
-  const fontMgr = isDK ? mushafPreloadService.fontMgr : null;
+  const subscribedFontMgr = useMushafFontMgr();
+  const fontMgr = isDK ? subscribedFontMgr : null;
 
   const indexedTajweedData = useTajweedStore(s => s.indexedTajweedData);
 

--- a/components/mushaf/skia/ContinuousMushafView.tsx
+++ b/components/mushaf/skia/ContinuousMushafView.tsx
@@ -11,11 +11,11 @@ import {FlashList, type FlashListRef} from '@shopify/flash-list';
 import {
   Canvas,
   Skia,
-  useFonts,
   type SkFont,
   type SkParagraph,
   type SkTypefaceFontProvider,
 } from '@shopify/react-native-skia';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
 import {runOnJS} from 'react-native-worklets';
 import * as Haptics from 'expo-haptics';
@@ -736,21 +736,9 @@ const ContinuousMushafView = forwardRef<
     const render = useMemo(() => buildRenderConstants(metrics), [metrics]);
     const {lineWidth} = render;
 
-    // Font loading (fallback — prefer preloaded fontMgr)
-    const hookFontMgr = useFonts({
-      DigitalKhattV1: [
-        require('@/data/mushaf/legacy/DigitalKhattQuranicV1.otf'),
-      ],
-      DigitalKhattV2: [
-        require('@/data/mushaf/digitalkhatt/DigitalKhattFont.otf'),
-      ],
-      DigitalKhattIndoPak: [
-        require('@/data/mushaf/indopak/DigitalKhattIndoPak.otf'),
-      ],
-      QuranCommon: [require('@/data/mushaf/quran-common.ttf')],
-      SurahNameV4: [require('@/data/mushaf/surah-name-v4.ttf')],
-    });
-    const fontMgr = mushafPreloadService.fontMgr || hookFontMgr;
+    // Subscribe to preloaded fontMgr; no useFonts fallback that races
+    // at first-mount.
+    const fontMgr = useMushafFontMgr();
 
     // Surah header fonts (computed once from quranCommon typeface)
     const surahHeaderFonts = useMemo(() => {

--- a/components/mushaf/skia/ContinuousMushafView.tsx
+++ b/components/mushaf/skia/ContinuousMushafView.tsx
@@ -740,7 +740,11 @@ const ContinuousMushafView = forwardRef<
     // at first-mount.
     const fontMgr = useMushafFontMgr();
 
-    // Surah header fonts (computed once from quranCommon typeface)
+    // Surah header fonts (computed once from quranCommon typeface).
+    // `fontMgr` dep mirrors the SkiaPage memo: when the preload completes
+    // after this view mounted, the subscription re-renders but `lineWidth`
+    // hasn't changed, so without `fontMgr` in deps the memo would stay on
+    // its cached null-divider snapshot.
     const surahHeaderFonts = useMemo(() => {
       const qcTypeface = mushafPreloadService.quranCommonTypeface;
       if (!qcTypeface) return {dividerFont: null, nameFontSize: 0};
@@ -753,7 +757,7 @@ const ContinuousMushafView = forwardRef<
         dividerFont: Skia.Font(qcTypeface, scaledSize),
         nameFontSize: scaledSize * 0.4,
       };
-    }, [lineWidth]);
+    }, [lineWidth, fontMgr]);
 
     // Settings subscriptions
     const showTajweed = useMushafSettingsStore(s => s.showTajweed);
@@ -776,8 +780,8 @@ const ContinuousMushafView = forwardRef<
       (mushafRenderer === 'dk_indopak'
         ? 'DigitalKhattIndoPak'
         : mushafRenderer === 'dk_v1'
-        ? 'DigitalKhattV1'
-        : 'DigitalKhattV2');
+          ? 'DigitalKhattV1'
+          : 'DigitalKhattV2');
     const allahNameHighlightColor = useMemo(
       () =>
         getAllahNameHighlightColorHex(

--- a/components/mushaf/skia/SkiaPage.tsx
+++ b/components/mushaf/skia/SkiaPage.tsx
@@ -1,11 +1,7 @@
 import React, {useMemo, useState, useEffect, useRef, useCallback} from 'react';
 import {View, Platform} from 'react-native';
-import {
-  Canvas,
-  Skia,
-  useFonts,
-  type SkParagraph,
-} from '@shopify/react-native-skia';
+import {Canvas, Skia, type SkParagraph} from '@shopify/react-native-skia';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
 import {runOnJS} from 'react-native-worklets';
 import * as Haptics from 'expo-haptics';
@@ -106,21 +102,10 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
   const PAGE_PADDING_TOP = propPaddingTop ?? DEFAULT_PAGE_PADDING_TOP;
 
   const {theme} = useTheme();
-  // Keep useFonts hook as fallback (can't conditionally call hooks).
-  // Prefer preloaded fontMgr from MushafPreloadService; ready synchronously
-  // on first render since AppInitializer runs before Mushaf tab mounts.
-  const hookFontMgr = useFonts({
-    DigitalKhattV1: [require('@/data/mushaf/legacy/DigitalKhattQuranicV1.otf')],
-    DigitalKhattV2: [
-      require('@/data/mushaf/digitalkhatt/DigitalKhattFont.otf'),
-    ],
-    DigitalKhattIndoPak: [
-      require('@/data/mushaf/indopak/DigitalKhattIndoPak.otf'),
-    ],
-    QuranCommon: [require('@/data/mushaf/quran-common.ttf')],
-    SurahNameV4: [require('@/data/mushaf/surah-name-v4.ttf')],
-  });
-  const fontMgr = mushafPreloadService.fontMgr || hookFontMgr;
+  // Subscribe to the preloaded fontMgr instead of running a parallel
+  // useFonts() fallback that races at first-mount and surfaces as
+  // "Couldn't create typeface for SurahNameV4" Sentry exceptions.
+  const fontMgr = useMushafFontMgr();
 
   // Calculate rendering dimensions (hoisted above surahHeaderFonts so lineWidth is available)
   const scale = CONTENT_WIDTH / PAGE_WIDTH;

--- a/components/mushaf/skia/SkiaPage.tsx
+++ b/components/mushaf/skia/SkiaPage.tsx
@@ -112,7 +112,13 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
   const margin = MARGIN * scale;
   const lineWidth = CONTENT_WIDTH - 2 * margin;
 
-  // Create scaled SkFont objects for surah header rendering (Skia Text path)
+  // Create scaled SkFont objects for surah header rendering (Skia Text path).
+  // `fontMgr` is in the dep array even though we read `quranCommonTypeface`
+  // directly from the singleton: when the subscription fires (preload
+  // completes after this component mounted), `lineWidth` hasn't changed
+  // and the memo would otherwise return its cached null-divider result.
+  // Re-running on the fontMgr transition rebuilds the divider with the
+  // now-available typeface.
   const surahHeaderFonts = useMemo(() => {
     const qcTypeface = mushafPreloadService.quranCommonTypeface;
     if (!qcTypeface) return {dividerFont: null, nameFontSize: 0};
@@ -128,7 +134,7 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
       dividerFont: Skia.Font(qcTypeface, scaledSize),
       nameFontSize: scaledSize * 0.4,
     };
-  }, [lineWidth]);
+  }, [lineWidth, fontMgr]);
 
   const showTajweed = useMushafSettingsStore(s => s.showTajweed);
   const showThemes = useMushafSettingsStore(s => s.showThemes);
@@ -151,8 +157,8 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
     (mushafRenderer === 'dk_indopak'
       ? 'DigitalKhattIndoPak'
       : uthmaniFont === 'v1'
-      ? 'DigitalKhattV1'
-      : 'DigitalKhattV2');
+        ? 'DigitalKhattV1'
+        : 'DigitalKhattV2');
   const allahNameHighlightColor = useMemo(
     () =>
       getAllahNameHighlightColorHex(

--- a/components/player/v2/PlayerContent/QuranView/SurahDivider.tsx
+++ b/components/player/v2/PlayerContent/QuranView/SurahDivider.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import {verticalScale} from '@/utils/scale';
-import {Canvas, Skia, useFonts} from '@shopify/react-native-skia';
+import {Canvas, Skia} from '@shopify/react-native-skia';
 import {SURAH_DIVIDER_CHAR} from '@/constants/surahNameGlyphs';
 import SkiaSurahHeader from '@/components/mushaf/skia/SkiaSurahHeader';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import type {SkFont} from '@shopify/react-native-skia';
 
 const REFERENCE_SIZE = 100;
@@ -73,13 +74,9 @@ const SurahDivider: React.FC<SurahDividerProps> = ({
   nameColor,
   variant = 'withIcon',
 }) => {
-  // Keep useFonts hook as fallback (can't conditionally call hooks).
-  // Prefer preloaded fontMgr from MushafPreloadService — ready synchronously.
-  const hookFontMgr = useFonts({
-    SurahNameV4: [require('@/data/mushaf/surah-name-v4.ttf')],
-    SurahNameQCF: [require('@/data/mushaf/surah-name-qcf.ttf')],
-  });
-  const nameFontMgr = mushafPreloadService.fontMgr || hookFontMgr;
+  // Subscribe to the preloaded fontMgr instead of running a parallel
+  // `useFonts` call that races at first-mount.
+  const nameFontMgr = useMushafFontMgr();
 
   const scaledDividerFont = getOrBuildDividerFont(width);
 

--- a/components/player/v2/PlayerContent/QuranView/index.tsx
+++ b/components/player/v2/PlayerContent/QuranView/index.tsx
@@ -23,6 +23,7 @@ import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import type {MushafArabicTextWeight} from '@/store/mushafSettingsStore';
 import {useTajweedStore} from '@/store/tajweedStore';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
 import type {SkTypefaceFontProvider} from '@shopify/react-native-skia';
 import type {IndexedTajweedData} from '@/utils/tajweedLoader';
@@ -201,7 +202,8 @@ export const QuranView: React.FC<QuranViewProps> = ({
       : mushafRenderer === 'dk_v1'
         ? 'DigitalKhattV1'
         : 'DigitalKhattV2';
-  const fontMgr = isDK ? mushafPreloadService.fontMgr : null;
+  const subscribedFontMgr = useMushafFontMgr();
+  const fontMgr = isDK ? subscribedFontMgr : null;
 
   // Tajweed data for DK Skia rendering (verse-level indexed)
   const indexedTajweedData = useTajweedStore(s => s.indexedTajweedData);

--- a/components/share/SkiaVersePreview.tsx
+++ b/components/share/SkiaVersePreview.tsx
@@ -4,8 +4,8 @@ import {
   useMushafSettingsStore,
   type RewayahId,
 } from '@/store/mushafSettingsStore';
-import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
 import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {useTheme} from '@/hooks/useTheme';
 import {getAllahNameHighlightColorHex} from '@/constants/mushafAllahHighlight';
 import SkiaVerseText from '@/components/player/v2/PlayerContent/QuranView/SkiaVerseText';
@@ -54,7 +54,7 @@ const SkiaVersePreview: React.FC<SkiaVersePreviewProps> = ({
         ? 'DigitalKhattV1'
         : 'DigitalKhattV2';
 
-  const fontMgr = mushafPreloadService.fontMgr;
+  const fontMgr = useMushafFontMgr();
 
   // Lazy-load the override rewayah's DB if it's not the active one.
   const [, bump] = useReducer(x => x + 1, 0);

--- a/components/sheets/SimilarVersesSheet.tsx
+++ b/components/sheets/SimilarVersesSheet.tsx
@@ -27,7 +27,7 @@ import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService
 import {useMushafNavigationStore} from '@/store/mushafNavigationStore';
 import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import {useTajweedStore} from '@/store/tajweedStore';
-import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import SkiaVerseText from '@/components/player/v2/PlayerContent/QuranView/SkiaVerseText';
 import type {SimilarAyah, MutashabihatPhrase} from '@/types/qul';
 
@@ -87,7 +87,7 @@ export const SimilarVersesSheet = (props: SheetProps<'similar-verses'>) => {
     [allahNameHighlightColorSetting, theme.isDarkMode],
   );
   const indexedTajweedData = useTajweedStore(s => s.indexedTajweedData);
-  const fontMgr = mushafPreloadService.fontMgr;
+  const fontMgr = useMushafFontMgr();
   const fontFamily =
     mushafRenderer === 'dk_indopak'
       ? 'DigitalKhattIndoPak'

--- a/components/sheets/VerseShareSheet.tsx
+++ b/components/sheets/VerseShareSheet.tsx
@@ -26,6 +26,7 @@ import {Feather} from '@expo/vector-icons';
 import * as Sharing from 'expo-sharing';
 import {useCanvasRef} from '@shopify/react-native-skia';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import ShareCardPreview from '@/components/share/ShareCardPreview';
 import {captureShareCard} from '@/components/share/captureShareCard';
 import {lightHaptics} from '@/utils/haptics';
@@ -68,7 +69,7 @@ export const VerseShareSheet = (props: SheetProps<'verse-share'>) => {
   const verseKey = payload?.verseKey ?? '';
   const verseKeys = payload?.verseKeys ?? [verseKey];
 
-  const fontMgr = mushafPreloadService.fontMgr;
+  const fontMgr = useMushafFontMgr();
   const quranCommonTypeface = mushafPreloadService.quranCommonTypeface;
 
   const mushafRenderer = useMushafSettingsStore(s => s.mushafRenderer);

--- a/components/sheets/verse-actions/ShareContent.tsx
+++ b/components/sheets/verse-actions/ShareContent.tsx
@@ -21,6 +21,7 @@ import Color from 'color';
 import * as Sharing from 'expo-sharing';
 import {useCanvasRef} from '@shopify/react-native-skia';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import ShareCardPreview from '@/components/share/ShareCardPreview';
 import {captureShareCard} from '@/components/share/captureShareCard';
 import {lightHaptics} from '@/utils/haptics';
@@ -78,7 +79,7 @@ export const ShareContent: React.FC<ShareContentProps> = ({
   const [isCapturing, setIsCapturing] = useState(false);
 
   const verseKeys = verseKeysProp ?? [verseKey];
-  const fontMgr = mushafPreloadService.fontMgr;
+  const fontMgr = useMushafFontMgr();
   const quranCommonTypeface = mushafPreloadService.quranCommonTypeface;
 
   const mushafRenderer = useMushafSettingsStore(s => s.mushafRenderer);

--- a/components/sheets/verse-actions/SimilarVersesContent.tsx
+++ b/components/sheets/verse-actions/SimilarVersesContent.tsx
@@ -23,7 +23,7 @@ import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService
 import {useMushafNavigationStore} from '@/store/mushafNavigationStore';
 import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import {useTajweedStore} from '@/store/tajweedStore';
-import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import SkiaVerseText from '@/components/player/v2/PlayerContent/QuranView/SkiaVerseText';
 import type {SimilarAyah, MutashabihatPhrase} from '@/types/qul';
 
@@ -97,7 +97,7 @@ export const SimilarVersesContent: React.FC<SimilarVersesContentProps> = ({
     [allahNameHighlightColorSetting, theme.isDarkMode],
   );
   const indexedTajweedData = useTajweedStore(s => s.indexedTajweedData);
-  const fontMgr = mushafPreloadService.fontMgr;
+  const fontMgr = useMushafFontMgr();
   const fontFamily =
     mushafRenderer === 'dk_indopak'
       ? 'DigitalKhattIndoPak'

--- a/components/sheets/verse-actions/WBWContent.tsx
+++ b/components/sheets/verse-actions/WBWContent.tsx
@@ -9,6 +9,7 @@ import {ScrollView} from 'react-native-actions-sheet';
 import {WBWVerseView} from '@/components/player/v2/PlayerContent/QuranView/WBWVerseView';
 import {useMushafSettingsStore} from '@/store/mushafSettingsStore';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+import {useMushafFontMgr} from '@/hooks/useMushafFontMgr';
 import {digitalKhattDataService} from '@/services/mushaf/DigitalKhattDataService';
 import {useTajweedStore} from '@/store/tajweedStore';
 
@@ -56,7 +57,8 @@ export const WBWContent: React.FC<WBWContentProps> = ({
 
   const isDK =
     mushafPreloadService.initialized && digitalKhattDataService.initialized;
-  const fontMgr = isDK ? mushafPreloadService.fontMgr : null;
+  const subscribedFontMgr = useMushafFontMgr();
+  const fontMgr = isDK ? subscribedFontMgr : null;
 
   const indexedTajweedData = useTajweedStore(s => s.indexedTajweedData);
 

--- a/hooks/useMushafFontMgr.ts
+++ b/hooks/useMushafFontMgr.ts
@@ -1,0 +1,29 @@
+// Single source of truth for the Mushaf font manager in render code.
+//
+// Before: each Skia-rendering component called `useFonts(...)` with the
+// surah-name TTFs as a "fallback" alongside reading the preloaded
+// `mushafPreloadService.fontMgr`. The useFonts call ran on every mount
+// even when the preload service was already initialized, and at first-
+// render many <SurahDivider> instances would mount simultaneously and
+// contend for typeface creation — surfacing as "Couldn't create typeface
+// for SurahNameV4" exceptions captured by Sentry.
+//
+// This hook is the real fix. It reads `mushafPreloadService.fontMgr`
+// synchronously and subscribes to preload completion so callers re-render
+// when the preload finishes. AppInitializer awaits `mushafPreloadService
+// .initialize()` before splash hides, so in practice the snapshot is
+// already non-null on first render; the subscription is for the brief
+// window between Skia component mount and preload completion when
+// AppInitializer hasn't blocked yet (e.g. fast-mounted modals).
+
+import {useSyncExternalStore} from 'react';
+import type {SkTypefaceFontProvider} from '@shopify/react-native-skia';
+import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
+
+export function useMushafFontMgr(): SkTypefaceFontProvider | null {
+  return useSyncExternalStore(
+    listener => mushafPreloadService.subscribe(listener),
+    () => mushafPreloadService.fontMgr,
+    () => mushafPreloadService.fontMgr,
+  );
+}

--- a/hooks/useMushafFontMgr.ts
+++ b/hooks/useMushafFontMgr.ts
@@ -47,9 +47,11 @@ import {
 } from '@shopify/react-native-skia';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
 
-// Mushaf-critical font families that the fallback `useFonts` must load to
-// keep the Mushaf renderable when the preload pipeline fails. Kept in
-// sync with the `FONT_ASSETS` map in `MushafPreloadService`.
+// Mushaf-critical subset of `FONT_ASSETS` in `MushafPreloadService`. UI
+// fonts (Manrope) are intentionally excluded — they're loaded by the
+// app-wide font loader, not the Mushaf preload service, so the fallback
+// path doesn't need to re-load them. Updating this list does NOT need to
+// mirror every `FONT_ASSETS` addition; only the Mushaf-rendering families.
 const FALLBACK_FONT_SOURCES = {
   DigitalKhattV1: [require('@/data/mushaf/legacy/DigitalKhattQuranicV1.otf')],
   DigitalKhattV2: [require('@/data/mushaf/digitalkhatt/DigitalKhattFont.otf')],
@@ -62,20 +64,27 @@ const FALLBACK_FONT_SOURCES = {
 };
 
 export function useMushafFontMgr(): SkTypefaceFontProvider | null {
-  const preloadFontMgr = useSyncExternalStore(
+  // Single subscription per hook instance (Osman review MEDIUM). The
+  // previous shape called `useSyncExternalStore` twice — once for
+  // `fontMgr`, once for `loadError` — so each `_notify()` scheduled two
+  // re-renders per subscribing component per state transition. Under
+  // Hermes legacy rendering with 13+ subscribers across the Mushaf tree
+  // that's a double cold-start render storm at the worst moment.
+  //
+  // Now: one subscription, snapshot is a primitive boolean `isReady`
+  // (`true` once preload terminated as 'ready' OR 'failed'). Primitive
+  // snapshot means default identity comparison correctly short-circuits
+  // unchanged renders without needing a custom comparator. `fontMgr` and
+  // `loadError` are then derived from the service's current state at
+  // render time — both flip together inside `_notify`, so reading them
+  // post-isReady-flip is consistent.
+  const isReady = useSyncExternalStore(
     listener => mushafPreloadService.subscribe(listener),
-    () => mushafPreloadService.fontMgr,
-    () => mushafPreloadService.fontMgr,
+    () => mushafPreloadService.initialized,
+    () => mushafPreloadService.initialized,
   );
-
-  // Subscribe to loadError so a transition from 'loading' → 'failed' flips
-  // the hook return to the fallback fontMgr below (and so a 'failed' →
-  // 'ready' retry flips it back to the preload result).
-  const loadError = useSyncExternalStore(
-    listener => mushafPreloadService.subscribe(listener),
-    () => mushafPreloadService.loadError,
-    () => mushafPreloadService.loadError,
-  );
+  const preloadFontMgr = isReady ? mushafPreloadService.fontMgr : null;
+  const loadError = isReady && mushafPreloadService.loadError;
 
   // Rules of Hooks: `useFonts` must be called unconditionally on every
   // render. The result is only consumed when the preload truly has nothing

--- a/hooks/useMushafFontMgr.ts
+++ b/hooks/useMushafFontMgr.ts
@@ -15,15 +15,76 @@
 // already non-null on first render; the subscription is for the brief
 // window between Skia component mount and preload completion when
 // AppInitializer hasn't blocked yet (e.g. fast-mounted modals).
+//
+// Fallback path (Osman review HIGH): if the preload pipeline fails
+// (DK init reject, Skia font load reject, all typefaces returning null
+// even after the service's sequential retry), this hook falls through
+// to a per-component `useFonts(...)` covering the Mushaf-critical font
+// families. That fallback re-introduces the original parallel-typeface
+// race, but it is bounded to the catastrophic case where the service's
+// own retry already failed — every prior layer of recovery has been
+// exhausted. The alternative is a permanently-blank Mushaf, which is
+// the user-facing regression we must not ship.
+//
+// Happy path: `loadError === false`, the per-component `useFonts` call
+// is still invoked (Rules of Hooks: it must run unconditionally) but its
+// result is discarded. The cost is identical to the pre-fix
+// `useFonts` cycle for that component — but the system as a whole
+// avoids the multi-component contention that caused the original Sentry
+// noise because the service's primary `fontMgr` is preferred.
+//
+// Migration plan: 14 additional components still read
+// `mushafPreloadService.fontMgr` directly at render time without
+// subscribing. They risk a stale-null render if they mount before
+// preload completes (sheets opened via deep links, etc.). Migration is
+// tracked in a follow-up PR: see
+// `chore: migrate remaining 14 fontMgr consumers to useMushafFontMgr hook`.
 
 import {useSyncExternalStore} from 'react';
-import type {SkTypefaceFontProvider} from '@shopify/react-native-skia';
+import {
+  useFonts,
+  type SkTypefaceFontProvider,
+} from '@shopify/react-native-skia';
 import {mushafPreloadService} from '@/services/mushaf/MushafPreloadService';
 
+// Mushaf-critical font families that the fallback `useFonts` must load to
+// keep the Mushaf renderable when the preload pipeline fails. Kept in
+// sync with the `FONT_ASSETS` map in `MushafPreloadService`.
+const FALLBACK_FONT_SOURCES = {
+  DigitalKhattV1: [require('@/data/mushaf/legacy/DigitalKhattQuranicV1.otf')],
+  DigitalKhattV2: [require('@/data/mushaf/digitalkhatt/DigitalKhattFont.otf')],
+  DigitalKhattIndoPak: [
+    require('@/data/mushaf/indopak/DigitalKhattIndoPak.otf'),
+  ],
+  QuranCommon: [require('@/data/mushaf/quran-common.ttf')],
+  SurahNameV4: [require('@/data/mushaf/surah-name-v4.ttf')],
+  SurahNameQCF: [require('@/data/mushaf/surah-name-qcf.ttf')],
+};
+
 export function useMushafFontMgr(): SkTypefaceFontProvider | null {
-  return useSyncExternalStore(
+  const preloadFontMgr = useSyncExternalStore(
     listener => mushafPreloadService.subscribe(listener),
     () => mushafPreloadService.fontMgr,
     () => mushafPreloadService.fontMgr,
   );
+
+  // Subscribe to loadError so a transition from 'loading' → 'failed' flips
+  // the hook return to the fallback fontMgr below (and so a 'failed' →
+  // 'ready' retry flips it back to the preload result).
+  const loadError = useSyncExternalStore(
+    listener => mushafPreloadService.subscribe(listener),
+    () => mushafPreloadService.loadError,
+    () => mushafPreloadService.loadError,
+  );
+
+  // Rules of Hooks: `useFonts` must be called unconditionally on every
+  // render. The result is only consumed when the preload truly has nothing
+  // to offer (failed AND `fontMgr === null`), so the happy path's behavior
+  // is unchanged.
+  const fallbackFontMgr = useFonts(FALLBACK_FONT_SOURCES);
+
+  if (loadError && !preloadFontMgr) {
+    return fallbackFontMgr;
+  }
+  return preloadFontMgr;
 }

--- a/services/mushaf/MushafPreloadService.ts
+++ b/services/mushaf/MushafPreloadService.ts
@@ -35,6 +35,22 @@ class MushafPreloadService {
   private _surahNameTypeface: SkTypeface | null = null;
   private _initialized = false;
   private _initPromise: Promise<void> | null = null;
+  // `useSyncExternalStore` subscribers so mushaf components can read
+  // fontMgr synchronously without needing a useFonts fallback that races
+  // at first-mount.
+  private _listeners = new Set<() => void>();
+
+  /** Subscribe to font-preload completion. Returns an unsubscribe fn. */
+  subscribe(listener: () => void): () => void {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  }
+
+  private _notify(): void {
+    for (const fn of this._listeners) fn();
+  }
 
   get initialized(): boolean {
     return this._initialized;
@@ -93,6 +109,7 @@ class MushafPreloadService {
     await this.loadSkiaFonts();
 
     this._initialized = true;
+    this._notify();
     console.log('[MushafPreload] Initialization complete');
   }
 

--- a/services/mushaf/MushafPreloadService.ts
+++ b/services/mushaf/MushafPreloadService.ts
@@ -93,10 +93,17 @@ class MushafPreloadService {
     if (this._state === 'ready') return;
     // Allow a retry after a prior failure (Osman review LOW): the previous
     // implementation cached the rejected promise forever, so a later call
-    // got the same rejection with no way to recover.
+    // got the same rejection with no way to recover. Also explicitly
+    // reset typeface/fontMgr fields so the invariant "retry starts from
+    // a clean slate" is in the code, not implicit on the second run's
+    // overwrites. Otherwise a fallback-then-retry sequence could observe
+    // a stale `_quranCommonTypeface` mid-init.
     if (this._state === 'failed') {
       this._initPromise = null;
       this._state = 'idle';
+      this._fontMgr = null;
+      this._quranCommonTypeface = null;
+      this._surahNameTypeface = null;
     }
     if (this._initPromise) return this._initPromise;
 
@@ -207,8 +214,22 @@ class MushafPreloadService {
   }
 
   private async loadSkiaFontsSequentialFallback(): Promise<void> {
+    // Mushaf-critical families: at least one DK variant + QuranCommon must
+    // register or the Mushaf renders blank. SurahName fonts are ornamental
+    // (surah header glyphs); their absence is cosmetic, not catastrophic.
+    // Tracked separately so a fallback that drops only ornamental fonts
+    // still publishes a usable provider.
+    const CRITICAL_FAMILIES = new Set([
+      'DigitalKhattV1',
+      'DigitalKhattV2',
+      'DigitalKhattIndoPak',
+      'QuranCommon',
+    ]);
     try {
       const fontMgr = Skia.TypefaceFontProvider.Make();
+      const registered = new Set<string>();
+      let anyCriticalFailed = false;
+
       for (const [family, asset] of Object.entries(FONT_ASSETS)) {
         try {
           const uri = Image.resolveAssetSource(asset).uri;
@@ -218,21 +239,37 @@ class MushafPreloadService {
             console.warn(
               `[MushafPreload] Fallback failed for ${family}, skipping`,
             );
+            if (CRITICAL_FAMILIES.has(family)) anyCriticalFailed = true;
             continue;
           }
           if (family === 'QuranCommon') this._quranCommonTypeface = typeface;
           if (family === 'SurahNameV4') this._surahNameTypeface = typeface;
           fontMgr.registerFont(typeface, family);
+          registered.add(family);
         } catch (err) {
           console.warn(
             `[MushafPreload] Fallback exception for ${family}:`,
             err,
           );
+          if (CRITICAL_FAMILIES.has(family)) anyCriticalFailed = true;
         }
       }
-      // Publish whatever we got; even a partial provider keeps most of
-      // the Mushaf renderable, which is strictly better than the
-      // permanent-blank outcome before this fix.
+
+      // Only publish if every critical family registered AND at least one
+      // typeface landed. A zero-typeface provider is a non-null empty
+      // object — assigning it would pass `_doInit`'s null-guard, flip
+      // `_state` to 'ready' with `loadError === false`, and the hook's
+      // fallback (`useFonts`) would never fire. Result: every consumer
+      // gets the empty provider, every Mushaf surface renders blank, no
+      // recovery. Leaving `_fontMgr` null on critical-typeface failure
+      // makes the null-guard fire so the hook's `useFonts` fallback
+      // activates per Osman review HIGH.
+      if (anyCriticalFailed || registered.size === 0) {
+        console.warn(
+          '[MushafPreload] Sequential fallback dropped critical typefaces; leaving _fontMgr null so useFonts fallback activates',
+        );
+        return;
+      }
       this._fontMgr = fontMgr;
     } catch (error) {
       console.warn('[MushafPreload] Sequential fallback rejected:', error);

--- a/services/mushaf/MushafPreloadService.ts
+++ b/services/mushaf/MushafPreloadService.ts
@@ -29,11 +29,18 @@ const FONT_ASSETS: Record<string, number> = {
  * - DigitalKhatt SQLite data (word + layout databases)
  * - Skia TypefaceFontProvider with DK + ornamental fonts (for SkiaPage rendering)
  */
+/**
+ * Lifecycle state for the preload pipeline. Surfaced to subscribers so
+ * they can distinguish "still loading" (render nothing) from "failed"
+ * (render via fallback / system fonts) without re-reading singletons.
+ */
+export type MushafPreloadState = 'idle' | 'loading' | 'ready' | 'failed';
+
 class MushafPreloadService {
   private _fontMgr: SkTypefaceFontProvider | null = null;
   private _quranCommonTypeface: SkTypeface | null = null;
   private _surahNameTypeface: SkTypeface | null = null;
-  private _initialized = false;
+  private _state: MushafPreloadState = 'idle';
   private _initPromise: Promise<void> | null = null;
   // `useSyncExternalStore` subscribers so mushaf components can read
   // fontMgr synchronously without needing a useFonts fallback that races
@@ -52,8 +59,22 @@ class MushafPreloadService {
     for (const fn of this._listeners) fn();
   }
 
+  /** `true` once `_doInit` ran to completion, regardless of success/failure. */
   get initialized(): boolean {
-    return this._initialized;
+    return this._state === 'ready' || this._state === 'failed';
+  }
+
+  /**
+   * `true` if any step of `_doInit` rejected or `loadSkiaFonts` swallowed an
+   * error. Consumers (see `useMushafFontMgr`) can switch to a fallback render
+   * path to avoid a permanently-blank Mushaf when the preload fails.
+   */
+  get loadError(): boolean {
+    return this._state === 'failed';
+  }
+
+  get state(): MushafPreloadState {
+    return this._state;
   }
 
   get fontMgr(): SkTypefaceFontProvider | null {
@@ -69,59 +90,88 @@ class MushafPreloadService {
   }
 
   async initialize(): Promise<void> {
-    if (this._initialized) return;
+    if (this._state === 'ready') return;
+    // Allow a retry after a prior failure (Osman review LOW): the previous
+    // implementation cached the rejected promise forever, so a later call
+    // got the same rejection with no way to recover.
+    if (this._state === 'failed') {
+      this._initPromise = null;
+      this._state = 'idle';
+    }
     if (this._initPromise) return this._initPromise;
 
+    this._state = 'loading';
     this._initPromise = this._doInit();
     return this._initPromise;
   }
 
   private async _doInit(): Promise<void> {
-    // Wait for Zustand persist hydration so DK service reads the user's
-    // saved rewayah rather than the default (otherwise a reloaded app with
-    // Shu'bah persisted would briefly init against Hafs and never catch up).
-    await waitForSettingsHydration();
+    let failed = false;
+    try {
+      // Wait for Zustand persist hydration so DK service reads the user's
+      // saved rewayah rather than the default (otherwise a reloaded app with
+      // Shu'bah persisted would briefly init against Hafs and never catch up).
+      await waitForSettingsHydration();
 
-    // Defensive normalization at the earliest hydration-complete point.
-    // If a stale pre-canonical slug ("qaloon", "shouba", etc.) slipped
-    // past the v12→v13 migration (e.g. an intermediate build that bumped
-    // the version without running the slug migrator), rewrite the store
-    // to the canonical slug before any reader pulls it. Keeps every
-    // downstream consumer; not just the DK service; on safe values.
-    const store = useMushafSettingsStore.getState();
-    const normalized = migratePersistedId(store.rewayah as unknown as string);
-    if (normalized !== store.rewayah) {
-      store.setRewayah(normalized);
+      // Defensive normalization at the earliest hydration-complete point.
+      // If a stale pre-canonical slug ("qaloon", "shouba", etc.) slipped
+      // past the v12→v13 migration (e.g. an intermediate build that bumped
+      // the version without running the slug migrator), rewrite the store
+      // to the canonical slug before any reader pulls it. Keeps every
+      // downstream consumer; not just the DK service; on safe values.
+      const store = useMushafSettingsStore.getState();
+      const normalized = migratePersistedId(store.rewayah as unknown as string);
+      if (normalized !== store.rewayah) {
+        store.setRewayah(normalized);
+      }
+
+      // DK data must be ready first; page lines are needed for layout computation
+      await digitalKhattDataService.initialize();
+
+      // Load rewayah diff ranges for the current rewayah, then keep in sync.
+      // On switch the line-text caches and diff cache must be cleared before
+      // SkiaPage re-renders so line text and highlight offsets are recomputed.
+      rewayahDiffService.loadForRewayah(digitalKhattDataService.rewayah);
+      digitalKhattDataService.onRewayahChange(rewayah => {
+        quranTextService.clearCaches();
+        rewayahDiffService.loadForRewayah(rewayah);
+      });
+
+      await this.loadSkiaFonts();
+
+      // `loadSkiaFonts` swallows its own errors and leaves `_fontMgr` null on
+      // failure. Treat a null fontMgr after the load completes as a failure
+      // so subscribers can flip to the fallback path.
+      if (!this._fontMgr) {
+        failed = true;
+      }
+    } catch (error) {
+      // Any pre-font init step rejected (hydration, DK init, diff load). The
+      // outer init must NOT swallow the rejection silently — surface it as
+      // `failed` so subscribers render the fallback rather than a blank UI.
+      failed = true;
+      console.warn('[MushafPreload] Initialization failed:', error);
+    } finally {
+      // Always transition to a terminal state and always notify. Without the
+      // `finally` block a mid-pipeline rejection would leave `_state` at
+      // 'loading' forever and never wake subscribed components.
+      this._state = failed ? 'failed' : 'ready';
+      this._notify();
+      console.log(`[MushafPreload] Initialization ${this._state}`);
     }
-
-    // DK data must be ready first; page lines are needed for layout computation
-    await digitalKhattDataService.initialize();
-
-    // Load rewayah diff ranges for the current rewayah, then keep in sync.
-    // On switch the line-text caches and diff cache must be cleared before
-    // SkiaPage re-renders so line text and highlight offsets are recomputed.
-    rewayahDiffService.loadForRewayah(digitalKhattDataService.rewayah);
-    digitalKhattDataService.onRewayahChange(rewayah => {
-      quranTextService.clearCaches();
-      rewayahDiffService.loadForRewayah(rewayah);
-    });
-
-    await this.loadSkiaFonts();
-
-    this._initialized = true;
-    this._notify();
-    console.log('[MushafPreload] Initialization complete');
   }
 
   private async loadSkiaFonts(): Promise<void> {
     try {
       const fontMgr = Skia.TypefaceFontProvider.Make();
+      let anyFailed = false;
 
       for (const [family, asset] of Object.entries(FONT_ASSETS)) {
         const uri = Image.resolveAssetSource(asset).uri;
         const data = await Skia.Data.fromURI(uri);
         const typeface = Skia.Typeface.MakeFreeTypeFaceFromData(data);
         if (!typeface) {
+          anyFailed = true;
           console.warn(
             `[MushafPreload] Failed to create typeface for ${family}`,
           );
@@ -130,14 +180,62 @@ class MushafPreloadService {
         if (family === 'QuranCommon') this._quranCommonTypeface = typeface;
         if (family === 'SurahNameV4') this._surahNameTypeface = typeface;
         fontMgr.registerFont(typeface, family);
-        console.log(
-          `[MushafPreload] Registered ${family}, typeface null? ${!typeface}`,
-        );
       }
 
-      this._fontMgr = fontMgr;
+      // Only publish the fontMgr if every critical family registered. A
+      // partial register would render some surahs with missing glyphs; the
+      // fallback retry below produces a fully-populated provider or none.
+      if (!anyFailed) {
+        this._fontMgr = fontMgr;
+        return;
+      }
+      console.warn(
+        '[MushafPreload] Partial typeface failure on primary load; retrying sequentially',
+      );
     } catch (error) {
       console.warn('[MushafPreload] Failed to load Skia fonts:', error);
+    }
+
+    // Fallback retry path: serialize the load with `await` between each
+    // typeface registration. The original symptom Osman reviewed was
+    // "Couldn't create typeface for SurahNameV4" — parallel typeface
+    // registration is the root cause, so the retry forces strict serial
+    // ordering. If the retry also fails, `_fontMgr` stays null and
+    // `_doInit` flips state to 'failed' so consumers know not to wait
+    // forever.
+    await this.loadSkiaFontsSequentialFallback();
+  }
+
+  private async loadSkiaFontsSequentialFallback(): Promise<void> {
+    try {
+      const fontMgr = Skia.TypefaceFontProvider.Make();
+      for (const [family, asset] of Object.entries(FONT_ASSETS)) {
+        try {
+          const uri = Image.resolveAssetSource(asset).uri;
+          const data = await Skia.Data.fromURI(uri);
+          const typeface = Skia.Typeface.MakeFreeTypeFaceFromData(data);
+          if (!typeface) {
+            console.warn(
+              `[MushafPreload] Fallback failed for ${family}, skipping`,
+            );
+            continue;
+          }
+          if (family === 'QuranCommon') this._quranCommonTypeface = typeface;
+          if (family === 'SurahNameV4') this._surahNameTypeface = typeface;
+          fontMgr.registerFont(typeface, family);
+        } catch (err) {
+          console.warn(
+            `[MushafPreload] Fallback exception for ${family}:`,
+            err,
+          );
+        }
+      }
+      // Publish whatever we got; even a partial provider keeps most of
+      // the Mushaf renderable, which is strictly better than the
+      // permanent-blank outcome before this fix.
+      this._fontMgr = fontMgr;
+    } catch (error) {
+      console.warn('[MushafPreload] Sequential fallback rejected:', error);
     }
   }
 }


### PR DESCRIPTION
Follow-up to #273. That PR introduced `useMushafFontMgr()` — a `useSyncExternalStore`-backed hook over the `mushafPreloadService.fontMgr` snapshot — and migrated the three Mushaf hot-path renderers (`SkiaPage`, `ContinuousMushafView`, `SurahDivider`) off the direct singleton read.

Osman's review on #273 flagged the remaining 12 components that still call `mushafPreloadService.fontMgr` at render time without subscribing. They risk a stale-null render if they mount before the preload completes — realistic windows for sheets opened via deep links into a verse action, settings screens opened from a tab other than Mushaf, etc.

## What this PR does

Migrates all 12 components Osman called out, plus a 13th caller spotted in passing (`SimilarVersesContent.tsx` — same shape, not on the original list), to `useMushafFontMgr()`:

- `components/MushafPageIcon.tsx`
- `components/ReadingThemeContent.tsx`
- `components/MushafSettingsContent.tsx`
- `components/sheets/VerseShareSheet.tsx`
- `components/sheets/SimilarVersesSheet.tsx`
- `components/sheets/verse-actions/ShareContent.tsx`
- `components/sheets/verse-actions/SimilarVersesContent.tsx` (bonus — same anti-pattern)
- `components/sheets/verse-actions/WBWContent.tsx`
- `components/share/SkiaVersePreview.tsx`
- `components/mushaf/qcf/QCFPage.tsx`
- `components/mushaf/reading/ReadingPageView.tsx`
- `components/mushaf/reading/ContinuousListView.tsx`
- `components/player/v2/PlayerContent/QuranView/index.tsx`

For the conditional-fontMgr sites (`isDK ? mushafPreloadService.fontMgr : null`), the hook is called unconditionally and its result is gated by the same condition — the subscription is what matters; the conditional just decides whether to consume it.

## Two non-migrations preserved

- `components/mushaf/main.tsx:853` reads `mushafPreloadService.fontMgr` inside a `navigateToPage` callback, not at render time. Callback-time reads pick up the current singleton snapshot; no subscription needed.
- Three reads of `mushafPreloadService.quranCommonTypeface` (in `MushafPageIcon`, `QCFPage`, `VerseShareSheet`, `ShareContent`) are kept as direct singleton reads. That field has no hook today; consumers that also use `useMushafFontMgr` will re-render when fontMgr changes, at which point the typeface read inside the recomputed `useMemo` will pick up the now-populated typeface.

## Depends on #273

This branch is stacked on `fix/mushaf-font-loading-race` (the branch behind #273) since it imports the new `useMushafFontMgr` hook from that PR. Once #273 merges, this PR's diff against `develop` will reduce to just the 13 consumer migrations.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] prettier clean across all 13 files
- [ ] Cold-start the Mushaf tab on iOS sim — no regressions in pages, verse-action sheets, share sheet
- [ ] Open a verse-action sheet via a deep-link before the Mushaf tab has been visited — confirm the share preview + similar-verses surfaces render once preload completes (the case the migration is specifically targeting)
- [ ] Cold-start on Android emulator — same pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)