### PR TITLE
chore: drop unused expo-media-library plugin + media perms

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,9 +5,6 @@
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
   <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
-  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
-  <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>

--- a/app.config.js
+++ b/app.config.js
@@ -170,7 +170,6 @@ module.exports = {
       'expo-router',
       ['expo-audio', {enableBackgroundPlayback: true}],
       'expo-sqlite',
-      'expo-media-library',
       [
         'expo-splash-screen',
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "expo-image": "~55.0.5",
         "expo-linear-gradient": "~55.0.8",
         "expo-linking": "~55.0.7",
-        "expo-media-library": "~55.0.9",
         "expo-navigation-bar": "~55.0.8",
         "expo-notifications": "~55.0.10",
         "expo-router": "~55.0.3",
@@ -12977,16 +12976,6 @@
       },
       "peerDependencies": {
         "expo": "*"
-      }
-    },
-    "node_modules/expo-media-library": {
-      "version": "55.0.9",
-      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-55.0.9.tgz",
-      "integrity": "sha512-E12e4gjQEZNdAa7MHDLOAiOMQmhmOGHFMMU5DpiK6I01hPXyRcaxgAQQLpibIXNP4O5LjGi2psa3NBacjyjxkw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo-module-scripts": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "expo-image": "~55.0.5",
     "expo-linear-gradient": "~55.0.8",
     "expo-linking": "~55.0.7",
-    "expo-media-library": "~55.0.9",
     "expo-navigation-bar": "~55.0.8",
     "expo-notifications": "~55.0.10",
     "expo-router": "~55.0.3",


### PR DESCRIPTION
## Summary

`expo-media-library` is registered as a config plugin in `app.config.js` and listed as a direct dep in `package.json`, but it's never imported in source — pre-flight grep across `*.ts`/`*.tsx`/`*.js`/`*.jsx` returns zero matches outside `node_modules`. Pure dead inheritance.

The plugin auto-injects three Android permissions on every build: `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO`, `READ_MEDIA_VISUAL_USER_SELECTED`. Those trigger Play Console's **Photo and Video Permissions Declaration** form at AAB upload time — a release blocker the first time anyone tries to ship Bayaan (or a fork) to the Play Store, even though the app doesn't use either photos or video.

## Cleanup

- Drop the plugin registration from `app.config.js`.
- Drop the `"expo-media-library": "~55.0.9"` direct dep from `package.json`.
- Drop the 3 `READ_MEDIA_*` perms from `AndroidManifest.xml`. **Keep `READ_MEDIA_AUDIO`** (genuinely needed for the share-intent audio filter that lets users send audio files into Bayaan).
- `package-lock.json` re-synced via `npm install --ignore-scripts`.

## Downstream context

Discovered while a Bayaan fork (Qariah) was attempting its first AAB upload — Play Console blocked it on the Photo/Video Permissions Declaration despite the app having no media-library functionality. Fixed downstream as `e76747b` on 2026-05-23. Porting the same fix here so future Bayaan-derived forks (and Bayaan itself if/when uploading to Play) don't hit the same blocker.

## Test plan

- [x] `git grep -rE "from ['\"]expo-media-library|require\(['\"]expo-media-library"` — zero matches outside node_modules
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint app.config.js` clean (1 pre-existing warning unrelated)
- [x] `package-lock.json` no longer contains `expo-media-library` references
- [ ] `expo prebuild --platform android --clean` does not regenerate the dropped perms (verify on next prebuild cycle)
- [ ] Visual: native build still completes, share-intent audio path still works (no change expected since `READ_MEDIA_AUDIO` was retained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)