### PR TITLE
feat(sentry): tag release/dist + breadcrumb cold-start for crash observability

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -61,6 +61,11 @@ configureReanimatedLogger({
 // Cache for expo-navigation-bar module (Android only)
 let NavigationBarModule: any = null;
 
+// Cold-start budget: if prepare() blows past this, fire a one-shot
+// 'slow-cold-start' Sentry message naming the phase it stalled in. prepare()
+// is gated by initializationRef, so this fires at most once per process.
+const SLOW_BOOT_THRESHOLD_MS = 8000;
+
 // Prevent the splash screen from auto-hiding
 SplashScreen.preventAutoHideAsync().catch(() => {
   /* reloading the app might trigger some race conditions, ignore them */
@@ -74,6 +79,18 @@ SystemUI.setBackgroundColorAsync(
 
 const analyticsEnabled = process.env.EXPO_PUBLIC_ANALYTICS_ENABLED !== 'false';
 
+// Narrows the `any`-typed expoConfig.extra.version without an `as` cast.
+function isVersionInfo(
+  value: unknown,
+): value is {semanticVersion: string; buildNumber: string | number} {
+  if (value == null || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.semanticVersion === 'string' &&
+    (typeof v.buildNumber === 'string' || typeof v.buildNumber === 'number')
+  );
+}
+
 if (analyticsEnabled) {
   // Explicit release + dist tagging. Android events were landing with no
   // release (`release: None`), so crashes/ANRs couldn't be tied to a build.
@@ -82,14 +99,16 @@ if (analyticsEnabled) {
   // platforms, unlike Sentry's native auto-detection. `undefined` is a safe
   // no-op (Sentry falls back to auto-detect), so a missing manifest can't
   // regress the current behavior.
-  const versionInfo = Constants.expoConfig?.extra?.version as
-    | {semanticVersion?: string; buildNumber?: string | number}
-    | undefined;
+  const rawVersion: unknown = Constants.expoConfig?.extra?.version;
+  const versionInfo = isVersionInfo(rawVersion) ? rawVersion : undefined;
   const appId =
     Constants.expoConfig?.ios?.bundleIdentifier ??
     Constants.expoConfig?.android?.package;
+  // Require appId too — without it the template literal would stringify
+  // `undefined` into the release name (e.g. "undefined@2.2.1+935"). Falling
+  // back to an undefined release is the safe no-op (Sentry auto-detects).
   const sentryRelease =
-    versionInfo?.semanticVersion != null && versionInfo?.buildNumber != null
+    versionInfo != null && appId != null
       ? `${appId}@${versionInfo.semanticVersion}+${versionInfo.buildNumber}`
       : undefined;
   const sentryDist =
@@ -246,7 +265,7 @@ function RootLayout() {
           level: 'warning',
           tags: {scope: 'cold-start', boot_step: lastBootStep},
         });
-      }, 8000);
+      }, SLOW_BOOT_THRESHOLD_MS);
       try {
         markBoot('start');
         if (__DEV__)

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -48,6 +48,7 @@ import {SheetManager} from 'react-native-actions-sheet';
 import {showToast} from '@/utils/toastUtils';
 import {mushafSessionStore} from '@/services/mushaf/MushafSessionStore';
 import {USE_GLASS} from '@/hooks/useGlassProps';
+import Constants from 'expo-constants';
 import * as Sentry from '@sentry/react-native';
 import * as ScreenOrientation from 'expo-screen-orientation';
 
@@ -74,10 +75,34 @@ SystemUI.setBackgroundColorAsync(
 const analyticsEnabled = process.env.EXPO_PUBLIC_ANALYTICS_ENABLED !== 'false';
 
 if (analyticsEnabled) {
+  // Explicit release + dist tagging. Android events were landing with no
+  // release (`release: None`), so crashes/ANRs couldn't be tied to a build.
+  // Derive both from the build-time version injected into
+  // expoConfig.extra.version by scripts/generate-version.js — reliable on both
+  // platforms, unlike Sentry's native auto-detection. `undefined` is a safe
+  // no-op (Sentry falls back to auto-detect), so a missing manifest can't
+  // regress the current behavior.
+  const versionInfo = Constants.expoConfig?.extra?.version as
+    | {semanticVersion?: string; buildNumber?: string | number}
+    | undefined;
+  const appId =
+    Constants.expoConfig?.ios?.bundleIdentifier ??
+    Constants.expoConfig?.android?.package;
+  const sentryRelease =
+    versionInfo?.semanticVersion != null && versionInfo?.buildNumber != null
+      ? `${appId}@${versionInfo.semanticVersion}+${versionInfo.buildNumber}`
+      : undefined;
+  const sentryDist =
+    versionInfo?.buildNumber != null
+      ? String(versionInfo.buildNumber)
+      : undefined;
+
   Sentry.init({
     dsn: process.env.EXPO_PUBLIC_SENTRY_DSN ?? '',
     tracesSampleRate: 0.2,
     enableAutoSessionTracking: true,
+    release: sentryRelease,
+    dist: sentryDist,
   });
 }
 
@@ -206,21 +231,42 @@ function RootLayout() {
     }
 
     async function prepare() {
+      // Cold-start observability. Breadcrumb each boot phase so any later
+      // crash/ANR carries the boot trail, and fire a one-shot 'slow-cold-start'
+      // Sentry message if we blow past the budget — turning the otherwise-
+      // invisible splash-screen hang into a queryable signal that names the
+      // phase it stalled in.
+      let lastBootStep = 'start';
+      const markBoot = (step: string): void => {
+        lastBootStep = step;
+        Sentry.addBreadcrumb({category: 'boot', message: step, level: 'info'});
+      };
+      const slowBootWatchdog = setTimeout(() => {
+        Sentry.captureMessage('slow-cold-start', {
+          level: 'warning',
+          tags: {scope: 'cold-start', boot_step: lastBootStep},
+        });
+      }, 8000);
       try {
+        markBoot('start');
         if (__DEV__)
           console.log('[App] Starting initialization with expo-audio...');
 
         // Initialize expo-audio service
         await expoAudioService.initialize();
+        markBoot('expo-audio-ready');
         if (__DEV__) console.log('[App] expo-audio service initialized');
 
         // Fetch reciter data from backend API (or fallback if killswitch active)
+        markBoot('catalog-fetch-start');
         await getAllReciters();
+        markBoot('catalog-ready');
         if (__DEV__) console.log('[App] Reciter data loaded');
 
         // Initialize all SQLite services, adhkar, playlists, mushaf, fonts, stores, etc.
         // This blocks splash screen so everything is ready when the user sees the app
         await appInitializer.initialize();
+        markBoot('app-initializer-ready');
         if (__DEV__) console.log('[App] AppInitializer complete');
 
         // PRE-WARM: Initialize stores BEFORE first play to prevent cold start lag
@@ -237,6 +283,7 @@ function RootLayout() {
         // Restore last session so floating player + lock screen show last track
         try {
           await restoreSession();
+          markBoot('session-restored');
           if (__DEV__) console.log('[App] Session restored');
         } catch (error) {
           console.debug('[App] Failed to restore session:', error);
@@ -246,6 +293,7 @@ function RootLayout() {
         setIsPlayerReady(true);
         setAppIsReady(true);
         initializationRef.current = true;
+        markBoot('ready');
         if (__DEV__) console.log('[App] Initialization complete');
       } catch (error) {
         console.error('[App] Preparation error:', error);
@@ -263,6 +311,8 @@ function RootLayout() {
         setIsPlayerReady(false);
         setAppIsReady(false);
         initializationRef.current = false;
+      } finally {
+        clearTimeout(slowBootWatchdog);
       }
     }
 


### PR DESCRIPTION
Two small, generic observability changes in `app/_layout.tsx` — both no-config-change and safe.

## 1. Explicit `release` + `dist` in `Sentry.init`

Android crash/ANR events were landing in Sentry with `release: None` — Sentry's native release auto-detection isn't reliable on Android, so an event couldn't be tied to a build. This derives `release` + `dist` from the build-time version that `scripts/generate-version.js` already injects into `expoConfig.extra.version`, and sets them explicitly in `Sentry.init`.

```ts
release: `${appId}@${semanticVersion}+${buildNumber}`
dist: String(buildNumber)
```

If the manifest is somehow missing the version info, both resolve to `undefined`, which is a no-op (Sentry just falls back to its existing auto-detect) — so this can't regress current behavior. `appId` reads `ios.bundleIdentifier ?? android.package`, no hardcoded fallback.

## 2. Cold-start breadcrumbs + slow-boot watchdog

A hang at the splash screen is otherwise invisible in Sentry — nothing breadcrumbs the boot path, so a "stuck on logo" report has no trail. This adds:

- a `markBoot(step)` helper that drops a `boot` breadcrumb at each real phase in `prepare()` (audio init → catalog fetch → app initializer → session restore → ready), so any later crash carries the boot trail, and
- an 8s `setTimeout` watchdog that fires `captureMessage('slow-cold-start', { tags: { boot_step } })` if init blows past budget, `clearTimeout`'d in a `finally`. This turns the invisible boot hang into a queryable signal that names the phase it stalled in.

## Notes

- No new dependency — `expo-constants` is already a transitive dep; just added the import.
- Verified with `tsc --noEmit` (clean).
- Diff is +50 / −0, single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
