### PR TITLE
fix(recent-reciter-card): timeRemaining display for short / unknown-duration tracks

### DIFF
--- a/components/cards/RecentReciterCard.tsx
+++ b/components/cards/RecentReciterCard.tsx
@@ -111,20 +111,40 @@ export const RecentReciterCard = ({
   ]);
 
   // Calculate time remaining
+  //
+  // Two display states the old code conflated as `'0m'`:
+  //   1. **Duration unknown** — `effectiveDuration` is 0 because the
+  //      track's duration hasn't been measured yet, or we're paused on
+  //      a track with no `duration` field. The old `'0m'` reads as
+  //      "track ended" to the user. Now returns an em-dash so the user
+  //      knows the time is genuinely unknown rather than zero.
+  //   2. **Short tracks** — for any remaining duration under 60s,
+  //      `Math.round(remainingSeconds / 60)` rounds to 0 → `'0m'`. Most
+  //      visible on short surahs like Al-Fatihah (~50s total): every
+  //      state past mid-track collapses to "0m". Now shows seconds for
+  //      remaining < 60s, e.g. "20s".
   const timeRemaining = useMemo(() => {
     const effectiveDuration =
       isCurrentlyPlaying && storeDuration > 0 ? storeDuration : duration;
-    let remainingSeconds = effectiveDuration;
 
-    if (effectiveDuration > 0) {
-      if (isCurrentlyPlaying && storePosition >= 0) {
-        remainingSeconds = effectiveDuration - storePosition;
-      } else {
-        remainingSeconds = effectiveDuration * (1 - progress);
-      }
+    // Duration unknown → em-dash placeholder rather than '0m'
+    // which the user reads as "track ended".
+    if (effectiveDuration <= 0) return '—';
+
+    let remainingSeconds = effectiveDuration;
+    if (isCurrentlyPlaying && storePosition >= 0) {
+      remainingSeconds = effectiveDuration - storePosition;
+    } else {
+      remainingSeconds = effectiveDuration * (1 - progress);
     }
 
-    if (remainingSeconds <= 0) return '0m';
+    if (remainingSeconds <= 0) return '0s';
+
+    // Under a minute → show seconds so short surahs (Al-Fatihah / An-Nas
+    // / Al-Falaq / Al-Ikhlas) don't all collapse to "0m" near the end.
+    if (remainingSeconds < 60) {
+      return `${Math.max(1, Math.ceil(remainingSeconds))}s`;
+    }
 
     const totalMinutes = Math.round(remainingSeconds / 60);
     if (totalMinutes >= 60) {


### PR DESCRIPTION
## Summary

Fix `RecentReciterCard#timeRemaining` returning `'0m'` in two distinct display states the user reads as "track ended":

1. **Duration unknown** — when `effectiveDuration` is 0 (duration hasn't been measured yet, or paused on a track with no `duration` field), the old code fell through to `'0m'`. Now returns `'—'` so the user knows the time is genuinely unknown rather than zero.

2. **Short tracks** — `Math.round(remainingSeconds / 60)` rounds to 0 for any remaining duration under 60s. Most visible on short surahs like Al-Fatihah (~50s total): every state past mid-track collapses to `'0m'`. Now shows seconds for remaining < 60s, e.g. `'20s'`.

Also tightens the "track ended" branch from `'0m'` → `'0s'` so the new lower-bound unit aligns with the new seconds branch above it.

## Discovery

Surfaced via user feedback on a downstream fork (Qariah's Greta walkthrough on Samsung Galaxy A55, TF-1036): user played Al-Fatihah for ~15s on the Listen tab → returning to Listen showed a "Continue Listening" card with `▶ 0m` badge even though ~35 seconds remained. Same `RecentReciterCard.tsx` lives on `develop` since its original Sprint-12-era introduction — no Qariah-specific patches involved.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (no new warnings; the 2 existing warnings on lines 55/63 pre-date this change)
- [ ] Visual: short surah (e.g. Al-Fatihah) plays for ~15s, return to Listen, verify badge reads "20s" or similar (not "0m")
- [ ] Visual: long surah plays, behavior unchanged at minute resolution
- [ ] Visual: track in initial state with no duration → badge reads "—" not "0m"

Originally shipped on Qariah's fork as commit `e8df7d5` (Sprint 24 FB-4 fix). Cherry-picked here as a goodwill chore PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)