### PR TITLE
feat: add download-all for a reciter's surahs

### DIFF
--- a/components/reciter-profile/ReciterProfile.tsx
+++ b/components/reciter-profile/ReciterProfile.tsx
@@ -41,7 +41,7 @@ import {useFavoriteReciters} from '@/hooks/useFavoriteReciters';
 import {
   useDownloadQueries,
   useDownloadActions,
-  useDownloads,
+  useAreAllSurahsDownloaded,
 } from '@/services/player/store/downloadSelectors';
 import {downloadSurah} from '@/services/downloadService';
 import {bulkDownloadSurahs} from '@/services/player/bulkDownloadSurahs';
@@ -357,10 +357,23 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
   // @ai-start
   const {setDownloading, clearDownloading, addDownload, setDownloadProgress} =
     useDownloadActions();
-  const downloads = useDownloads();
   const [isDownloadingAll, setIsDownloadingAll] = useState(false);
   const [downloadAllProgress, setDownloadAllProgress] = useState(0);
   const downloadAllCancelledRef = useRef(false);
+  // Tracks mount state so a long batch's deferred setState/Alert never fire
+  // after the screen is gone; the in-flight ref also closes the same-frame
+  // double-tap window that React state alone leaves open.
+  const isMountedRef = useRef(true);
+  const downloadAllInFlightRef = useRef(false);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      // Signal any in-flight batch to stop when the user leaves the screen.
+      downloadAllCancelledRef.current = true;
+    };
+  }, []);
   // @ai-end
   const {startNewChain} = useRecentlyPlayedStore();
   const {reciterPreferences, setReciterPreference} = useSettings();
@@ -588,26 +601,27 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
   ]);
 
   // @ai-start
-  // Derived from `downloads` (not the query selectors) so it recomputes as
-  // items complete; mirrors the store's isDownloadedWithRewayat semantics.
-  const allDownloaded = useMemo(() => {
-    if (!selectedRewayat || filteredSurahs.length === 0) return false;
-    return filteredSurahs.every(s =>
-      downloads.some(
-        d =>
-          d.reciterId === currentReciterId &&
-          d.surahId === s.id.toString() &&
-          d.rewayatId === selectedRewayat.id &&
-          d.status === 'completed',
-      ),
-    );
-  }, [filteredSurahs, selectedRewayat, currentReciterId, downloads]);
+  // Subscribe through a primitive-returning store selector so this (heavy)
+  // screen only re-renders when the boolean flips — not on every mutation of
+  // the downloads array (single-surah downloads, removals, each batch item).
+  const surahIdsForRewayat = useMemo(
+    () => filteredSurahs.map(s => s.id.toString()),
+    [filteredSurahs],
+  );
+  const allDownloaded = useAreAllSurahsDownloaded(
+    currentReciterId,
+    surahIdsForRewayat,
+    selectedRewayat?.id,
+  );
 
   const handleDownloadAll = useCallback(async () => {
     if (!reciter || !selectedRewayat) return;
 
-    // A second tap while a batch is running requests cancellation.
-    if (isDownloadingAll) {
+    // A tap while a batch is in flight requests cancellation. Read the ref
+    // (not `isDownloadingAll` state) so a rapid second tap in the same frame
+    // is caught before the setIsDownloadingAll(true) re-render lands, which
+    // otherwise lets two concurrent batches start.
+    if (downloadAllInFlightRef.current) {
       downloadAllCancelledRef.current = true;
       return;
     }
@@ -622,6 +636,7 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
       return;
     }
 
+    downloadAllInFlightRef.current = true;
     downloadAllCancelledRef.current = false;
     setIsDownloadingAll(true);
     setDownloadAllProgress(0);
@@ -647,11 +662,19 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
           setDownloadProgress,
         },
         {
-          onProgress: (completed, total) =>
-            setDownloadAllProgress(total > 0 ? completed / total : 1),
-          isCancelled: () => downloadAllCancelledRef.current,
+          onProgress: (completed, total) => {
+            // Skip progress writes once the screen is gone.
+            if (!isMountedRef.current) return;
+            setDownloadAllProgress(total > 0 ? completed / total : 1);
+          },
+          isCancelled: () =>
+            downloadAllCancelledRef.current || !isMountedRef.current,
         },
       );
