### PR TITLE
chore(scripts): verify-version-sync — cover iOS extension targets

### DIFF
--- a/scripts/__tests__/verify-version-sync.test.js
+++ b/scripts/__tests__/verify-version-sync.test.js
@@ -346,7 +346,7 @@ const SAMPLE_PBXPROJ = `// !$*UTF8*$!
 \t\t\t\tCURRENT_PROJECT_VERSION = 1;
 \t\t\t\tGCC_PREPROCESSOR_DEFINITIONS = (
 \t\t\t\t\t"DEBUG=1",
-\t\t\t\t\t"\$(inherited)",
+\t\t\t\t\t"$(inherited)",
 \t\t\t\t);
 \t\t\t\tGENERATE_INFOPLIST_FILE = YES;
 \t\t\t\tINFOPLIST_FILE = Bayaan/Info.plist;
@@ -430,7 +430,7 @@ describe('findExtensionConfigBlocks', () => {
   it('does not match GENERATE_INFOPLIST_FILE (regex anchoring)', () => {
     // Construct a config block that has GENERATE_INFOPLIST_FILE = YES but no
     // standalone INFOPLIST_FILE — should NOT be picked up as an extension.
-    const trick = `// !\$*UTF8*\$!
+    const trick = `// !$*UTF8*$!
 {
 \tobjects = {
 \t\tA1B2C3D4E5F6789012345678 /* Debug */ = {

--- a/scripts/__tests__/verify-version-sync.test.js
+++ b/scripts/__tests__/verify-version-sync.test.js
@@ -16,8 +16,10 @@ const {
   findInfoPlistPath,
   readVersionFromInfoPlist,
   readVersionFromAndroidGradle,
+  findExtensionConfigBlocks,
   patchInfoPlist,
   patchAndroidGradle,
+  patchExtensionConfigBlocks,
 } = require('../verify-version-sync');
 
 /**
@@ -317,5 +319,170 @@ describe('round-trip', () => {
     const after = readVersionFromAndroidGradle(tmpRoot);
     expect(after.semanticVersion).toBe('4.0.0');
     expect(after.buildNumber).toBe('1000');
+  });
+});
+
+// =====================================================================
+// findExtensionConfigBlocks / patchExtensionConfigBlocks
+// =====================================================================
+
+// Minimal pbxproj fixture: one main app XCBuildConfiguration (Info.plist =
+// Bayaan/Info.plist, no MARKETING_VERSION set) and one ShareExtension pair
+// (Debug + Release, INFOPLIST_FILE ending `-Info.plist`, both carrying
+// MARKETING_VERSION + CURRENT_PROJECT_VERSION). Mirrors expo-prebuild
+// pbxproj output structure with tab indentation.
+const SAMPLE_PBXPROJ = `// !$*UTF8*$!
+{
+\tarchiveVersion = 1;
+\tclasses = {
+\t};
+\tobjectVersion = 60;
+\tobjects = {
+
+/* Begin XCBuildConfiguration section */
+\t\t13B07F941A680F5B00A75B9A /* Debug */ = {
+\t\t\tisa = XCBuildConfiguration;
+\t\t\tbuildSettings = {
+\t\t\t\tCURRENT_PROJECT_VERSION = 1;
+\t\t\t\tGCC_PREPROCESSOR_DEFINITIONS = (
+\t\t\t\t\t"DEBUG=1",
+\t\t\t\t\t"\$(inherited)",
+\t\t\t\t);
+\t\t\t\tGENERATE_INFOPLIST_FILE = YES;
+\t\t\t\tINFOPLIST_FILE = Bayaan/Info.plist;
+\t\t\t\tMARKETING_VERSION = 1.0;
+\t\t\t\tPRODUCT_BUNDLE_IDENTIFIER = "com.bayaan.app";
+\t\t\t\tPRODUCT_NAME = Bayaan;
+\t\t\t};
+\t\t\tname = Debug;
+\t\t};
+\t\t376EE19454074DB08B7E9626 /* Debug */ = {
+\t\t\tisa = XCBuildConfiguration;
+\t\t\tbuildSettings = {
+\t\t\t\tCODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+\t\t\t\tCURRENT_PROJECT_VERSION = 698;
+\t\t\t\tGENERATE_INFOPLIST_FILE = YES;
+\t\t\t\tINFOPLIST_FILE = "ShareExtension/ShareExtension-Info.plist";
+\t\t\t\tMARKETING_VERSION = 2.2.0;
+\t\t\t\tPRODUCT_BUNDLE_IDENTIFIER = "com.bayaan.app.share-extension";
+\t\t\t\tPRODUCT_NAME = ShareExtension;
+\t\t\t};
+\t\t\tname = Debug;
+\t\t};
+\t\t376EE19454074DB08B7E9627 /* Release */ = {
+\t\t\tisa = XCBuildConfiguration;
+\t\t\tbuildSettings = {
+\t\t\t\tCODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+\t\t\t\tCURRENT_PROJECT_VERSION = 698;
+\t\t\t\tGENERATE_INFOPLIST_FILE = YES;
+\t\t\t\tINFOPLIST_FILE = "ShareExtension/ShareExtension-Info.plist";
+\t\t\t\tMARKETING_VERSION = 2.2.0;
+\t\t\t\tPRODUCT_BUNDLE_IDENTIFIER = "com.bayaan.app.share-extension";
+\t\t\t\tPRODUCT_NAME = ShareExtension;
+\t\t\t};
+\t\t\tname = Release;
+\t\t};
+/* End XCBuildConfiguration section */
+\t};
+\trootObject = 83CB B9F71A601CBA00E9 B192;
+}
+`;
+
+describe('findExtensionConfigBlocks', () => {
+  it('returns empty list when ios/ does not exist', () => {
+    const result = findExtensionConfigBlocks(tmpRoot);
+    expect(result.pbxprojPath).toBeNull();
+    expect(result.blocks).toEqual([]);
+  });
+
+  it('returns empty list when no extension targets are present', () => {
+    // Main-app-only pbxproj: INFOPLIST_FILE = Bayaan/Info.plist (no `-Info.plist` suffix).
+    writeFile(
+      'ios/Bayaan.xcodeproj/project.pbxproj',
+      `${SAMPLE_PBXPROJ.replace(
+        /[\s\S]*?376EE19454074DB08B7E9626 \/\* Debug \*\/ = \{[\s\S]*?376EE19454074DB08B7E9627 \/\* Release \*\/ = \{[\s\S]*?\t\t\};/m,
+        '',
+      )}`,
+    );
+    const result = findExtensionConfigBlocks(tmpRoot);
+    expect(result.pbxprojPath).toContain('project.pbxproj');
+    expect(result.blocks).toEqual([]);
+  });
+
+  it('finds the Debug + Release config blocks for an extension target', () => {
+    writeFile('ios/Bayaan.xcodeproj/project.pbxproj', SAMPLE_PBXPROJ);
+    const result = findExtensionConfigBlocks(tmpRoot);
+    expect(result.blocks).toHaveLength(2);
+    const debug = result.blocks.find(b => b.configName === 'Debug');
+    const release = result.blocks.find(b => b.configName === 'Release');
+    expect(debug).toMatchObject({
+      infoPlistRelPath: 'ShareExtension/ShareExtension-Info.plist',
+      marketingVersion: '2.2.0',
+      currentProjectVersion: '698',
+    });
+    expect(release).toMatchObject({
+      infoPlistRelPath: 'ShareExtension/ShareExtension-Info.plist',
+      marketingVersion: '2.2.0',
+      currentProjectVersion: '698',
+    });
+  });
+
+  it('does not match GENERATE_INFOPLIST_FILE (regex anchoring)', () => {
+    // Construct a config block that has GENERATE_INFOPLIST_FILE = YES but no
+    // standalone INFOPLIST_FILE — should NOT be picked up as an extension.
+    const trick = `// !\$*UTF8*\$!
+{
+\tobjects = {
+\t\tA1B2C3D4E5F6789012345678 /* Debug */ = {
+\t\t\tisa = XCBuildConfiguration;
+\t\t\tbuildSettings = {
+\t\t\t\tCURRENT_PROJECT_VERSION = 99;
+\t\t\t\tGENERATE_INFOPLIST_FILE = YES;
+\t\t\t\tMARKETING_VERSION = 9.9.9;
+\t\t\t};
+\t\t\tname = Debug;
+\t\t};
+\t};
+}
+`;
+    writeFile('ios/Bayaan.xcodeproj/project.pbxproj', trick);
+    const result = findExtensionConfigBlocks(tmpRoot);
+    expect(result.blocks).toEqual([]);
+  });
+});
+
+describe('patchExtensionConfigBlocks', () => {
+  it('patches MARKETING_VERSION + CURRENT_PROJECT_VERSION for all blocks', () => {
+    const pbxprojPath = writeFile(
+      'ios/Bayaan.xcodeproj/project.pbxproj',
+      SAMPLE_PBXPROJ,
+    );
+    const before = findExtensionConfigBlocks(tmpRoot);
+    patchExtensionConfigBlocks(pbxprojPath, before.blocks, {
+      semanticVersion: '4.0.0',
+      buildNumber: '1000',
+    });
+    const after = findExtensionConfigBlocks(tmpRoot);
+    expect(after.blocks).toHaveLength(2);
+    for (const block of after.blocks) {
+      expect(block.marketingVersion).toBe('4.0.0');
+      expect(block.currentProjectVersion).toBe('1000');
+    }
+  });
+
+  it('leaves main-app config blocks untouched', () => {
+    const pbxprojPath = writeFile(
+      'ios/Bayaan.xcodeproj/project.pbxproj',
+      SAMPLE_PBXPROJ,
+    );
+    const before = findExtensionConfigBlocks(tmpRoot);
+    patchExtensionConfigBlocks(pbxprojPath, before.blocks, {
+      semanticVersion: '4.0.0',
+      buildNumber: '1000',
+    });
+    const text = fs.readFileSync(pbxprojPath, 'utf8');
+    // Main app block still has the 1.0 / 1 placeholders.
+    expect(text).toMatch(/MARKETING_VERSION = 1\.0;/);
+    expect(text).toMatch(/CURRENT_PROJECT_VERSION = 1;/);
   });
 });

--- a/scripts/verify-version-sync.js
+++ b/scripts/verify-version-sync.js
@@ -168,6 +168,101 @@ function readVersionFromInfoPlist(repoRoot = REPO) {
   return {semanticVersion: semantic[1], buildNumber: build[1], path: p};
 }
 
+// iOS Share / Action / Notification extension targets carry their own
+// CFBundleShortVersionString + CFBundleVersion values in Xcode build
+// settings (`MARKETING_VERSION` + `CURRENT_PROJECT_VERSION` written into
+// `project.pbxproj`). Their stub `*-Info.plist` files don't contain the
+// raw CFBundle keys — Xcode generates them at build time by substituting
+// the build settings. So we parse the pbxproj, not the plist.
+//
+// Apple's processor warns at submission time when an embedded
+// extension's CFBundleVersion drifts from the parent app's
+// (`CFBundleVersion of an app extension ('N') must match that of its
+// containing parent app ('M')`). The warning isn't a hard rejection
+// but it pollutes the upload log and the extension's TestFlight build
+// metadata stays stale. PR #251 introduced this verifier for the main
+// app's Info.plist + Android gradle; this widens it to cover Xcode
+// extension targets (Share Extension, Action Extension, Notification
+// Service, Widget, etc.).
+//
+// Auto-discovery: scan `project.pbxproj` for `XCBuildConfiguration`
+// blocks whose `INFOPLIST_FILE` points at a file ending `-Info.plist`
+// (Xcode's convention for non-main-app target stub plists). Each such
+// block carries one Debug + one Release entry; we read + patch both.
+function findExtensionConfigBlocks(repoRoot = REPO) {
+  const candidates = [];
+  const iosDir = path.join(repoRoot, 'ios');
+  if (!fs.existsSync(iosDir)) return {pbxprojPath: null, blocks: candidates};
+  // Find the .xcodeproj/project.pbxproj. Fork-agnostic.
+  let pbxprojPath = null;
+  for (const entry of fs.readdirSync(iosDir, {withFileTypes: true})) {
+    if (entry.isDirectory() && entry.name.endsWith('.xcodeproj')) {
+      const p = path.join(iosDir, entry.name, 'project.pbxproj');
+      if (fs.existsSync(p)) {
+        pbxprojPath = p;
+        break;
+      }
+    }
+  }
+  if (!pbxprojPath) return {pbxprojPath: null, blocks: candidates};
+  const text = fs.readFileSync(pbxprojPath, 'utf8');
+  // Match XCBuildConfiguration objects. Greedy-but-bounded by the
+  // closing `};` that ends the object. pbxproj formatting is consistent
+  // enough that this regex works on Xcode 14-26 output.
+  const blockRe =
+    /(\w{24})\s+\/\*\s+(Debug|Release)\s+\*\/\s+=\s+\{\s+isa = XCBuildConfiguration;[\s\S]*?\n\s+\};/g;
+  let m;
+  while ((m = blockRe.exec(text)) !== null) {
+    const block = m[0];
+    const infoPlistMatch = /(?<![A-Z_])INFOPLIST_FILE\s+=\s+"?([^";]+)"?\s*;/.exec(block);
+    if (!infoPlistMatch) continue;
+    const infoPlistRelPath = infoPlistMatch[1];
+    // Extension target plists in Xcode are named `<TargetName>-Info.plist`
+    // (or sometimes `Info.plist` inside an `<Extension>/` directory we
+    // already skip in findInfoPlistPath). The `-Info.plist` suffix is the
+    // reliable marker. The main app's plist is just `<App>/Info.plist`.
+    if (!infoPlistRelPath.endsWith('-Info.plist')) continue;
+    const cpvMatch = /CURRENT_PROJECT_VERSION\s+=\s+([^;]+);/.exec(block);
+    const mvMatch = /MARKETING_VERSION\s+=\s+([^;]+);/.exec(block);
+    if (!cpvMatch || !mvMatch) continue;
+    candidates.push({
+      configName: m[2],
+      configId: m[1],
+      blockStart: m.index,
+      blockEnd: m.index + block.length,
+      infoPlistRelPath,
+      currentProjectVersion: cpvMatch[1].trim(),
+      marketingVersion: mvMatch[1].trim(),
+    });
+  }
+  return {pbxprojPath, blocks: candidates};
+}
+
+function patchExtensionConfigBlocks(pbxprojPath, blocks, target) {
+  // Rewrite the pbxproj once, patching each block in place. Going
+  // back-to-front preserves the byte offsets of earlier blocks.
+  let text = fs.readFileSync(pbxprojPath, 'utf8');
+  const sorted = blocks.slice().sort((a, b) => b.blockStart - a.blockStart);
+  for (const block of sorted) {
+    let patched = text.slice(block.blockStart, block.blockEnd);
+    if (block.marketingVersion !== target.semanticVersion) {
+      patched = patched.replace(
+        /MARKETING_VERSION\s+=\s+[^;]+;/,
+        `MARKETING_VERSION = ${target.semanticVersion};`,
+      );
+    }
+    if (block.currentProjectVersion !== target.buildNumber) {
+      patched = patched.replace(
+        /CURRENT_PROJECT_VERSION\s+=\s+[^;]+;/,
+        `CURRENT_PROJECT_VERSION = ${target.buildNumber};`,
+      );
+    }
+    text =
+      text.slice(0, block.blockStart) + patched + text.slice(block.blockEnd);
+  }
+  fs.writeFileSync(pbxprojPath, text, 'utf8');
+}
+
 function readVersionFromAndroidGradle(repoRoot = REPO) {
   const p = path.join(repoRoot, 'android/app/build.gradle');
   if (!fs.existsSync(p)) {
@@ -230,9 +325,14 @@ function main() {
   }
 
   let ios = null;
+  let iosExtensions = null;
   if (CHECK_IOS) {
     try {
       ios = readVersionFromInfoPlist(REPO);
+      // Auto-discover Xcode extension targets and include each in the
+      // check. Empty list (no extensions) is fine — means the project
+      // ships only the main app and the SE/widget check is a no-op.
+      iosExtensions = findExtensionConfigBlocks(REPO);
     } catch (e) {
       console.error('FATAL:', e.message);
       process.exit(2);
@@ -255,8 +355,19 @@ function main() {
     ? `${android.semanticVersion}/${android.buildNumber}`
     : null;
   const iosMatch = !CHECK_IOS || iosPair === truthPair;
+  // Extension targets agree when every discovered XCBuildConfiguration
+  // block matches the source-of-truth (both Debug + Release for each
+  // target). Drift in any one fails the check.
+  const extensionMismatches = CHECK_IOS
+    ? iosExtensions.blocks.filter(
+        b =>
+          b.marketingVersion !== truth.semanticVersion ||
+          b.currentProjectVersion !== truth.buildNumber,
+      )
+    : [];
+  const extensionsMatch = extensionMismatches.length === 0;
   const androidMatch = !CHECK_ANDROID || androidPair === truthPair;
-  const allMatch = iosMatch && androidMatch;
+  const allMatch = iosMatch && extensionsMatch && androidMatch;
 
   console.log(`Version sync check (platform=${PLATFORM}):`);
   console.log(
@@ -264,6 +375,13 @@ function main() {
   );
   if (CHECK_IOS) console.log(`  iOS ${ios.path}: ${iosPair}`);
   else console.log('  iOS: skipped (--platform=android)');
+  if (CHECK_IOS && iosExtensions.blocks.length > 0) {
+    for (const block of iosExtensions.blocks) {
+      console.log(
+        `  iOS extension ${iosExtensions.pbxprojPath} (${block.infoPlistRelPath} ${block.configName}): ${block.marketingVersion}/${block.currentProjectVersion}`,
+      );
+    }
+  }
   if (CHECK_ANDROID) console.log(`  Android ${android.path}: ${androidPair}`);
   else console.log('  Android: skipped (--platform=ios)');
 
@@ -278,6 +396,18 @@ function main() {
       patchInfoPlist(ios.path, ios, truth);
       console.log(`  ✓ ${ios.path} → ${truthPair}`);
     }
+    if (CHECK_IOS && extensionMismatches.length > 0) {
+      patchExtensionConfigBlocks(
+        iosExtensions.pbxprojPath,
+        extensionMismatches,
+        truth,
+      );
+      for (const block of extensionMismatches) {
+        console.log(
+          `  ✓ ${iosExtensions.pbxprojPath} ${block.infoPlistRelPath} ${block.configName} → ${truthPair}`,
+        );
+      }
+    }
     if (CHECK_ANDROID && androidPair !== truthPair) {
       patchAndroidGradle(android.path, android, truth);
       console.log(`  ✓ ${android.path} → ${truthPair}`);
@@ -289,6 +419,16 @@ function main() {
           return `${a.semanticVersion}/${a.buildNumber}`;
         })()
       : null;
+    const iosExtensionsAfter = CHECK_IOS
+      ? findExtensionConfigBlocks(REPO)
+      : null;
+    const iosExtensionsOk = CHECK_IOS
+      ? iosExtensionsAfter.blocks.every(
+          b =>
+            b.marketingVersion === truth.semanticVersion &&
+            b.currentProjectVersion === truth.buildNumber,
+        )
+      : true;
     const androidAfterPair = CHECK_ANDROID
       ? (() => {
           const a = readVersionFromAndroidGradle(REPO);
@@ -297,7 +437,7 @@ function main() {
       : null;
     const iosOk = !CHECK_IOS || iosAfterPair === truthPair;
     const androidOk = !CHECK_ANDROID || androidAfterPair === truthPair;
-    if (iosOk && androidOk) {
+    if (iosOk && iosExtensionsOk && androidOk) {
       console.log('\n✓ Working tree now in sync.');
       console.log(
         'Standing rule: archive BEFORE committing the version sync. ' +
@@ -317,6 +457,14 @@ function main() {
       `  ${ios.path}\n    has    CFBundleShortVersionString=${ios.semanticVersion}, CFBundleVersion=${ios.buildNumber}` +
         `\n    needs  CFBundleShortVersionString=${truth.semanticVersion}, CFBundleVersion=${truth.buildNumber}`,
     );
+  }
+  if (CHECK_IOS && extensionMismatches.length > 0) {
+    for (const block of extensionMismatches) {
+      console.error(
+        `  ${iosExtensions.pbxprojPath} (${block.infoPlistRelPath} ${block.configName})\n    has    MARKETING_VERSION=${block.marketingVersion}, CURRENT_PROJECT_VERSION=${block.currentProjectVersion}` +
+          `\n    needs  MARKETING_VERSION=${truth.semanticVersion}, CURRENT_PROJECT_VERSION=${truth.buildNumber}`,
+      );
+    }
   }
   if (CHECK_ANDROID && androidPair !== truthPair) {
     console.error(
@@ -346,8 +494,10 @@ module.exports = {
   findInfoPlistPath,
   readVersionFromInfoPlist,
   readVersionFromAndroidGradle,
+  findExtensionConfigBlocks,
   patchInfoPlist,
   patchAndroidGradle,
+  patchExtensionConfigBlocks,
   IOS_NON_APP_DIRS,
   IOS_NON_APP_SUFFIXES,
 };

--- a/scripts/verify-version-sync.js
+++ b/scripts/verify-version-sync.js
@@ -214,7 +214,8 @@ function findExtensionConfigBlocks(repoRoot = REPO) {
   let m;
   while ((m = blockRe.exec(text)) !== null) {
     const block = m[0];
-    const infoPlistMatch = /(?<![A-Z_])INFOPLIST_FILE\s+=\s+"?([^";]+)"?\s*;/.exec(block);
+    const infoPlistMatch =
+      /(?<![A-Z_])INFOPLIST_FILE\s+=\s+"?([^";]+)"?\s*;/.exec(block);
     if (!infoPlistMatch) continue;
     const infoPlistRelPath = infoPlistMatch[1];
     // Extension target plists in Xcode are named `<TargetName>-Info.plist`


### PR DESCRIPTION
## Summary

Widens PR #251's `verify-version-sync.js` to also cover Xcode extension targets (Share Extension, Action Extension, Notification Service, Widget). Without this, extension target versions silently drift off the parent app's, producing Apple submission warnings (`CFBundleVersion of an app extension ('N') must match that of its containing parent app ('M')`).

## Why

iOS extension targets carry CFBundle values via Xcode build settings (`MARKETING_VERSION` + `CURRENT_PROJECT_VERSION` in `project.pbxproj`), not in their stub `*-Info.plist`. PR #251's verifier checked only the main app's `Info.plist` + Android gradle, so SE drift went undetected. On Bayaan today the SE is at 2.2.0/698 (stale since the version bumped) — this PR's `--fix` would patch it to the current 2.2.0/812.

## Implementation

- **`findExtensionConfigBlocks(repoRoot)`** — auto-discovers extension targets by scanning `project.pbxproj` for `XCBuildConfiguration` blocks whose `INFOPLIST_FILE` ends `-Info.plist` (Xcode's convention for non-main-app stubs). Anchored with `(?<![A-Z_])INFOPLIST_FILE` so `GENERATE_INFOPLIST_FILE = YES;` doesn't false-match.
- **`patchExtensionConfigBlocks(path, blocks, target)`** — rewrites `MARKETING_VERSION` + `CURRENT_PROJECT_VERSION` back-to-front so earlier blocks' byte offsets stay stable. Same idempotent semantics as `patchInfoPlist` / `patchAndroidGradle`.
- main() ties them in: extension mismatches participate in the iOS match boolean and the mismatch report, and `--fix` patches them too. Empty extension list (project with only a main app target) is a no-op — behavior unchanged for projects without extensions.
- 6 new unit tests on top of PR #251's existing 21 (4 for find, 2 for patch). Total 27/27 green.

## Test plan

- [x] Existing 21 tests still green (no regression on main-app path)
- [x] 6 new tests cover: empty-when-no-ios, empty-no-extensions, happy-path, regex-anchoring against GENERATE_INFOPLIST_FILE, patch-happy-path, main-app-untouched
- [x] End-to-end smoke against Bayaan's own pbxproj: SE detected at 2.2.0/698, `--fix` patches both Debug + Release blocks, re-verify reports ✓
- [x] `npx eslint` clean
- [x] `npx prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)