### PR TITLE
fix(player): stop the collapsed PlayerSheet backdrop from eating all touches on slow Android

### DIFF
--- a/components/player/v2/PlayerSheet.tsx
+++ b/components/player/v2/PlayerSheet.tsx
@@ -156,15 +156,31 @@ export const PlayerSheet = () => {
   );
 
   const renderBackdrop = useCallback(
-    (props: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop
-        {...props}
-        disappearsOnIndex={-1}
-        appearsOnIndex={0}
-        opacity={0.5}
-      />
-    ),
-    [],
+    (props: BottomSheetBackdropProps) => {
+      // Slow-Android play-time freeze fix: gorhom's BottomSheetBackdrop mounts
+      // pointerEvents:'auto' (full-screen absoluteFillObject, opacity-0 but still
+      // hit-testable, wrapped in a Tap GestureDetector) and only flips to 'none'
+      // via a useAnimatedReaction -> runOnJS -> setState chain gated on its
+      // internal animatedIndex settling to disappearsOnIndex (-1). On a slow CPU
+      // the *closed* sheet's container-height layout race delays that settle, so
+      // the backdrop keeps eating EVERY touch while the sheet is logically hidden
+      // -> the whole app is unresponsive though audio keeps playing and only the
+      // hardware BACK key works. Don't render the backdrop at all unless the sheet
+      // is the full player; keyed off the LOGICAL sheetMode (set synchronously
+      // before expand()), so it is immune to gorhom's racing animatedIndex.
+      if (sheetMode !== 'full') {
+        return null;
+      }
+      return (
+        <BottomSheetBackdrop
+          {...props}
+          disappearsOnIndex={-1}
+          appearsOnIndex={0}
+          opacity={0.5}
+        />
+      );
+    },
+    [sheetMode],
   );
 
   const handleSpeedChange = useCallback(
@@ -356,7 +372,7 @@ export const PlayerSheet = () => {
         handleComponent={renderHandleComponent}
         enableContentPanningGesture
         enableOverDrag={false}
-        style={styles.sheet}
+        style={[styles.sheet, sheetMode !== 'full' && styles.sheetUntouchable]}
         backgroundStyle={[styles.background, {backgroundColor: 'transparent'}]}>
         {showTabletSplit ? (
           <View style={styles.tabletSplitRoot}>
@@ -407,6 +423,15 @@ const styles = StyleSheet.create({
   sheet: {
     zIndex: 2000,
     elevation: 20,
+  },
+  // Slow-Android play-time freeze fix (sibling guard of the backdrop gate above).
+  // gorhom applies this `style` to BottomSheetBody (an Animated.View), so the
+  // elevation:20 lives there; on a slow CPU a mis-positioned *closed* sheet's
+  // elevated Body can also capture touches (Android elevation drives touch order).
+  // pointerEvents:'none' removes it from hit-testing whenever the sheet is not the
+  // full player — keyed off logical sheetMode, not gorhom's racing animatedIndex.
+  sheetUntouchable: {
+    pointerEvents: 'none',
   },
   background: {
     borderTopLeftRadius: 0,


### PR DESCRIPTION
## The bug

On a slow Android device, playing **any** recitation freezes the entire UI — pause, back, the tab bar, every button stops responding — while **audio keeps playing** and only the hardware BACK key works. Reproduced on a Xiaomi Redmi Note 9 (Helio G85 / Android 10 / 4 GB / MIUI). Fast/modern devices never reproduce it.

## Root cause

The PlayerSheet mounts on play but stays **closed**, and it renders a gorhom `BottomSheetBackdrop`. Per gorhom 5.2.8, the backdrop:
- **mounts `pointerEvents:'auto'`** (`useState(enableTouchThrough ? 'none' : 'auto')`, default `false`),
- is **full-screen** (`StyleSheet.absoluteFillObject` injected by gorhom) and **opacity-0-but-hit-testable** when closed (opacity ≠ pointerEvents),
- is wrapped in a Tap `GestureDetector` (default `pressBehavior='close'`),
- and only flips to `pointerEvents:'none'` via a `useAnimatedReaction(() => animatedIndex.value <= disappearsOnIndex, … runOnJS(setPointerEvents))` — a UI-thread→JS-thread hop + `setState` re-render.

On a slow CPU the **closed sheet's container-height layout race** delays `animatedIndex` settling to `-1`, so the full-screen backdrop sits over the app and **eats every touch** while the sheet is logically hidden. Fast devices settle layout in <1 frame, so they never hit it.

## The fix

Gate the backdrop render on the **logical** `sheetMode` (`renderBackdrop` returns `null` unless `'full'`). `sheetMode` is set **synchronously before** `expand()` in `expandPlayerSheet()`, so:
- **open path** renders the scrim from frame 1 → no scrim-pop, no regression;
- **resting-hidden** (the freeze case) **never mounts the backdrop** → immune to CPU speed by construction (no reaction, no `runOnJS`, no race).

Plus a belt-and-suspenders `pointerEvents:'none'` on the sheet **Body** (`style={[styles.sheet, sheetMode !== 'full' && styles.sheetUntouchable]}`) — a separate gorhom sibling that carries the same `elevation:20` and can race the same way (on Android `elevation` drives touch dispatch order).

## Validation

- **Cleared the freeze on the real Redmi Note 9.**
- **Pixel 3 release boot-gate**: play → mini-player → expand to full player (scrim renders normally) → pause/resume → collapse, all work; no regression.
- RN 0.83.2 / Fabric / gorhom 5.2.8 expert-reviewed: confirmed `setSheetMode('full')` is synchronous before `expand()` (no open regression) and that render-gating is the only race-immune approach (`pressBehavior="none"`/`enableTouchThrough` are defeated by the same reaction).

Found + fixed downstream in a fork that inherits this PlayerSheet (the `elevation:20` + the sheet originate here).

## Related (separate, not in this PR)

- There's a **second** stacked bug on the same slow device — expo-audio's `player.play()`/`replace()` `runBlocking(mainQueue)` **on the JS thread**, which hard-locks JS on a saturated main thread. That's an `expo-audio` library issue (a patch-package patch downstream); worth picking up if/when it lands upstream in expo.
- `android:forceDarkAllowed=false` (opt out of MIUI's per-mount force-dark walk) also helped on Xiaomi — happy to send as a separate small PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