+
+      // Don't surface result alerts on an unrelated screen if the user
+      // navigated away from the reciter profile mid-batch.
+      if (!isMountedRef.current) return;
 
       if (summary.cancelled) {
         Alert.alert(
@@ -671,17 +694,21 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
       }
     } catch (error) {
       console.error('Error downloading all surahs:', error);
-      Alert.alert('Download Error', 'Some downloads may have failed.');
+      if (isMountedRef.current) {
+        Alert.alert('Download Error', 'Some downloads may have failed.');
+      }
     } finally {
-      setIsDownloadingAll(false);
-      setDownloadAllProgress(0);
+      downloadAllInFlightRef.current = false;
       downloadAllCancelledRef.current = false;
+      if (isMountedRef.current) {
+        setIsDownloadingAll(false);
+        setDownloadAllProgress(0);
+      }
     }
   }, [
     reciter,
     selectedRewayat,
     filteredSurahs,
-    isDownloadingAll,
     allDownloaded,
     isDownloaded,
     isDownloadedWithRewayat,

--- a/components/reciter-profile/ReciterProfile.tsx
+++ b/components/reciter-profile/ReciterProfile.tsx
@@ -18,6 +18,7 @@ import {
   InteractionManager,
   Platform,
   StyleSheet,
+  Alert,
 } from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useTheme} from '@/hooks/useTheme';
@@ -37,7 +38,13 @@ import {shuffleArray} from '@/utils/arrayUtils';
 import {useRecentlyPlayedStore} from '@/services/player/store/recentlyPlayedStore';
 import {SheetManager} from 'react-native-actions-sheet';
 import {useFavoriteReciters} from '@/hooks/useFavoriteReciters';
-import {useDownloadQueries} from '@/services/player/store/downloadSelectors';
+import {
+  useDownloadQueries,
+  useDownloadActions,
+  useDownloads,
+} from '@/services/player/store/downloadSelectors';
+import {downloadSurah} from '@/services/downloadService';
+import {bulkDownloadSurahs} from '@/services/player/bulkDownloadSurahs';
 import {createSharedStyles} from './styles';
 import {useSettings} from '@/hooks/useSettings';
 import {Feather} from '@expo/vector-icons';
@@ -291,7 +298,9 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                   const slug = reciter?.slug ?? currentReciterId;
                   shareUrl(
                     reciterShareUrl(slug),
-                    `Listen to ${reciter?.name ?? 'this reciter'} on ${branding.appName}`,
+                    `Listen to ${reciter?.name ?? 'this reciter'} on ${
+                      branding.appName
+                    }`,
                   );
                 }}
                 hitSlop={8}>
@@ -339,7 +348,20 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
   // iOS: offset below transparent native header; Android: below custom sticky title
   const stickyPinOffset = isGlass ? headerHeight : stickyTitleHeight;
   const {isLovedWithRewayat} = useLoved();
-  const {isDownloaded} = useDownloadQueries();
+  const {
+    isDownloaded,
+    isDownloadedWithRewayat,
+    isDownloading,
+    isDownloadingWithRewayat,
+  } = useDownloadQueries();
+  // @ai-start
+  const {setDownloading, clearDownloading, addDownload, setDownloadProgress} =
+    useDownloadActions();
+  const downloads = useDownloads();
+  const [isDownloadingAll, setIsDownloadingAll] = useState(false);
+  const [downloadAllProgress, setDownloadAllProgress] = useState(0);
+  const downloadAllCancelledRef = useRef(false);
+  // @ai-end
   const {startNewChain} = useRecentlyPlayedStore();
   const {reciterPreferences, setReciterPreference} = useSettings();
 
@@ -564,6 +586,113 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
     shuffleEnabled,
     toggleShuffleAction,
   ]);
