### PR TITLE
chore(branding): convert top-level const arrays to getX() factories

### DIFF
--- a/app/(tabs)/(d.settings)/credits.tsx
+++ b/app/(tabs)/(d.settings)/credits.tsx
@@ -5,6 +5,7 @@ import {ScaledSheet, moderateScale} from 'react-native-size-matters';
 import {Feather} from '@expo/vector-icons';
 import Color from 'color';
 import {Theme} from '@/utils/themeUtils';
+import branding from '@/config/branding';
 
 interface Credit {
   title: string;
@@ -12,113 +13,120 @@ interface Credit {
   link?: string;
 }
 
-const CREDITS: {
-  section: string;
-  items: Credit[];
-}[] = [
-  {
-    section: 'Quran Data',
-    items: [
-      {
-        title: 'Quranic Universal Library',
-        description:
-          'Advanced Quranic data and word-level information by Tarteel',
-        link: 'https://qul.tarteel.ai',
-      },
-      {
-        title: 'Quran Foundation API',
-        description: 'Comprehensive Quran API services by Quran.com',
-        link: 'https://api-docs.quran.foundation',
-      },
-    ],
-  },
-  {
-    section: 'Audio Sources',
-    items: [
-      {
-        title: 'MP3Quran',
-        description: 'Comprehensive reciter collection',
-        link: 'https://mp3quran.net',
-      },
-    ],
-  },
-  {
-    section: 'Design Resources',
-    items: [
-      {
-        title: 'SVGRepo',
-        description: 'Beautiful open source icons and illustrations',
-        link: 'https://www.svgrepo.com',
-      },
-      {
-        title: 'Manrope Font',
-        description: 'Modern geometric sans-serif font family',
-        link: 'https://fonts.google.com/specimen/Manrope',
-      },
-      {
-        title: 'Uthmani Font',
-        description: 'Beautiful Quranic font from Arabic Fonts',
-        link: 'https://arabicfonts.net',
-      },
-      {
-        title: 'Quran.com Resources',
-        description: 'Surah name SVGs and icons',
-        link: 'https://api-docs.quran.foundation',
-      },
-    ],
-  },
-  {
-    section: 'Open Source Libraries',
-    items: [
-      {
-        title: 'React Native',
-        description: 'Core framework',
-        link: 'https://reactnative.dev',
-      },
-      {
-        title: 'Expo',
-        description: 'Development platform',
-        link: 'https://expo.dev',
-      },
-      {
-        title: 'React Native Reanimated',
-        description: 'Animations library',
-        link: 'https://docs.swmansion.com/react-native-reanimated/',
-      },
-    ],
-  },
-  {
-    section: 'Special Thanks',
-    items: [
-      {
-        title: 'Our Contributors',
-        description: 'Everyone who helped make Bayaan better',
-      },
-      {
-        title: 'Beta Testers',
-        description: 'For their valuable feedback and suggestions',
-      },
-      {
-        title: 'Muslim Community',
-        description: 'For their continuous support and guidance',
-      },
-    ],
-  },
-  {
-    section: 'Design & Art',
-    items: [
-      {
-        title: 'Dr. Naoki Yamamoto',
-        description: 'Custom designed splash screen calligraphy',
-        link: 'https://twitter.com/NaokiQYamamoto',
-      },
-    ],
-  },
-];
+/**
+ * Credits data factory. Brand strings (e.g. `branding.appName`) resolve
+ * at call time, not module load — this lets a fork override `branding`
+ * without having to fork this file. Originally a top-level const, but
+ * top-level const arrays evaluate before any `branding` resolution,
+ * baking the upstream brand name into the bundle.
+ */
+function getCredits(): {section: string; items: Credit[]}[] {
+  return [
+    {
+      section: 'Quran Data',
+      items: [
+        {
+          title: 'Quranic Universal Library',
+          description:
+            'Advanced Quranic data and word-level information by Tarteel',
+          link: 'https://qul.tarteel.ai',
+        },
+        {
+          title: 'Quran Foundation API',
+          description: 'Comprehensive Quran API services by Quran.com',
+          link: 'https://api-docs.quran.foundation',
+        },
+      ],
+    },
+    {
+      section: 'Audio Sources',
+      items: [
+        {
+          title: 'MP3Quran',
+          description: 'Comprehensive reciter collection',
+          link: 'https://mp3quran.net',
+        },
+      ],
+    },
+    {
+      section: 'Design Resources',
+      items: [
+        {
+          title: 'SVGRepo',
+          description: 'Beautiful open source icons and illustrations',
+          link: 'https://www.svgrepo.com',
+        },
+        {
+          title: 'Manrope Font',
+          description: 'Modern geometric sans-serif font family',
+          link: 'https://fonts.google.com/specimen/Manrope',
+        },
+        {
+          title: 'Uthmani Font',
+          description: 'Beautiful Quranic font from Arabic Fonts',
+          link: 'https://arabicfonts.net',
+        },
+        {
+          title: 'Quran.com Resources',
+          description: 'Surah name SVGs and icons',
+          link: 'https://api-docs.quran.foundation',
+        },
+      ],
+    },
+    {
+      section: 'Open Source Libraries',
+      items: [
+        {
+          title: 'React Native',
+          description: 'Core framework',
+          link: 'https://reactnative.dev',
+        },
+        {
+          title: 'Expo',
+          description: 'Development platform',
+          link: 'https://expo.dev',
+        },
+        {
+          title: 'React Native Reanimated',
+          description: 'Animations library',
+          link: 'https://docs.swmansion.com/react-native-reanimated/',
+        },
+      ],
+    },
+    {
+      section: 'Special Thanks',
+      items: [
+        {
+          title: 'Our Contributors',
+          description: `Everyone who helped make ${branding.appName} better`,
+        },
+        {
+          title: 'Beta Testers',
+          description: 'For their valuable feedback and suggestions',
+        },
+        {
+          title: 'Muslim Community',
+          description: 'For their continuous support and guidance',
+        },
+      ],
+    },
+    {
+      section: 'Design & Art',
+      items: [
+        {
+          title: 'Dr. Naoki Yamamoto',
+          description: 'Custom designed splash screen calligraphy',
+          link: 'https://twitter.com/NaokiQYamamoto',
+        },
+      ],
+    },
+  ];
+}
 
 export default function CreditsScreen() {
   const {theme} = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const credits = useMemo(() => getCredits(), []);
 
   const linkIconColor = Color(theme.colors.text).alpha(0.35).toString();
   const pressedBg = Color(theme.colors.text).alpha(0.06).toString();
@@ -144,7 +152,7 @@ export default function CreditsScreen() {
             tech world.
           </Text>
 
-          {CREDITS.map(section => (
+          {credits.map(section => (
             <View key={section.section} style={styles.section}>
               <Text style={styles.sectionHeader}>
                 {section.section.toUpperCase()}

--- a/components/modals/WhatsNewOnboarding/index.tsx
+++ b/components/modals/WhatsNewOnboarding/index.tsx
@@ -29,7 +29,7 @@ import {
   getLastSeenVersion,
   filterPagesByVersion,
 } from '@/utils/versionUtils';
-import {ONBOARDING_PAGES, OnboardingPage} from '@/data/onboardingPages';
+import {getOnboardingPages, OnboardingPage} from '@/data/onboardingPages';
 import OnboardingPageComponent from './OnboardingPage';
 import DotIndicator from './DotIndicator';
 
@@ -43,7 +43,7 @@ export const WhatsNewModal = forwardRef<WhatsNewModalRef>((_, ref) => {
   const {theme} = useTheme();
   const [visible, setVisible] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
-  const [pages, setPages] = useState<OnboardingPage[]>(ONBOARDING_PAGES);
+  const [pages, setPages] = useState<OnboardingPage[]>(getOnboardingPages());
   const flatListRef = useRef<FlatList<OnboardingPage>>(null);
   const scrollX = useSharedValue(0);
 
@@ -57,7 +57,7 @@ export const WhatsNewModal = forwardRef<WhatsNewModalRef>((_, ref) => {
 
   useImperativeHandle(ref, () => ({
     show: () => {
-      setPages(ONBOARDING_PAGES);
+      setPages(getOnboardingPages());
       setCurrentPage(0);
       scrollX.value = 0;
       flatListRef.current?.scrollToOffset({offset: 0, animated: false});
@@ -71,7 +71,7 @@ export const WhatsNewModal = forwardRef<WhatsNewModalRef>((_, ref) => {
         const versionChanged = await hasVersionChanged();
         if (versionChanged) {
           const lastSeen = await getLastSeenVersion();
-          const filtered = filterPagesByVersion(ONBOARDING_PAGES, lastSeen);
+          const filtered = filterPagesByVersion(getOnboardingPages(), lastSeen);
 
           if (filtered.length === 0) return;
 

--- a/data/onboardingPages.ts
+++ b/data/onboardingPages.ts
@@ -1,3 +1,5 @@
+import branding from '@/config/branding';
+
 export interface OnboardingPage {
   id: string;
   icon: string;
@@ -10,140 +12,149 @@ export interface OnboardingPage {
   minVersion: string;
 }
 
-export const ONBOARDING_PAGES: OnboardingPage[] = [
-  {
-    id: 'welcome',
-    icon: 'app-icon',
-    title: 'Welcome to Bayaan',
-    subtitle: 'A New Chapter',
-    description:
-      'A beautiful Mushaf, ayah highlighting, word-by-word translation, adhkar, ambient sounds, and so much more.',
-    minVersion: '2.0',
-  },
-  {
-    id: 'mushaf',
-    icon: 'book-outline',
-    isCustomIcon: true,
-    gradientColors: ['#3B82F6', '#1D4ED8'],
-    title: 'The Mushaf',
-    description:
-      'A dedicated reading screen with the full Uthmani script, beautiful tajweed coloring, and an immersive reading mode.',
-    minVersion: '2.0',
-  },
-  {
-    id: 'highlighting',
-    icon: 'locate-outline',
-    gradientColors: ['#8B5CF6', '#6D28D9'],
-    title: 'Follow Along',
-    description:
-      'Each ayah highlights in sync with the recitation so you never lose your place. Available for most of your favorite reciters, and coming to all reciters soon.',
-    minVersion: '2.0',
-  },
-  {
-    id: 'memorize',
-    icon: 'repeat-outline',
-    isCustomIcon: true,
-    gradientColors: ['#6366F1', '#4338CA'],
-    title: 'Listen to Memorize',
-    description:
-      'Repeat a single ayah, play a range of verses, or loop an entire page. Perfect for hifdh and review.',
-    minVersion: '2.0',
-  },
-  {
-    id: 'uploads',
-    icon: 'cloud-upload-outline',
-    gradientColors: ['#06B6D4', '#0891B2'],
-    title: 'Personal Recitations',
-    description:
-      'Import your own audio recordings, tag them with surah and reciter metadata, and organize your personal collection.',
-    minVersion: '2.0',
-  },
-  {
-    id: 'ambient',
-    icon: 'leaf-outline',
-    isCustomIcon: true,
-    gradientColors: ['#10B981', '#059669'],
-    title: 'Ambient Sounds',
-    description:
-      'Layer calming nature soundscapes like rain, ocean, forest, and more over your recitation for a focused experience.',
-    minVersion: '2.0',
-  },
-  {
-    id: 'verse-interactions',
-    icon: 'bookmark-outline',
-    gradientColors: ['#F59E0B', '#D97706'],
-    title: 'Verse Interactions',
-    description:
-      'Bookmark, highlight, take notes, copy, and share any verse. Your annotations sync across the app.',
-    minVersion: '2.0',
-  },
-  {
-    id: 'adhkar',
-    icon: 'flower-outline',
-    isCustomIcon: true,
-    gradientColors: ['#EC4899', '#DB2777'],
-    title: 'Adhkar (Remembrance)',
-    description:
-      'The complete Hisnul Muslim collection with audio playback, Play All mode, and saved favorites.',
-    minVersion: '2.0',
-  },
-  {
-    id: 'wbw',
-    icon: 'text-outline',
-    isCustomIcon: true,
-    gradientColors: ['#0EA5E9', '#0284C7'],
-    title: 'Word by Word',
-    description:
-      'Tap any word to see its meaning, transliteration, and grammar — right in the mushaf or player.',
-    minVersion: '2.1',
-  },
-  {
-    id: 'translations',
-    icon: 'language-outline',
-    isCustomIcon: true,
-    gradientColors: ['#A855F7', '#7C3AED'],
-    title: 'Translations & Tafseer',
-    description:
-      'Browse dozens of translations and scholarly commentaries in multiple languages, all downloadable for offline use.',
-    minVersion: '2.1',
-  },
-  {
-    id: 'themes',
-    icon: 'color-palette-outline',
-    isCustomIcon: true,
-    gradientColors: ['#F43F5E', '#E11D48'],
-    title: 'Thematic Highlighting',
-    description:
-      'Verses are color-coded by theme so you can see the structure and topics of each surah at a glance.',
-    minVersion: '2.1',
-  },
-  {
-    id: 'indopak',
-    icon: 'globe-outline',
-    gradientColors: ['#22D3EE', '#06B6D4'],
-    title: 'IndoPak Script',
-    description:
-      'Switch to the IndoPak Nastaliq script in the mushaf for the style used across South Asia.',
-    minVersion: '2.1',
-  },
-  {
-    id: 'downloads',
-    icon: 'download-outline',
-    isCustomIcon: true,
-    gradientColors: ['#14B8A6', '#0D9488'],
-    title: 'Offline Downloads',
-    description:
-      'Download individual surahs or entire playlists so you can listen without an internet connection.',
-    minVersion: '1.3',
-  },
-  {
-    id: 'playlists',
-    icon: 'list-outline',
-    isCustomIcon: true,
-    gradientColors: ['#F97316', '#EA580C'],
-    title: 'Playlists',
-    description:
-      'Create custom playlists, reorder tracks, and build your own listening routines.',
-    minVersion: '1.3',
-  },
-];
+/**
+ * Onboarding pages factory. Brand strings (e.g. `branding.appName`)
+ * resolve at call time, not module load — this lets a fork override
+ * `branding` without having to fork this file. Originally a top-level
+ * const, but top-level const arrays evaluate before any `branding`
+ * resolution, baking the upstream brand name into the bundle.
+ */
+export function getOnboardingPages(): OnboardingPage[] {
+  return [
+    {
+      id: 'welcome',
+      icon: 'app-icon',
+      title: `Welcome to ${branding.appName}`,
+      subtitle: 'A New Chapter',
+      description:
+        'A beautiful Mushaf, ayah highlighting, word-by-word translation, adhkar, ambient sounds, and so much more.',
+      minVersion: '2.0',
+    },
+    {
+      id: 'mushaf',
+      icon: 'book-outline',
+      isCustomIcon: true,
+      gradientColors: ['#3B82F6', '#1D4ED8'],
+      title: 'The Mushaf',
+      description:
+        'A dedicated reading screen with the full Uthmani script, beautiful tajweed coloring, and an immersive reading mode.',
+      minVersion: '2.0',
+    },
+    {
+      id: 'highlighting',
+      icon: 'locate-outline',
+      gradientColors: ['#8B5CF6', '#6D28D9'],
+      title: 'Follow Along',
+      description:
+        'Each ayah highlights in sync with the recitation so you never lose your place. Available for most of your favorite reciters, and coming to all reciters soon.',
+      minVersion: '2.0',
+    },
+    {
+      id: 'memorize',
+      icon: 'repeat-outline',
+      isCustomIcon: true,
+      gradientColors: ['#6366F1', '#4338CA'],
+      title: 'Listen to Memorize',
+      description:
+        'Repeat a single ayah, play a range of verses, or loop an entire page. Perfect for hifdh and review.',
+      minVersion: '2.0',
+    },
+    {
+      id: 'uploads',
+      icon: 'cloud-upload-outline',
+      gradientColors: ['#06B6D4', '#0891B2'],
+      title: 'Personal Recitations',
+      description:
+        'Import your own audio recordings, tag them with surah and reciter metadata, and organize your personal collection.',
+      minVersion: '2.0',
+    },
+    {
+      id: 'ambient',
+      icon: 'leaf-outline',
+      isCustomIcon: true,
+      gradientColors: ['#10B981', '#059669'],
+      title: 'Ambient Sounds',
+      description:
+        'Layer calming nature soundscapes like rain, ocean, forest, and more over your recitation for a focused experience.',
+      minVersion: '2.0',
+    },
+    {
+      id: 'verse-interactions',
+      icon: 'bookmark-outline',
+      gradientColors: ['#F59E0B', '#D97706'],
+      title: 'Verse Interactions',
+      description:
+        'Bookmark, highlight, take notes, copy, and share any verse. Your annotations sync across the app.',
+      minVersion: '2.0',
+    },
+    {
+      id: 'adhkar',
+      icon: 'flower-outline',
+      isCustomIcon: true,
+      gradientColors: ['#EC4899', '#DB2777'],
+      title: 'Adhkar (Remembrance)',
+      description:
+        'The complete Hisnul Muslim collection with audio playback, Play All mode, and saved favorites.',
+      minVersion: '2.0',
+    },
+    {
+      id: 'wbw',
+      icon: 'text-outline',
+      isCustomIcon: true,
+      gradientColors: ['#0EA5E9', '#0284C7'],
+      title: 'Word by Word',
+      description:
+        'Tap any word to see its meaning, transliteration, and grammar — right in the mushaf or player.',
+      minVersion: '2.1',
+    },
+    {
+      id: 'translations',
+      icon: 'language-outline',
+      isCustomIcon: true,
+      gradientColors: ['#A855F7', '#7C3AED'],
+      title: 'Translations & Tafseer',
+      description:
+        'Browse dozens of translations and scholarly commentaries in multiple languages, all downloadable for offline use.',
+      minVersion: '2.1',
+    },
+    {
+      id: 'themes',
+      icon: 'color-palette-outline',
+      isCustomIcon: true,
+      gradientColors: ['#F43F5E', '#E11D48'],
+      title: 'Thematic Highlighting',
+      description:
+        'Verses are color-coded by theme so you can see the structure and topics of each surah at a glance.',
+      minVersion: '2.1',
+    },
+    {
+      id: 'indopak',
+      icon: 'globe-outline',
+      gradientColors: ['#22D3EE', '#06B6D4'],
+      title: 'IndoPak Script',
+      description:
+        'Switch to the IndoPak Nastaliq script in the mushaf for the style used across South Asia.',
+      minVersion: '2.1',
+    },
+    {
+      id: 'downloads',
+      icon: 'download-outline',
+      isCustomIcon: true,
+      gradientColors: ['#14B8A6', '#0D9488'],
+      title: 'Offline Downloads',
+      description:
+        'Download individual surahs or entire playlists so you can listen without an internet connection.',
+      minVersion: '1.3',
+    },
+    {
+      id: 'playlists',
+      icon: 'list-outline',
+      isCustomIcon: true,
+      gradientColors: ['#F97316', '#EA580C'],
+      title: 'Playlists',
+      description:
+        'Create custom playlists, reorder tracks, and build your own listening routines.',
+      minVersion: '1.3',
+    },
+  ];
+}

--- a/data/systemPlaylists.ts
+++ b/data/systemPlaylists.ts
@@ -1,7 +1,15 @@
 /**
- * System Playlists - Curated playlists created by Bayaan
- * These are read-only playlists that provide themed collections of Quranic recitations
+ * System Playlists - Curated playlists shipped with the app.
+ * These are read-only playlists that provide themed collections of Quranic recitations.
+ *
+ * The data lives behind `getSystemPlaylists()` (not a top-level const) so that
+ * brand strings inside the array — e.g. the "Bayaan Essentials" trending tile —
+ * resolve `branding.appName` at call time. Top-level const arrays evaluate
+ * before any `branding` resolution, baking the upstream brand name into the
+ * bundle.
  */
+
+import branding from '@/config/branding';
 
 export interface SystemPlaylistItem {
   surahId: number;
@@ -23,297 +31,302 @@ export interface SystemPlaylist {
 }
 
 /**
- * System playlists organized by category
- * Total: 12 playlists (6 per column)
+ * System playlists organized by category. Factory so brand strings
+ * inside the array resolve `branding.appName` at call time.
+ * Total: 12 playlists (6 per column).
  */
-export const SYSTEM_PLAYLISTS: SystemPlaylist[] = [
-  // ========== LEFT COLUMN ==========
+export function getSystemPlaylists(): SystemPlaylist[] {
+  return [
+    // ========== LEFT COLUMN ==========
 
-  // Time-based: Morning Reflections
-  {
-    id: 'morning-reflections',
-    title: 'Morning Reflections',
-    description:
-      'Start your day with uplifting surahs that inspire gratitude and hope',
-    backgroundColor: '#F59E0B', // Warm amber
-    type: 'surah-only',
-    items: [
-      {surahId: 1}, // Al-Fatihah
-      {surahId: 93}, // Ad-Duhaa
-      {surahId: 94}, // Ash-Sharh
-      {surahId: 112}, // Al-Ikhlas
-      {surahId: 113}, // Al-Falaq
-      {surahId: 114}, // An-Nas
-    ],
-    heightMultiplier: 2,
-    column: 'left',
-    order: 1,
-  },
+    // Time-based: Morning Reflections
+    {
+      id: 'morning-reflections',
+      title: 'Morning Reflections',
+      description:
+        'Start your day with uplifting surahs that inspire gratitude and hope',
+      backgroundColor: '#F59E0B', // Warm amber
+      type: 'surah-only',
+      items: [
+        {surahId: 1}, // Al-Fatihah
+        {surahId: 93}, // Ad-Duhaa
+        {surahId: 94}, // Ash-Sharh
+        {surahId: 112}, // Al-Ikhlas
+        {surahId: 113}, // Al-Falaq
+        {surahId: 114}, // An-Nas
+      ],
+      heightMultiplier: 2,
+      column: 'left',
+      order: 1,
+    },
 
-  // Duration: Quick Listen
-  {
-    id: 'quick-listen',
-    title: 'Quick Listen',
-    subtitle: '5-15 minutes',
-    description:
-      'Perfect for short listening sessions during your commute or breaks',
-    backgroundColor: '#8B5CF6', // Purple
-    type: 'surah-only',
-    items: [
-      {surahId: 36}, // Ya-Sin
-      {surahId: 55}, // Ar-Rahman
-      {surahId: 56}, // Al-Waqiah
-      {surahId: 67}, // Al-Mulk
-      {surahId: 78}, // An-Naba
-    ],
-    heightMultiplier: 1,
-    column: 'left',
-    order: 2,
-  },
+    // Duration: Quick Listen
+    {
+      id: 'quick-listen',
+      title: 'Quick Listen',
+      subtitle: '5-15 minutes',
+      description:
+        'Perfect for short listening sessions during your commute or breaks',
+      backgroundColor: '#8B5CF6', // Purple
+      type: 'surah-only',
+      items: [
+        {surahId: 36}, // Ya-Sin
+        {surahId: 55}, // Ar-Rahman
+        {surahId: 56}, // Al-Waqiah
+        {surahId: 67}, // Al-Mulk
+        {surahId: 78}, // An-Naba
+      ],
+      heightMultiplier: 1,
+      column: 'left',
+      order: 2,
+    },
 
-  // Purpose: Heart Softeners
-  {
-    id: 'heart-softeners',
-    title: 'Heart Softeners',
-    description: 'Emotional and touching recitations that deeply move the soul',
-    backgroundColor: '#EC4899', // Pink
-    type: 'surah-only',
-    items: [
-      {surahId: 12}, // Yusuf
-      {surahId: 18}, // Al-Kahf
-      {surahId: 19}, // Maryam
-      {surahId: 36}, // Ya-Sin
-      {surahId: 55}, // Ar-Rahman
-      {surahId: 56}, // Al-Waqiah
-    ],
-    heightMultiplier: 2,
-    column: 'left',
-    order: 3,
-  },
+    // Purpose: Heart Softeners
+    {
+      id: 'heart-softeners',
+      title: 'Heart Softeners',
+      description:
+        'Emotional and touching recitations that deeply move the soul',
+      backgroundColor: '#EC4899', // Pink
+      type: 'surah-only',
+      items: [
+        {surahId: 12}, // Yusuf
+        {surahId: 18}, // Al-Kahf
+        {surahId: 19}, // Maryam
+        {surahId: 36}, // Ya-Sin
+        {surahId: 55}, // Ar-Rahman
+        {surahId: 56}, // Al-Waqiah
+      ],
+      heightMultiplier: 2,
+      column: 'left',
+      order: 3,
+    },
 
-  // Educational: Stories of the Prophets
-  {
-    id: 'stories-prophets',
-    title: 'Stories of the Prophets',
-    description: 'Surahs featuring narratives of the messengers of Allah',
-    backgroundColor: '#0EA5E9', // Sky blue
-    type: 'surah-only',
-    items: [
-      {surahId: 10}, // Yunus
-      {surahId: 11}, // Hud
-      {surahId: 12}, // Yusuf
-      {surahId: 14}, // Ibrahim
-      {surahId: 19}, // Maryam
-      {surahId: 71}, // Nuh
-    ],
-    heightMultiplier: 1,
-    column: 'left',
-    order: 4,
-  },
+    // Educational: Stories of the Prophets
+    {
+      id: 'stories-prophets',
+      title: 'Stories of the Prophets',
+      description: 'Surahs featuring narratives of the messengers of Allah',
+      backgroundColor: '#0EA5E9', // Sky blue
+      type: 'surah-only',
+      items: [
+        {surahId: 10}, // Yunus
+        {surahId: 11}, // Hud
+        {surahId: 12}, // Yusuf
+        {surahId: 14}, // Ibrahim
+        {surahId: 19}, // Maryam
+        {surahId: 71}, // Nuh
+      ],
+      heightMultiplier: 1,
+      column: 'left',
+      order: 4,
+    },
 
-  // Special: Protection & Healing
-  {
-    id: 'protection-healing',
-    title: 'Protection & Healing',
-    description: 'Surahs for ruqyah and seeking refuge in Allah',
-    backgroundColor: '#10B981', // Emerald
-    type: 'surah-only',
-    items: [
-      {surahId: 1}, // Al-Fatihah
-      {surahId: 2}, // Al-Baqarah (for Ayat al-Kursi)
-      {surahId: 112}, // Al-Ikhlas
-      {surahId: 113}, // Al-Falaq
-      {surahId: 114}, // An-Nas
-    ],
-    heightMultiplier: 2,
-    column: 'left',
-    order: 5,
-  },
+    // Special: Protection & Healing
+    {
+      id: 'protection-healing',
+      title: 'Protection & Healing',
+      description: 'Surahs for ruqyah and seeking refuge in Allah',
+      backgroundColor: '#10B981', // Emerald
+      type: 'surah-only',
+      items: [
+        {surahId: 1}, // Al-Fatihah
+        {surahId: 2}, // Al-Baqarah (for Ayat al-Kursi)
+        {surahId: 112}, // Al-Ikhlas
+        {surahId: 113}, // Al-Falaq
+        {surahId: 114}, // An-Nas
+      ],
+      heightMultiplier: 2,
+      column: 'left',
+      order: 5,
+    },
 
-  // Trending: Most Loved
-  {
-    id: 'most-loved',
-    title: 'Most Loved',
-    description: 'Community favorites that resonate with listeners worldwide',
-    backgroundColor: '#EF4444', // Red
-    type: 'surah-only',
-    items: [
-      {surahId: 18}, // Al-Kahf
-      {surahId: 36}, // Ya-Sin
-      {surahId: 55}, // Ar-Rahman
-      {surahId: 56}, // Al-Waqiah
-      {surahId: 67}, // Al-Mulk
-    ],
-    heightMultiplier: 1,
-    column: 'left',
-    order: 6,
-  },
+    // Trending: Most Loved
+    {
+      id: 'most-loved',
+      title: 'Most Loved',
+      description: 'Community favorites that resonate with listeners worldwide',
+      backgroundColor: '#EF4444', // Red
+      type: 'surah-only',
+      items: [
+        {surahId: 18}, // Al-Kahf
+        {surahId: 36}, // Ya-Sin
+        {surahId: 55}, // Ar-Rahman
+        {surahId: 56}, // Al-Waqiah
+        {surahId: 67}, // Al-Mulk
+      ],
+      heightMultiplier: 1,
+      column: 'left',
+      order: 6,
+    },
 
-  // ========== RIGHT COLUMN ==========
+    // ========== RIGHT COLUMN ==========
 
-  // Time-based: Evening Serenity
-  {
-    id: 'evening-serenity',
-    title: 'Evening Serenity',
-    description: 'Calm and peaceful surahs perfect for evening reflection',
-    backgroundColor: '#6366F1', // Indigo
-    type: 'surah-only',
-    items: [
-      {surahId: 36}, // Ya-Sin
-      {surahId: 55}, // Ar-Rahman
-      {surahId: 67}, // Al-Mulk
-      {surahId: 76}, // Al-Insan
-      {surahId: 89}, // Al-Fajr
-    ],
-    heightMultiplier: 1,
-    column: 'right',
-    order: 1,
-  },
+    // Time-based: Evening Serenity
+    {
+      id: 'evening-serenity',
+      title: 'Evening Serenity',
+      description: 'Calm and peaceful surahs perfect for evening reflection',
+      backgroundColor: '#6366F1', // Indigo
+      type: 'surah-only',
+      items: [
+        {surahId: 36}, // Ya-Sin
+        {surahId: 55}, // Ar-Rahman
+        {surahId: 67}, // Al-Mulk
+        {surahId: 76}, // Al-Insan
+        {surahId: 89}, // Al-Fajr
+      ],
+      heightMultiplier: 1,
+      column: 'right',
+      order: 1,
+    },
 
-  // Time-based: Friday Essentials
-  {
-    id: 'friday-essentials',
-    title: 'Friday Essentials',
-    description: 'Al-Kahf and other recommended Friday recitations',
-    backgroundColor: '#059669', // Green
-    type: 'surah-only',
-    items: [
-      {surahId: 18}, // Al-Kahf (Friday essential)
-      {surahId: 32}, // As-Sajdah
-      {surahId: 62}, // Al-Jumuah
-      {surahId: 76}, // Al-Insan
-    ],
-    heightMultiplier: 2,
-    column: 'right',
-    order: 2,
-  },
+    // Time-based: Friday Essentials
+    {
+      id: 'friday-essentials',
+      title: 'Friday Essentials',
+      description: 'Al-Kahf and other recommended Friday recitations',
+      backgroundColor: '#059669', // Green
+      type: 'surah-only',
+      items: [
+        {surahId: 18}, // Al-Kahf (Friday essential)
+        {surahId: 32}, // As-Sajdah
+        {surahId: 62}, // Al-Jumuah
+        {surahId: 76}, // Al-Insan
+      ],
+      heightMultiplier: 2,
+      column: 'right',
+      order: 2,
+    },
 
-  // Purpose: Focus & Study
-  {
-    id: 'focus-study',
-    title: 'Focus & Study',
-    description: 'Measured, clear recitations ideal for background listening',
-    backgroundColor: '#14B8A6', // Teal
-    type: 'surah-only',
-    items: [
-      {surahId: 2}, // Al-Baqarah
-      {surahId: 3}, // Ali 'Imran
-      {surahId: 4}, // An-Nisa
-      {surahId: 18}, // Al-Kahf
-    ],
-    heightMultiplier: 1,
-    column: 'right',
-    order: 3,
-  },
+    // Purpose: Focus & Study
+    {
+      id: 'focus-study',
+      title: 'Focus & Study',
+      description: 'Measured, clear recitations ideal for background listening',
+      backgroundColor: '#14B8A6', // Teal
+      type: 'surah-only',
+      items: [
+        {surahId: 2}, // Al-Baqarah
+        {surahId: 3}, // Ali 'Imran
+        {surahId: 4}, // An-Nisa
+        {surahId: 18}, // Al-Kahf
+      ],
+      heightMultiplier: 1,
+      column: 'right',
+      order: 3,
+    },
 
-  // Special: Juz Amma
-  {
-    id: 'juz-amma',
-    title: 'Juz Amma',
-    subtitle: 'The 30th Juz',
-    description: 'Complete collection of short surahs from the last juz',
-    backgroundColor: '#F97316', // Orange
-    type: 'surah-only',
-    items: [
-      {surahId: 78}, // An-Naba
-      {surahId: 79}, // An-Naziat
-      {surahId: 80}, // Abasa
-      {surahId: 81}, // At-Takwir
-      {surahId: 82}, // Al-Infitar
-      {surahId: 83}, // Al-Mutaffifin
-      {surahId: 84}, // Al-Inshiqaq
-      {surahId: 85}, // Al-Buruj
-      {surahId: 86}, // At-Tariq
-      {surahId: 87}, // Al-Ala
-      {surahId: 88}, // Al-Ghashiyah
-      {surahId: 89}, // Al-Fajr
-      {surahId: 90}, // Al-Balad
-      {surahId: 91}, // Ash-Shams
-      {surahId: 92}, // Al-Layl
-      {surahId: 93}, // Ad-Duha
-      {surahId: 94}, // Ash-Sharh
-      {surahId: 95}, // At-Tin
-      {surahId: 96}, // Al-Alaq
-      {surahId: 97}, // Al-Qadr
-      {surahId: 98}, // Al-Bayyinah
-      {surahId: 99}, // Az-Zalzalah
-      {surahId: 100}, // Al-Adiyat
-      {surahId: 101}, // Al-Qariah
-      {surahId: 102}, // At-Takathur
-      {surahId: 103}, // Al-Asr
-      {surahId: 104}, // Al-Humazah
-      {surahId: 105}, // Al-Fil
-      {surahId: 106}, // Quraysh
-      {surahId: 107}, // Al-Maun
-      {surahId: 108}, // Al-Kawthar
-      {surahId: 109}, // Al-Kafirun
-      {surahId: 110}, // An-Nasr
-      {surahId: 111}, // Al-Masad
-      {surahId: 112}, // Al-Ikhlas
-      {surahId: 113}, // Al-Falaq
-      {surahId: 114}, // An-Nas
-    ],
-    heightMultiplier: 2,
-    column: 'right',
-    order: 4,
-  },
+    // Special: Juz Amma
+    {
+      id: 'juz-amma',
+      title: 'Juz Amma',
+      subtitle: 'The 30th Juz',
+      description: 'Complete collection of short surahs from the last juz',
+      backgroundColor: '#F97316', // Orange
+      type: 'surah-only',
+      items: [
+        {surahId: 78}, // An-Naba
+        {surahId: 79}, // An-Naziat
+        {surahId: 80}, // Abasa
+        {surahId: 81}, // At-Takwir
+        {surahId: 82}, // Al-Infitar
+        {surahId: 83}, // Al-Mutaffifin
+        {surahId: 84}, // Al-Inshiqaq
+        {surahId: 85}, // Al-Buruj
+        {surahId: 86}, // At-Tariq
+        {surahId: 87}, // Al-Ala
+        {surahId: 88}, // Al-Ghashiyah
+        {surahId: 89}, // Al-Fajr
+        {surahId: 90}, // Al-Balad
+        {surahId: 91}, // Ash-Shams
+        {surahId: 92}, // Al-Layl
+        {surahId: 93}, // Ad-Duha
+        {surahId: 94}, // Ash-Sharh
+        {surahId: 95}, // At-Tin
+        {surahId: 96}, // Al-Alaq
+        {surahId: 97}, // Al-Qadr
+        {surahId: 98}, // Al-Bayyinah
+        {surahId: 99}, // Az-Zalzalah
+        {surahId: 100}, // Al-Adiyat
+        {surahId: 101}, // Al-Qariah
+        {surahId: 102}, // At-Takathur
+        {surahId: 103}, // Al-Asr
+        {surahId: 104}, // Al-Humazah
+        {surahId: 105}, // Al-Fil
+        {surahId: 106}, // Quraysh
+        {surahId: 107}, // Al-Maun
+        {surahId: 108}, // Al-Kawthar
+        {surahId: 109}, // Al-Kafirun
+        {surahId: 110}, // An-Nasr
+        {surahId: 111}, // Al-Masad
+        {surahId: 112}, // Al-Ikhlas
+        {surahId: 113}, // Al-Falaq
+        {surahId: 114}, // An-Nas
+      ],
+      heightMultiplier: 2,
+      column: 'right',
+      order: 4,
+    },
 
-  // Special: Memorization Station
-  {
-    id: 'memorization-station',
-    title: 'Memorization Station',
-    description: 'Short surahs perfect for those beginning their memorization',
-    backgroundColor: '#7C3AED', // Violet
-    type: 'surah-only',
-    items: [
-      {surahId: 1}, // Al-Fatihah
-      {surahId: 103}, // Al-Asr
-      {surahId: 108}, // Al-Kawthar
-      {surahId: 109}, // Al-Kafirun
-      {surahId: 110}, // An-Nasr
-      {surahId: 111}, // Al-Masad
-      {surahId: 112}, // Al-Ikhlas
-      {surahId: 113}, // Al-Falaq
-      {surahId: 114}, // An-Nas
-    ],
-    heightMultiplier: 1,
-    column: 'right',
-    order: 5,
-  },
+    // Special: Memorization Station
+    {
+      id: 'memorization-station',
+      title: 'Memorization Station',
+      description:
+        'Short surahs perfect for those beginning their memorization',
+      backgroundColor: '#7C3AED', // Violet
+      type: 'surah-only',
+      items: [
+        {surahId: 1}, // Al-Fatihah
+        {surahId: 103}, // Al-Asr
+        {surahId: 108}, // Al-Kawthar
+        {surahId: 109}, // Al-Kafirun
+        {surahId: 110}, // An-Nasr
+        {surahId: 111}, // Al-Masad
+        {surahId: 112}, // Al-Ikhlas
+        {surahId: 113}, // Al-Falaq
+        {surahId: 114}, // An-Nas
+      ],
+      heightMultiplier: 1,
+      column: 'right',
+      order: 5,
+    },
 
-  // Trending: Bayaan Essentials
-  {
-    id: 'bayaan-essentials',
-    title: 'Bayaan Essentials',
-    description: 'Our top recommendations for every listener',
-    backgroundColor: '#DC2626', // Deep red
-    type: 'surah-only',
-    items: [
-      {surahId: 1}, // Al-Fatihah
-      {surahId: 18}, // Al-Kahf
-      {surahId: 36}, // Ya-Sin
-      {surahId: 55}, // Ar-Rahman
-      {surahId: 67}, // Al-Mulk
-      {surahId: 112}, // Al-Ikhlas
-    ],
-    heightMultiplier: 2,
-    column: 'right',
-    order: 6,
-  },
-];
+    // Trending: Bayaan Essentials
+    {
+      id: 'bayaan-essentials',
+      title: `${branding.appName} Essentials`,
+      description: 'Our top recommendations for every listener',
+      backgroundColor: '#DC2626', // Deep red
+      type: 'surah-only',
+      items: [
+        {surahId: 1}, // Al-Fatihah
+        {surahId: 18}, // Al-Kahf
+        {surahId: 36}, // Ya-Sin
+        {surahId: 55}, // Ar-Rahman
+        {surahId: 67}, // Al-Mulk
+        {surahId: 112}, // Al-Ikhlas
+      ],
+      heightMultiplier: 2,
+      column: 'right',
+      order: 6,
+    },
+  ];
+}
 
 /**
  * Get a system playlist by ID
  */
 export function getSystemPlaylistById(id: string): SystemPlaylist | undefined {
-  return SYSTEM_PLAYLISTS.find(playlist => playlist.id === id);
+  return getSystemPlaylists().find(playlist => playlist.id === id);
 }
 
 /**
  * Get all system playlists
  */
 export function getAllSystemPlaylists(): SystemPlaylist[] {
-  return SYSTEM_PLAYLISTS;
+  return getSystemPlaylists();
 }
 
 /**
@@ -323,11 +336,12 @@ export function getSystemPlaylistsByColumn(): {
   left: SystemPlaylist[];
   right: SystemPlaylist[];
 } {
-  const left = SYSTEM_PLAYLISTS.filter(p => p.column === 'left').sort(
-    (a, b) => a.order - b.order,
-  );
-  const right = SYSTEM_PLAYLISTS.filter(p => p.column === 'right').sort(
-    (a, b) => a.order - b.order,
-  );
+  const all = getSystemPlaylists();
+  const left = all
+    .filter(p => p.column === 'left')
+    .sort((a, b) => a.order - b.order);
+  const right = all
+    .filter(p => p.column === 'right')
+    .sort((a, b) => a.order - b.order);
   return {left, right};
 }


### PR DESCRIPTION
## Summary

Three module-load-time const arrays still hardcoded "Bayaan" because they evaluate before any `branding` import resolves. The branding-conformance lint flags hardcoded brand strings in source but can't catch these — the literals live inside object initializers in a top-level array assignment, so a file's `import branding from '@/config/branding'` (if present) hasn't run yet when the array evaluates.

Surfaced in #270's defensive re-grep after the call-site brand-string sweep landed. Left unmigrated then because the fix is structural (`const X = [...]` → `function getX() { return [...] }`) rather than a one-line swap.

## Changes

| File | Symbol | Brand literal |
|---|---|---|
| `data/onboardingPages.ts:17` | `ONBOARDING_PAGES` → `getOnboardingPages()` | `'Welcome to Bayaan'` → `\`Welcome to ${branding.appName}\`` |
| `data/systemPlaylists.ts:287` | `SYSTEM_PLAYLISTS` → `getSystemPlaylists()` | `'Bayaan Essentials'` → `\`${branding.appName} Essentials\`` |
| `app/(tabs)/(d.settings)/credits.tsx:95` | `CREDITS` → `getCredits()` | `'Everyone who helped make Bayaan better'` → templated |

`systemPlaylists.ts`'s three internal helpers (`getSystemPlaylistById`, `getAllSystemPlaylists`, `getSystemPlaylistsByColumn`) now call the factory instead of referencing the deleted const; external consumers were already using these helpers so no further call-site changes needed.

`onboardingPages.ts`'s one caller (`components/modals/WhatsNewOnboarding/index.tsx`) updated at 4 sites: import + `useState` init + `setPages` call + `filterPagesByVersion` arg.

`credits.tsx`'s render wraps `getCredits()` in `useMemo(() => getCredits(), [])` since it's already a one-shot snapshot per render — same behavior as the prior top-level const, but now lazy.

## Out of scope

The `Bayaan team` footer literal at `credits.tsx:193` and the intro `Text` at `credits.tsx:149` are JSX text nodes (not const-array entries) — separate follow-up if desired. Same with any other prose mentions of "Bayaan" in JSX trees.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (5 pre-existing warnings unrelated)
- [x] `npx prettier --check` clean
- [ ] WhatsNewOnboarding renders the same 14 pages with the same titles (the `branding.appName === 'Bayaan'` default means the rendered text is unchanged)
- [ ] System playlists grid renders the "Bayaan Essentials" tile (string also unchanged on the default branding)
- [ ] Credits screen renders all sections unchanged

Downstream confirmation: Qariah has been wanting this for two sprints — once this merges they can drop their downstream patches that special-case these three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)