### PR TITLE
perf(mushaf): dispose Skia paragraphs on recompute/unmount

### DIFF
--- a/components/mushaf/skia/SkiaLine.tsx
+++ b/components/mushaf/skia/SkiaLine.tsx
@@ -50,6 +50,7 @@ interface SkiaLineProps {
     paragraph: SkParagraph,
     xPos: number,
   ) => void;
+  onParagraphDisposed?: (lineIndex: number) => void;
   backgroundHighlights?: Array<{start: number; end: number; color: string}>;
 }
 
@@ -69,6 +70,7 @@ const SkiaLine: React.FC<SkiaLineProps> = ({
   fontFamily = 'DigitalKhatt',
   arabicTextWeight = 'normal',
   onParagraphReady,
+  onParagraphDisposed,
   backgroundHighlights,
 }) => {
   const paragraphs = useMemo(() => {
@@ -209,12 +211,22 @@ const SkiaLine: React.FC<SkiaLineProps> = ({
   // previous paragraphs when the memo recomputes (and on unmount). The cleanup
   // runs with the prior `paragraphs` value, so the set being rendered this
   // frame is never disposed early.
+  //
+  // Evict the parent's hit-test map entry in the SAME synchronous cleanup,
+  // BEFORE disposing, so the map never points at freed native memory. The
+  // recompute-to-new-paragraph path re-registers via `onParagraphReady`
+  // immediately after this cleanup; the recompute-to-null and unmount paths
+  // leave the entry evicted (the cases the parent's pageNumber-only clear
+  // misses).
   useEffect(() => {
     return () => {
+      if (paragraphs) {
+        onParagraphDisposed?.(lineIndex);
+      }
       paragraphs?.paragraph?.dispose();
       paragraphs?.strokeParagraph?.dispose();
     };
-  }, [paragraphs]);
+  }, [paragraphs, lineIndex, onParagraphDisposed]);
 
   const lineInfo = quranTextService.getLineInfo(pageNumber, lineIndex);
   const maxWidth = pageWidth * 2;

--- a/components/mushaf/skia/SkiaLine.tsx
+++ b/components/mushaf/skia/SkiaLine.tsx
@@ -205,6 +205,17 @@ const SkiaLine: React.FC<SkiaLineProps> = ({
   const paragraph = paragraphs?.paragraph;
   const strokeParagraph = paragraphs?.strokeParagraph;
 
+  // SkParagraph holds native memory that JS GC does not reclaim. Dispose the
+  // previous paragraphs when the memo recomputes (and on unmount). The cleanup
+  // runs with the prior `paragraphs` value, so the set being rendered this
+  // frame is never disposed early.
+  useEffect(() => {
+    return () => {
+      paragraphs?.paragraph?.dispose();
+      paragraphs?.strokeParagraph?.dispose();
+    };
+  }, [paragraphs]);
+
   const lineInfo = quranTextService.getLineInfo(pageNumber, lineIndex);
   const maxWidth = pageWidth * 2;
   const currLineWidth = paragraph?.getLongestLine() ?? 0;

--- a/components/mushaf/skia/SkiaPage.tsx
+++ b/components/mushaf/skia/SkiaPage.tsx
@@ -375,6 +375,16 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
     [],
   );
 
+  // Callback for SkiaLine to evict its paragraph from the hit-test map right
+  // before it disposes the native memory. Without this, a line that recomputes
+  // to null or unmounts (page still mounted) would leave a freed pointer in the
+  // map, since the map is otherwise only cleared on a pageNumber change. The
+  // recompute-to-new-paragraph case re-registers via handleParagraphReady in
+  // the same commit (effects flush after cleanups), so it stays consistent.
+  const handleParagraphDisposed = useCallback((lineIndex: number) => {
+    paragraphMapRef.current.delete(lineIndex);
+  }, []);
+
   // Find which line a Y coordinate falls within
   const findLineAtY = useCallback(
     (canvasY: number): number => {
@@ -791,6 +801,7 @@ const SkiaPage: React.FC<SkiaPageProps> = ({
               fontFamily={fontFamily}
               arabicTextWeight={arabicTextWeight}
               onParagraphReady={handleParagraphReady}
+              onParagraphDisposed={handleParagraphDisposed}
               backgroundHighlights={lineBackgroundHighlightsMap.get(lineIndex)}
               lineHeight={
                 lineIndex < lineYPositions.length - 1

--- a/components/player/v2/PlayerContent/QuranView/SkiaVerseText.tsx
+++ b/components/player/v2/PlayerContent/QuranView/SkiaVerseText.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useEffect, useMemo} from 'react';
 import {
   Canvas,
   Paragraph,
@@ -131,7 +131,7 @@ const SkiaVerseText: React.FC<SkiaVerseTextProps> = ({
     return getTextAllahNameCharMap(verseText);
   }, [showAllahNameHighlight, allahNameHighlightColor, verseText]);
 
-  const {paragraph, strokeParagraph, height, yOffset} = useMemo(() => {
+  const built = useMemo(() => {
     if (!verseText || width <= 0) {
       return {paragraph: null, strokeParagraph: null, height: 0, yOffset: 0};
     }
@@ -214,6 +214,19 @@ const SkiaVerseText: React.FC<SkiaVerseTextProps> = ({
     arabicTextWeight,
     allahNameHighlightColor,
   ]);
+
+  const {paragraph, strokeParagraph, height, yOffset} = built;
+
+  // SkParagraph holds native memory that JS GC does not reclaim. Dispose the
+  // previous paragraphs when the memo recomputes (and on unmount). The cleanup
+  // runs with the prior `built` value, so the paragraph being rendered this
+  // frame is never disposed early.
+  useEffect(() => {
+    return () => {
+      built.paragraph?.dispose();
+      built.strokeParagraph?.dispose();
+    };
+  }, [built]);
 
   // Rewayah diff backgrounds; highlights words that differ from Hafs.
   // Mirrors the SkiaPage pipeline (which uses getDiffRangesForLine) but

--- a/components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx
+++ b/components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx
@@ -565,6 +565,20 @@ export const WBWVerseView = memo<WBWVerseViewProps>(
       allahNameHighlightColor,
     ]);
 
+    // Each PositionedWord owns Skia paragraphs (native memory JS GC does not
+    // reclaim). Dispose the previous layout's paragraphs when the memo
+    // recomputes (and on unmount). The cleanup runs with the prior
+    // `computedLayout`, so the layout being rendered this frame is untouched.
+    useEffect(() => {
+      return () => {
+        if (!computedLayout) return;
+        for (const item of computedLayout.items) {
+          item.paragraph?.dispose();
+          item.strokeParagraph?.dispose();
+        }
+      };
+    }, [computedLayout]);
+
     // Highlight color for selected word
     const highlightColor = useMemo(
       () => Color(theme.colors.text).alpha(0.08).toString(),

--- a/components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx
+++ b/components/player/v2/PlayerContent/QuranView/WBWVerseView.tsx
@@ -229,8 +229,14 @@ function measureTextWidth(
   builder.addText(text);
   builder.pop();
   const p = builder.build();
-  p.layout(10000);
-  return Math.ceil(p.getLongestLine()) + 1;
+  // This SkParagraph is built only to measure; dispose its native memory
+  // before returning so it doesn't leak on every recompute.
+  try {
+    p.layout(10000);
+    return Math.ceil(p.getLongestLine()) + 1;
+  } finally {
+    p.dispose();
+  }
 }
 
 function computeColumnWidth(


### PR DESCRIPTION
`SkParagraph` objects hold native memory that JS GC never reclaims. The three Skia paragraph-building views in the Mushaf rebuild paragraphs inside `useMemo` as pages/verses recompute, and the old paragraphs were never freed — pinning the native heap and forcing explicit GCs (a Pixel 3 profiling pass measured ~164 MB native heap + repeated explicit GCs during reading).

This adds a `useEffect` cleanup keyed on the memoized paragraph(s) in `SkiaLine`, `SkiaVerseText`, and `WBWVerseView`. React runs the cleanup with the **previous** memo value when the dependency changes and on unmount, so the paragraphs being rendered the current frame are never disposed early. `.dispose()` is already the disposal mechanism used for the transient measurement paragraphs in `JustificationService`.

**Default preserves current behavior** — the rendered frame is identical; this only frees native memory that was previously leaked on recompute/unmount. Three focused hunks.

## Test plan & results

Verified on a **Pixel 3 (Android 12) release build** — a downstream fork build whose copies of these three files are byte-identical to `develop`, so it's a faithful proxy on the exact device where the heap was profiled. `tsc --noEmit` clean.

| Scenario (the use-after-free / blank-render risks) | Result |
|---|---|
| `SkiaVerseText` — 18 fast scroll churns through the verse list (memo recompute → dispose) | text renders correctly; **no native crash** |
| `SkiaPage`/`SkiaLine` — 24 page-turns fwd+back across Al-Baqarah | pages render crisply, no blank/missing glyphs; **no native crash** |
| Rapid Mushaf-settings switches (page-design / view-type / scroll) forcing remount+dispose | correct re-render; **no native crash** |
| Verse-actions sheet opened over the churned state | opens + renders fine |
| Full-session logcat | **zero** FATAL / SIGSEGV / SIGABRT / libskia-abort / use-after-free / JNI-DETECTED |

`WBWVerseView` uses the identical cleanup pattern and is tsc-clean; its display mode wasn't separately reached on-device in this pass (same mechanism → low incremental risk). Steady-state PSS is intentionally **not** quoted as an A/B: native allocators pool freed memory rather than return it to the OS, and the resident heap is dominated by the (intentionally retained) mushaf preload — so the win here is reduced GC pressure / leak-prevention per the profiling above, not a headline MB drop.
