### PR TITLE
fix: address PR #287 review follow-ups

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -60,8 +60,7 @@ module.exports = {
             CFBundleURLSchemes: ['bayaan'],
           },
         ],
-        NSPrivacyPolicyURL:
-          'https://osmansaeday.github.io/bayaan-privacy-policy',
+        NSPrivacyPolicyURL: PRIVACY_POLICY_URL,
         UISupportedInterfaceOrientations: [
           'UIInterfaceOrientationPortrait',
           'UIInterfaceOrientationLandscapeLeft',

--- a/components/mushaf/qcf/QCFPage.tsx
+++ b/components/mushaf/qcf/QCFPage.tsx
@@ -166,7 +166,7 @@ const QCFPage: React.FC<QCFPageProps> = ({
     // Reference glyph U+E000 in QuranCommon. Using the explicit escape
     // (not the literal char) so editors / Edit tools can't strip the
     // invisible PUA character and silently break the calc.
-    const ids = refFont.getGlyphIDs('');
+    const ids = refFont.getGlyphIDs('\uE000');
     const widths = refFont.getGlyphWidths(ids);
     const measuredW = widths[0] || 1;
     const scaledSize = (CONTENT_WIDTH / measuredW) * 100;

--- a/package.json
+++ b/package.json
@@ -39,11 +39,7 @@
     "build:prod:ios": "eas build --profile production --platform ios"
   },
   "jest": {
-    "preset": "jest-expo",
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "<rootDir>/utils/__tests__/storageAnalytics.test.ts"
-    ]
+    "preset": "jest-expo"
   },
   "dependencies": {
     "@babel/runtime": "^7.20.6",


### PR DESCRIPTION
## Summary

Addresses three findings from the review of PR #287 (develop → main):

- **`app.config.js`** — `NSPrivacyPolicyURL` was hardcoded to `https://osmansaeday.github.io/bayaan-privacy-policy`, which would have shipped a personal GitHub Pages URL in the official App Store privacy-policy field. Restored the `PRIVACY_POLICY_URL` constant (defaults to `https://thebayaan.com/privacy`, overridable via `EXPO_PUBLIC_PRIVACY_POLICY_URL`).
- **`components/mushaf/qcf/QCFPage.tsx`** — the comment at L166–168 explicitly warns "Using the explicit escape (not the literal char) so editors / Edit tools can't strip the invisible PUA character", but the code held a literal U+E000 (bytes `ee 80 80`). Replaced with `''` so the comment matches the code and the divider-font calc is robust against normalizers.
- **`package.json` + `utils/__tests__/storageAnalytics.test.ts`** — the empty (zero-byte) test file was both committed and listed in `testPathIgnorePatterns`. Deleted the file and dropped the ignore entry.

## Test plan

- [x] `npx tsc --noEmit` — exits 0
- [x] `npx prettier --write` on changed files — no formatting changes
- [ ] Verify `NSPrivacyPolicyURL` shows `https://thebayaan.com/privacy` (or the env override) in a prebuild Info.plist
- [ ] Confirm QCF mushaf divider-font sizing renders correctly on a real device build

🤖 Generated with [Claude Code](https://claude.com/claude-code)