+
+  // @ai-start
+  // Derived from `downloads` (not the query selectors) so it recomputes as
+  // items complete; mirrors the store's isDownloadedWithRewayat semantics.
+  const allDownloaded = useMemo(() => {
+    if (!selectedRewayat || filteredSurahs.length === 0) return false;
+    return filteredSurahs.every(s =>
+      downloads.some(
+        d =>
+          d.reciterId === currentReciterId &&
+          d.surahId === s.id.toString() &&
+          d.rewayatId === selectedRewayat.id &&
+          d.status === 'completed',
+      ),
+    );
+  }, [filteredSurahs, selectedRewayat, currentReciterId, downloads]);
+
+  const handleDownloadAll = useCallback(async () => {
+    if (!reciter || !selectedRewayat) return;
+
+    // A second tap while a batch is running requests cancellation.
+    if (isDownloadingAll) {
+      downloadAllCancelledRef.current = true;
+      return;
+    }
+
+    if (filteredSurahs.length === 0) return;
+
+    if (allDownloaded) {
+      Alert.alert(
+        'Already Downloaded',
+        'Every surah shown is already downloaded for this rewayah.',
+      );
+      return;
+    }
+
+    downloadAllCancelledRef.current = false;
+    setIsDownloadingAll(true);
+    setDownloadAllProgress(0);
+
+    try {
+      const items = filteredSurahs.map(s => ({
+        surahId: s.id,
+        reciterId: reciter.id,
+        rewayatId: selectedRewayat.id,
+      }));
+
+      const summary = await bulkDownloadSurahs(
+        items,
+        {
+          downloadSurah,
+          isDownloaded,
+          isDownloadedWithRewayat,
+          isDownloading,
+          isDownloadingWithRewayat,
+          setDownloading,
+          clearDownloading,
+          addDownload,
+          setDownloadProgress,
+        },
+        {
+          onProgress: (completed, total) =>
+            setDownloadAllProgress(total > 0 ? completed / total : 1),
+          isCancelled: () => downloadAllCancelledRef.current,
+        },
+      );
+
+      if (summary.cancelled) {
+        Alert.alert(
+          'Download Stopped',
+          `Downloaded ${summary.downloaded} surah(s) before stopping.`,
+        );
+      } else if (summary.failed > 0) {
+        Alert.alert(
+          'Download Finished',
+          `${summary.downloaded} downloaded, ${summary.failed} failed. Tap again to retry the rest.`,
+        );
+      } else if (summary.downloaded > 0) {
+        Alert.alert(
+          'Download Complete',
+          `All surahs for ${reciter.name} are now available offline.`,
+        );
+      }
+    } catch (error) {
+      console.error('Error downloading all surahs:', error);
+      Alert.alert('Download Error', 'Some downloads may have failed.');
+    } finally {
+      setIsDownloadingAll(false);
+      setDownloadAllProgress(0);
+      downloadAllCancelledRef.current = false;
+    }
+  }, [
+    reciter,
+    selectedRewayat,
+    filteredSurahs,
+    isDownloadingAll,
+    allDownloaded,
+    isDownloaded,
+    isDownloadedWithRewayat,
+    isDownloading,
+    isDownloadingWithRewayat,
+    setDownloading,
+    clearDownloading,
+    addDownload,
+    setDownloadProgress,
+  ]);
+  // @ai-end
 
   const handleToggleFavorite = useCallback(() => {
     if (reciter) {
@@ -921,6 +1050,10 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                   onShufflePress={handleShuffleAll}
                   onPlayPress={handlePlayAll}
                   isFavoriteReciter={isFavoriteReciter(reciter.id)}
+                  onDownloadAllPress={handleDownloadAll}
+                  isDownloadingAll={isDownloadingAll}
+                  downloadAllProgress={downloadAllProgress}
+                  allDownloaded={allDownloaded}
                 />
               </View>
             </View>
@@ -1163,7 +1296,9 @@ const ReciterProfileContent: React.FC<ReciterProfileProps> = ({
                 const slug = reciter?.slug ?? currentReciterId;
                 shareUrl(
                   reciterShareUrl(slug),
-                  `Listen to ${reciter?.name ?? 'this reciter'} on ${branding.appName}`,
+                  `Listen to ${reciter?.name ?? 'this reciter'} on ${
+                    branding.appName
+                  }`,
                 );
               }}
             />

--- a/components/reciter-profile/components/ActionButtons/index.tsx
+++ b/components/reciter-profile/components/ActionButtons/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Pressable} from 'react-native';
+import {View, Pressable, Text} from 'react-native';
 import {moderateScale} from 'react-native-size-matters';
 import {ScaledSheet} from 'react-native-size-matters';
 import {Theme} from '@/utils/themeUtils';
@@ -16,9 +16,19 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
   onShufflePress,
   onPlayPress,
   isFavoriteReciter,
+  onDownloadAllPress,
+  isDownloadingAll = false,
+  downloadAllProgress = 0,
+  allDownloaded = false,
 }) => {
   const {theme} = useTheme();
   const styles = createStyles(theme);
+
+  const getDownloadAllLabel = () => {
+    if (isDownloadingAll) return 'Cancel downloading all surahs';
+    if (allDownloaded) return 'All surahs downloaded';
+    return 'Download all surahs';
+  };
 
   return (
     <View style={styles.actionButtons}>
@@ -39,6 +49,31 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
       <Pressable style={styles.circleButton} onPress={onShufflePress}>
         <ShuffleIcon color={theme.colors.text} size={moderateScale(20)} />
       </Pressable>
+      {/* @ai-start */}
+      {onDownloadAllPress ? (
+        <Pressable
+          style={styles.circleButton}
+          onPress={onDownloadAllPress}
+          accessibilityRole="button"
+          accessibilityLabel={getDownloadAllLabel()}>
+          {isDownloadingAll ? (
+            <Text style={styles.progressText} numberOfLines={1}>
+              {`${Math.round(downloadAllProgress * 100)}%`}
+            </Text>
+          ) : (
+            <Ionicons
+              name={allDownloaded ? 'checkmark-circle' : 'download-outline'}
+              size={moderateScale(20)}
+              color={
+                allDownloaded
+                  ? theme.colors.text
+                  : Color(theme.colors.text).alpha(0.7).toString()
+              }
+            />
+          )}
+        </Pressable>
+      ) : null}
+      {/* @ai-end */}
     </View>
   );
 };
