### PR TITLE
perf(mushaf): bound and clear the page-layout cache

### DIFF
--- a/services/mushaf/JustificationService.ts
+++ b/services/mushaf/JustificationService.ts
@@ -929,8 +929,13 @@ export class JustService {
         fontFamily,
       );
       if (mmkvHit) {
-        // Populate in-memory cache for fastest subsequent access
-        pageCache.set(pageNumber, mmkvHit);
+        // Populate in-memory cache for fastest subsequent access (bounded)
+        JustService.cachePageLayout(
+          fontSizeLineWidthRatio,
+          pageNumber,
+          mmkvHit,
+          fontFamily,
+        );
         return mmkvHit;
       }
     } catch {
@@ -947,7 +952,24 @@ export class JustService {
     fontFamily: string = 'DigitalKhatt',
   ): void {
     const pageCache = getPageLayoutCache(fontSizeLineWidthRatio, fontFamily);
+    // Bound the per-partition page cache to the most recently used pages.
+    // Map preserves insertion order, so re-inserting on hit keeps recent
+    // pages live and the first key is always the oldest to evict.
+    pageCache.delete(pageNumber);
+    if (pageCache.size >= MAX_CACHED_PAGES_PER_PARTITION) {
+      const oldest = pageCache.keys().next().value;
+      if (oldest !== undefined) pageCache.delete(oldest);
+    }
     pageCache.set(pageNumber, layout);
+  }
+
+  /**
+   * Drop all in-memory page layouts. Layouts are keyed by rewayah/font/ratio,
+   * so stale partitions accumulate as the user switches rewayah or font size;
+   * call this on those transitions (QuranTextService.clearCaches does).
+   */
+  static clearPageLayoutCache(): void {
+    pageLayoutsCache.clear();
   }
 }
 
@@ -988,6 +1010,12 @@ function getPageLayoutCache(
   pageLayoutsCache.set(cacheKey, created);
   return created;
 }
+
+// Per-partition LRU bound. A reader rarely keeps more than a handful of
+// recently visited pages hot; the MMKV layer backs anything evicted, so a
+// modest cap keeps the in-memory cache useful without growing toward 604
+// pages per rewayah/font/ratio partition.
+const MAX_CACHED_PAGES_PER_PARTITION = 50;
 
 const pageLayoutsCache: Map<
   string,

--- a/services/mushaf/JustificationService.ts
+++ b/services/mushaf/JustificationService.ts
@@ -83,6 +83,12 @@ const dualJoinLetters = quranTextService.dualJoinLetters;
 const rightNoJoinLetters = quranTextService.rightNoJoinLetters;
 const finalAscendant = 'آادذٱأإكلهة';
 
+// Per-partition page-cache bound. A reader rarely keeps more than a handful of
+// recently visited pages hot; the MMKV layer backs anything evicted, so a
+// modest cap keeps the in-memory cache useful without growing toward 604
+// pages per rewayah/font/ratio partition.
+const MAX_CACHED_PAGES_PER_PARTITION = 50;
+
 // --- JustService class ---
 
 export class JustService {
@@ -952,9 +958,12 @@ export class JustService {
     fontFamily: string = 'DigitalKhatt',
   ): void {
     const pageCache = getPageLayoutCache(fontSizeLineWidthRatio, fontFamily);
-    // Bound the per-partition page cache to the most recently used pages.
-    // Map preserves insertion order, so re-inserting on hit keeps recent
-    // pages live and the first key is always the oldest to evict.
+    // Bound the per-partition page cache. Eviction is insertion/rewarm order:
+    // the delete+set below re-inserts on every write (and on an MMKV rewarm),
+    // so the first key is always the oldest-written page to evict. An in-memory
+    // read hit does not re-insert, so a resident page that is only re-read keeps
+    // its original recency — this is not strict access-LRU, but every eviction
+    // is backed by MMKV so it costs at most a ~1ms re-read.
     pageCache.delete(pageNumber);
     if (pageCache.size >= MAX_CACHED_PAGES_PER_PARTITION) {
       const oldest = pageCache.keys().next().value;
@@ -1011,12 +1020,10 @@ function getPageLayoutCache(
   return created;
 }
 
-// Per-partition LRU bound. A reader rarely keeps more than a handful of
-// recently visited pages hot; the MMKV layer backs anything evicted, so a
-// modest cap keeps the in-memory cache useful without growing toward 604
-// pages per rewayah/font/ratio partition.
-const MAX_CACHED_PAGES_PER_PARTITION = 50;
-
+// Each entry is a per-rewayah/font/ratio partition, itself capped at
+// MAX_CACHED_PAGES_PER_PARTITION pages. The partition COUNT is currently
+// unbounded (one per font-size ratio the user drags through); benign in
+// practice, worth a follow-up if ratio churn proves heavy.
 const pageLayoutsCache: Map<
   string,
   Map<number, JustResultByLine[]>

--- a/services/mushaf/QuranTextService.ts
+++ b/services/mushaf/QuranTextService.ts
@@ -56,6 +56,13 @@ class QuranTextService {
   clearCaches(): void {
     this.lineTextCache.clear();
     this.lineTextInfoCache.clear();
+    // Page layouts are keyed by rewayah/font/ratio; clear them on the same
+    // transitions (e.g. rewayah change) so stale partitions don't accumulate.
+    // Required lazily to avoid a JustificationService ⇄ QuranTextService
+    // import cycle (JustificationService imports from this module).
+    const {JustService} =
+      require('./JustificationService') as typeof import('./JustificationService');
+    JustService.clearPageLayoutCache();
   }
 
   private initBases(): void {


### PR DESCRIPTION
`pageLayoutsCache` in `JustificationService` grew without limit and was never cleared. It partitions by `font::rewayah::ratio`, and each partition can hold up to 604 page layouts, so switching rewayah / font / size left stale partitions resident for the whole session.

- Cap each partition's page map at the **50 most-recently-used** pages, evicting the oldest on overflow (Map insertion order; re-inserting on hit keeps recent pages live). The MMKV layer still backs evicted pages, so recent-page hits are unaffected.
- Add `JustService.clearPageLayoutCache()` and call it from `QuranTextService.clearCaches()` — which already runs on rewayah change — so stale partitions are dropped on exactly the transition that invalidates them (lazy `require` to avoid the JustificationService ⇄ QuranTextService import cycle, matching the existing pattern in both files).

**Default preserves current behavior** for the common case: recent pages still hit in memory; this only bounds growth and clears layouts that were already being recomputed after a rewayah/font change.

## Test plan & results

Verified on a **Pixel 3 release build** (files byte-identical to `develop`). `tsc --noEmit` clean.

| Scenario (the dropped-needed-layout / wrong-page risks) | Result |
|---|---|
| Repeatedly toggle PAGE DESIGN (Fullscreen↔Book) and VIEW TYPE (Mushaf↔List) — each switches the layout partition and runs `clearCaches` | page re-renders correctly every time; **no blank / wrong page**; no crash |
| 24 page-turns to populate the cache, then leave the Mushaf (triggers `clearCaches`) | correct render throughout; Graphics PSS released on leave (206 → 132 MB) |
| Full-session logcat | no FATAL / native abort |

Two files, tsc-clean.
