### PR TITLE
chore(ios): sync main-app MARKETING_VERSION in pbxproj to match Info.plist (2.2.0)

### DIFF
--- a/ios/Bayaan.xcodeproj/project.pbxproj
+++ b/ios/Bayaan.xcodeproj/project.pbxproj
@@ -511,7 +511,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -543,7 +543,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
## Summary

The two main-app `XCBuildConfiguration` blocks (Debug + Release) in `ios/Bayaan.xcodeproj/project.pbxproj` had `MARKETING_VERSION = 1.0`, while `ios/Bayaan/Info.plist` (the runtime truth) has `2.2.0`. Bringing them in sync.

## Why

Surfaced during review of #280 (which extended `verify-version-sync.js` to cover iOS extension Info.plist files). While auditing the pbxproj for ShareExtension version state, noticed the main-app blocks were stale.

Bayaan ships with `GENERATE_INFOPLIST_FILE = NO` for the main target, so the committed `Info.plist` wins at build time and the stale pbxproj field has had no runtime effect. The drift went unnoticed because nothing reads it.

Three reasons to fix now:

1. **Defense-in-depth against future Xcode/expo prebuild changes**: if `GENERATE_INFOPLIST_FILE` ever flips to `YES` for the main target (Xcode upgrade default, expo prebuild template change, etc.), the stale `1.0` would suddenly become the truth and ship a version downgrade.
2. **Within-file consistency**: the ShareExtension blocks already correctly show `MARKETING_VERSION = 2.2.0` (lines 703, 729). Aligning main-app to match removes an inconsistency.
3. **Visibility for tools that DO scan main-app blocks** (App Store metadata extractors, static analysis tooling, future iterations of `verify-version-sync` that loosen the `-Info.plist` suffix filter).

`CURRENT_PROJECT_VERSION = 698` is already correct in all four blocks (both main-app and both ShareExtension), so no change needed there.

## Diff

```
ios/Bayaan.xcodeproj/project.pbxproj
- L514:  MARKETING_VERSION = 1.0;   →  MARKETING_VERSION = 2.2.0;
- L546:  MARKETING_VERSION = 1.0;   →  MARKETING_VERSION = 2.2.0;
```

After: all four `MARKETING_VERSION` lines (2 main-app + 2 ShareExtension) show `2.2.0`.

## Test plan

- [ ] CI green (TS, ESLint, Prettier, Jest)
- [ ] `grep MARKETING_VERSION ios/Bayaan.xcodeproj/project.pbxproj` returns four lines, all `2.2.0`
- [ ] No runtime behavior change expected; the field was never read at build time for the main target

🤖 Generated with [Claude Code](https://claude.com/claude-code)