@@ -70,4 +105,11 @@ const createStyles = (theme: Theme) =>
     playIconContainer: {
       paddingLeft: moderateScale(4),
     },
+    // @ai-start
+    progressText: {
+      fontSize: moderateScale(11),
+      fontWeight: '600',
+      color: theme.colors.text,
+    },
+    // @ai-end
   });

--- a/components/reciter-profile/types/index.ts
+++ b/components/reciter-profile/types/index.ts
@@ -120,4 +120,14 @@ export interface ActionButtonsProps {
   onPlayPress: () => void;
   /** Whether the reciter is in the user's favorites */
   isFavoriteReciter: boolean;
+  // @ai-start
+  /** Handler for the "download all surahs" button (tap again to cancel). */
+  onDownloadAllPress?: () => void;
+  /** Whether a bulk download is currently running. */
+  isDownloadingAll?: boolean;
+  /** Aggregate bulk-download progress, 0–1. */
+  downloadAllProgress?: number;
+  /** Whether every surah in the current view is already downloaded. */
+  allDownloaded?: boolean;
+  // @ai-end
 }

--- a/services/player/__tests__/bulkDownloadSurahs.test.ts
+++ b/services/player/__tests__/bulkDownloadSurahs.test.ts
@@ -1,0 +1,161 @@
+// @ai-start
+// Unit tests for the reciter "download all" bulk helper.
+//
+// The helper is dependency-injected and free of expo/React Native imports, so
+// these tests exercise the real control flow with lightweight mocks.
+
+import {
+  bulkDownloadSurahs,
+  buildDownloadId,
+  type BulkDownloadDeps,
+  type BulkDownloadItem,
+} from '../bulkDownloadSurahs';
+
+function makeItems(count: number, rewayatId?: string): BulkDownloadItem[] {
+  return Array.from({length: count}, (_, i) => ({
+    surahId: i + 1,
+    reciterId: 'abdul_basit',
+    rewayatId,
+  }));
+}
+
+function makeDeps(overrides: Partial<BulkDownloadDeps> = {}): BulkDownloadDeps {
+  return {
+    downloadSurah: jest.fn(async (surahId: number) => ({
+      filePath: `${surahId}.mp3`,
+      fileSize: 1000,
+    })),
+    isDownloaded: jest.fn(() => false),
+    isDownloadedWithRewayat: jest.fn(() => false),
+    isDownloading: jest.fn(() => false),
+    isDownloadingWithRewayat: jest.fn(() => false),
+    setDownloading: jest.fn(),
+    clearDownloading: jest.fn(),
+    addDownload: jest.fn(),
+    setDownloadProgress: jest.fn(),
+    ...overrides,
+  };
+}
+
+// No real delay between downloads so the suite stays fast.
+const fast = {interDownloadDelayMs: 0};
+
+describe('buildDownloadId', () => {
+  it('omits rewayah when absent', () => {
+    expect(buildDownloadId({surahId: 2, reciterId: 'r'})).toBe('r-2');
+  });
+
+  it('includes rewayah when present (matching SurahItem)', () => {
+    expect(
+      buildDownloadId({surahId: 2, reciterId: 'r', rewayatId: 'hafs'}),
+    ).toBe('r-2-hafs');
+  });
+});
+
+describe('bulkDownloadSurahs', () => {
+  it('downloads every pending surah and records each one', async () => {
+    const deps = makeDeps();
+    const summary = await bulkDownloadSurahs(makeItems(3, 'hafs'), deps, fast);
+
+    expect(deps.downloadSurah).toHaveBeenCalledTimes(3);
+    expect(deps.addDownload).toHaveBeenCalledTimes(3);
+    expect(deps.setDownloading).toHaveBeenCalledWith('abdul_basit-1-hafs');
+    expect(deps.clearDownloading).toHaveBeenCalledWith('abdul_basit-1-hafs');
+    expect(summary).toEqual({
+      total: 3,
+      downloaded: 3,
+      skipped: 0,
+      failed: 0,
+      cancelled: false,
+    });
+  });
+
+  it('skips surahs that are already downloaded', async () => {
+    const deps = makeDeps({
+      isDownloadedWithRewayat: jest.fn(
+        (_reciterId, surahId) => surahId === '2',
+      ),
+    });
+    const summary = await bulkDownloadSurahs(makeItems(3, 'hafs'), deps, fast);
+
+    expect(deps.downloadSurah).toHaveBeenCalledTimes(2);
+    expect(summary.skipped).toBe(1);
+    expect(summary.downloaded).toBe(2);
+  });
+
+  it('continues past a failed download and counts it', async () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const deps = makeDeps({
+      downloadSurah: jest.fn(async (surahId: number) => {
+        if (surahId === 2) throw new Error('network error');
+        return {filePath: `${surahId}.mp3`, fileSize: 10};
+      }),
+    });
+    const summary = await bulkDownloadSurahs(makeItems(3, 'hafs'), deps, fast);
+
+    expect(summary).toMatchObject({downloaded: 2, failed: 1, cancelled: false});
+    expect(deps.addDownload).toHaveBeenCalledTimes(2);
+    // downloading state is always cleared, even on failure
+    expect(deps.clearDownloading).toHaveBeenCalledTimes(3);
+    errorSpy.mockRestore();
+  });
+
+  it('stops early when cancellation is requested', async () => {
+    let processed = 0;
+    const deps = makeDeps({
+      downloadSurah: jest.fn(async (surahId: number) => {
+        processed += 1;
+        return {filePath: `${surahId}.mp3`, fileSize: 10};
+      }),
+    });
+    const summary = await bulkDownloadSurahs(makeItems(5, 'hafs'), deps, {
+      ...fast,
+      isCancelled: () => processed >= 2,
+    });
+
+    expect(summary.cancelled).toBe(true);
+    expect(summary.downloaded).toBe(2);
+    expect(deps.downloadSurah).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips items already in flight without downloading again', async () => {
+    const deps = makeDeps({
+      isDownloadingWithRewayat: jest.fn(
+        (_reciterId, surahId) => surahId === '1',
+      ),
+    });
+    const summary = await bulkDownloadSurahs(makeItems(2, 'hafs'), deps, fast);
+
+    expect(deps.downloadSurah).toHaveBeenCalledTimes(1);
+    expect(summary.downloaded).toBe(1);
+  });
+
+  it('reports aggregate progress over the pending set', async () => {
+    const deps = makeDeps();
+    const progress: Array<[number, number]> = [];
+    await bulkDownloadSurahs(makeItems(2, 'hafs'), deps, {
+      ...fast,
+      onProgress: (completed, total) => progress.push([completed, total]),
+    });
+
+    expect(progress).toEqual([
+      [0, 2],
+      [1, 2],
+      [2, 2],
+    ]);
+  });
+
+  it('uses non-rewayah queries and IDs when no rewayah is given', async () => {
+    const deps = makeDeps();
+    await bulkDownloadSurahs(makeItems(1), deps, fast);
+
+    expect(deps.isDownloaded).toHaveBeenCalledWith('abdul_basit', '1');
+    expect(deps.setDownloading).toHaveBeenCalledWith('abdul_basit-1');
+    expect(deps.addDownload).toHaveBeenCalledWith(
+      expect.objectContaining({rewayatId: '', status: 'completed'}),
+    );
+  });
+});
+// @ai-end

--- a/services/player/bulkDownloadSurahs.ts
+++ b/services/player/bulkDownloadSurahs.ts
@@ -1,0 +1,194 @@
+// @ai-start
+import type {DownloadedSurah} from './store/downloadStore';
+
+/**
+ * A single surah to download as part of a bulk operation.
+ */
+export interface BulkDownloadItem {
+  surahId: number;
+  reciterId: string;
+  /** Optional rewayah. When provided, downloads are tracked per-rewayah. */
+  rewayatId?: string;
+}
+
+/**
+ * Side-effecting dependencies injected into {@link bulkDownloadSurahs}.
+ *
+ * Injecting these (rather than importing the download service and store
+ * directly) keeps this module free of expo/React Native imports, which makes
+ * the bulk-download logic unit-testable in isolation.
+ */
+export interface BulkDownloadDeps {
+  downloadSurah: (
+    surahId: number,
+    reciterId: string,
+    rewayatId: string | undefined,
+    onProgress?: (progress: number) => void,
+  ) => Promise<{filePath: string; fileSize: number}>;
+  isDownloaded: (reciterId: string, surahId: string) => boolean;
+  isDownloadedWithRewayat: (
+    reciterId: string,
+    surahId: string,
+    rewayatId: string,
+  ) => boolean;
+  isDownloading: (reciterId: string, surahId: string) => boolean;
+  isDownloadingWithRewayat: (
+    reciterId: string,
+    surahId: string,
+    rewayatId: string,
+  ) => boolean;
+  setDownloading: (id: string) => void;
+  clearDownloading: (id: string) => void;
+  addDownload: (download: DownloadedSurah) => void;
+  setDownloadProgress: (id: string, progress: number) => void;
+}
+
+export interface BulkDownloadCallbacks {
+  /** Reports how many pending items have finished out of the pending total. */
+  onProgress?: (completed: number, total: number) => void;
+  /** Polled before each download; return true to stop the batch gracefully. */
+  isCancelled?: () => boolean;
+  /** Delay between downloads (ms) to avoid AsyncStorage write storms. */
+  interDownloadDelayMs?: number;
+  /** Minimum gap (ms) between per-item progress writes to the store. */
+  progressThrottleMs?: number;
+}
+
+export interface BulkDownloadSummary {
+  /** Total items requested. */
+  total: number;
+  /** Items newly downloaded in this run. */
+  downloaded: number;
+  /** Items skipped because they were already downloaded. */
+  skipped: number;
+  /** Items that errored (the batch continues past failures). */
+  failed: number;
+  /** Whether the run was stopped early via the cancellation hook. */
+  cancelled: boolean;
+}
+
+const DEFAULT_INTER_DOWNLOAD_DELAY_MS = 100;
+const DEFAULT_PROGRESS_THROTTLE_MS = 300;
+
+/**
+ * Builds the download-tracking ID for a surah. This MUST match the format used
+ * by `SurahItem` (`${reciterId}-${surahId}` or `${reciterId}-${surahId}-${rewayatId}`)
+ * so per-row progress rings and downloaded checkmarks update during the batch.
+ */
+export function buildDownloadId(item: BulkDownloadItem): string {
+  return item.rewayatId
+    ? `${item.reciterId}-${item.surahId}-${item.rewayatId}`
+    : `${item.reciterId}-${item.surahId}`;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Downloads a list of surahs sequentially for offline playback.
+ *
+ * Mirrors the proven bulk-download flow used elsewhere in the app: it skips
+ * items that are already downloaded or currently in-flight, throttles progress
+ * writes, spaces downloads out to avoid overwhelming persistence, and isolates
+ * per-item failures so a single bad download does not abort the whole batch.
+ */
+export async function bulkDownloadSurahs(
+  items: BulkDownloadItem[],
+  deps: BulkDownloadDeps,
+  callbacks: BulkDownloadCallbacks = {},
+): Promise<BulkDownloadSummary> {
+  const {
+    onProgress,
+    isCancelled,
+    interDownloadDelayMs = DEFAULT_INTER_DOWNLOAD_DELAY_MS,
+    progressThrottleMs = DEFAULT_PROGRESS_THROTTLE_MS,
+  } = callbacks;
+
+  const total = items.length;
+  let downloaded = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  const pending = items.filter(item => {
+    const surahIdStr = item.surahId.toString();
+    const already = item.rewayatId
+      ? deps.isDownloadedWithRewayat(item.reciterId, surahIdStr, item.rewayatId)
+      : deps.isDownloaded(item.reciterId, surahIdStr);
+    if (already) skipped += 1;
+    return !already;
+  });
+
+  const pendingTotal = pending.length;
+  onProgress?.(0, pendingTotal);
+
+  let cancelled = false;
+  let lastProgressUpdate = 0;
+
+  for (let index = 0; index < pending.length; index++) {
+    if (isCancelled?.()) {
+      cancelled = true;
+      break;
+    }
+
+    const item = pending[index];
+    const surahIdStr = item.surahId.toString();
+    const downloadId = buildDownloadId(item);
+
+    const inFlight = item.rewayatId
+      ? deps.isDownloadingWithRewayat(
+          item.reciterId,
+          surahIdStr,
+          item.rewayatId,
+        )
+      : deps.isDownloading(item.reciterId, surahIdStr);
+
+    if (inFlight) {
+      onProgress?.(index + 1, pendingTotal);
+      continue;
+    }
+
+    try {
+      deps.setDownloading(downloadId);
+
+      const result = await deps.downloadSurah(
+        item.surahId,
+        item.reciterId,
+        item.rewayatId,
+        progress => {
+          const now = Date.now();
+          if (now - lastProgressUpdate < progressThrottleMs) return;
+          lastProgressUpdate = now;
+          deps.setDownloadProgress(downloadId, progress);
+        },
+      );
+
+      deps.addDownload({
+        reciterId: item.reciterId,
+        surahId: surahIdStr,
+        rewayatId: item.rewayatId ?? '',
+        filePath: result.filePath,
+        fileSize: result.fileSize,
+        downloadDate: Date.now(),
+        status: 'completed',
+      });
+
+      downloaded += 1;
+    } catch (error) {
+      failed += 1;
+      console.error(`Bulk download failed for surah ${item.surahId}:`, error);
+    } finally {
+      deps.clearDownloading(downloadId);
+    }
+
+    onProgress?.(index + 1, pendingTotal);
+
+    const isLast = index === pending.length - 1;
+    if (!isLast && interDownloadDelayMs > 0 && !isCancelled?.()) {
+      await delay(interDownloadDelayMs);
+    }
+  }
+
+  return {total, downloaded, skipped, failed, cancelled};
+}
+// @ai-end

--- a/services/player/store/downloadSelectors.ts
+++ b/services/player/store/downloadSelectors.ts
@@ -3,6 +3,26 @@ import {useDownloadStore} from './downloadStore';
 
 export const useDownloads = () => useDownloadStore(state => state.downloads);
 
+/**
+ * True when every provided surah is downloaded for the given rewayah.
+ *
+ * Subscribes with a primitive-returning selector so the consuming component
+ * only re-renders when this boolean flips — not on every mutation of the
+ * `downloads` array (single-surah downloads, removals, each batch item). Reuses
+ * the store's `isDownloadedWithRewayat` so the semantics stay in one place.
+ */
+export const useAreAllSurahsDownloaded = (
+  reciterId: string,
+  surahIds: string[],
+  rewayatId: string | undefined,
+) =>
+  useDownloadStore(state => {
+    if (!rewayatId || surahIds.length === 0) return false;
+    return surahIds.every(surahId =>
+      state.isDownloadedWithRewayat(reciterId, surahId, rewayatId),
+    );
+  });
+
 export const useDownloadProgress = (id: string) =>
   useDownloadStore(state => state.downloadProgress[id] ?? 0);
 


### PR DESCRIPTION
## What does this PR do?

Adds a **download-all** button to the reciter profile action bar (next to Favorite / Play / Shuffle). One tap downloads every surah for the **currently selected rewayah** for offline playback, so listeners who follow a particular reciter no longer have to open each surah and download it individually.

The button has three states:
- Idle: download icon (only shows the percentage/checkmark states once acted on).
- In progress: shows aggregate percentage; tap again to cancel.
- All downloaded: checkmark.

It targets the same surah set as Play All / Shuffle All (current rewayah, respecting the loved/search filters), for consistency.

### Implementation notes
- New dependency-injected helper `services/player/bulkDownloadSurahs.ts`. It imports nothing from expo/React Native, which keeps the bulk-download logic unit-testable in isolation. It mirrors the existing bulk-download flow used elsewhere in the app: skips already-downloaded and in-flight items, throttles progress writes, spaces downloads out to avoid AsyncStorage write storms, and isolates per-item failures so one bad download doesn't abort the batch.
- Download-tracking IDs use the exact format `SurahItem` reads (`reciterId-surahId-rewayatId`), so the existing per-row progress rings and downloaded checkmarks animate live during the batch.
- `ActionButtons` gains optional props (`onDownloadAllPress`, `isDownloadingAll`, `downloadAllProgress`, `allDownloaded`), all with safe defaults so existing usage is unaffected.
- No changes to the existing single-surah, loved, or playlist download paths.

Closes #

## Type of change

- New feature

## Testing

- Added unit tests (`services/player/__tests__/bulkDownloadSurahs.test.ts`) covering: downloading the pending set, skipping already-downloaded items, skipping in-flight items, continuing past per-item failures, cancellation, and aggregate progress reporting. All 9 pass.
- `npx tsc --noEmit` passes; `npx prettier --check` and `eslint` are clean on the changed files.
- [ ] Tested on iOS
- [ ] Tested on Android

> Note: on-device iOS/Android testing has not been run yet. The new logic is covered by unit tests and the UI reuses the app's existing, shipped download plumbing. Happy to validate on simulators/devices or adjust the UX (icon/placement/copy) per maintainer preference.

## Checklist

- [x] Ran `npx prettier --write` on all changed files
- [x] Ran `npx tsc --noEmit` — no new type errors
- [x] Branch targets `develop` (not `main`)
- [x] No `console.log` debug statements left in
- [x] AI assistance used? If yes, all AI-generated blocks are marked with `// @ai`

Made with [Cursor](https://cursor.com)