### PR TITLE
fix(settings): stop the closed BottomSheetModal from eating all touches on slow Android

### DIFF
--- a/components/BottomSheetModal.tsx
+++ b/components/BottomSheetModal.tsx
@@ -86,14 +86,29 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
   }, [isVisible, onClose]);
 
   const renderBackdrop = useCallback(
-    (props: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop
-        {...props}
-        disappearsOnIndex={-1}
-        appearsOnIndex={0}
-      />
-    ),
-    [],
+    (props: BottomSheetBackdropProps) => {
+      // gorhom's BottomSheetBackdrop mounts with pointerEvents:'auto' (a
+      // full-screen, opacity-0-but-hit-testable Tap GestureDetector) and only
+      // flips to 'none' via a reanimated useAnimatedReaction -> runOnJS ->
+      // setState chain gated on its internal animatedIndex settling to -1. On
+      // slow Android CPUs the closed-sheet layout race delays that settle, so
+      // the backdrop keeps eating every touch while the sheet is LOGICALLY
+      // closed -> the entire host screen goes touch-dead until the next
+      // re-render. Gate on the logical `isVisible` prop so the backdrop never
+      // renders while closed, immune to gorhom's racing animatedIndex. Same
+      // touch-eater fix shipped for the PlayerSheet backdrop in #308.
+      if (!isVisible) {
+        return null;
+      }
+      return (
+        <BottomSheetBackdrop
+          {...props}
+          disappearsOnIndex={-1}
+          appearsOnIndex={0}
+        />
+      );
+    },
+    [isVisible],
   );
 
   return (
@@ -112,10 +127,15 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
       handleComponent={CustomHandle}
       enableContentPanningGesture
       onClose={onClose}
-      style={{
-        zIndex: 3000,
-        elevation: 3000,
-      }}>
+      // The elevated BottomSheet Body is a SEPARATE sibling from the backdrop
+      // above; gorhom drops its touch-interactivity asynchronously too, so on
+      // slow CPUs it can still swallow touches while the sheet is logically
+      // closed. Gate its pointerEvents on `isVisible` as well — the proven fix
+      // is BOTH siblings gated (matches the PlayerSheet guard in #308).
+      style={[
+        {zIndex: 3000, elevation: 3000},
+        !isVisible && {pointerEvents: 'none' as const},
+      ]}>
       <View style={[styles(theme).contentContainer, contentContainerStyle]}>
         {children}
       </View>


### PR DESCRIPTION
### Problem

The shared `components/BottomSheetModal.tsx` wrapper (the confirm / note bottom sheets) can leave its **host screen completely touch-dead on slow Android CPUs** while the sheet is logically closed — taps register nowhere, even though the rest of the app keeps working. This is the same class as the PlayerSheet freeze fixed in #308, on a separate ungated component instance.

### Root cause

gorhom's `BottomSheetBackdrop` mounts with `pointerEvents:'auto'` (a full-screen, opacity-0-but-hit-testable Tap `GestureDetector`) and only flips to `'none'` via a reanimated `useAnimatedReaction` → `runOnJS` → `setState` chain gated on its internal `animatedIndex` settling to `-1`. On slow CPUs the closed-sheet layout race delays that settle, so the backdrop keeps eating every touch while the sheet is **logically** closed.

And — exactly as #308 found — the **elevated BottomSheet Body is a SEPARATE sibling** (`elevation/zIndex: 3000`) that drops its touch-interactivity asynchronously too. Gating only the backdrop is not enough; the Body still swallows touches.

### Fix

Gate **both** siblings on the logical `isVisible` prop (immune to gorhom's racing `animatedIndex`):

- `renderBackdrop` returns `null` when `!isVisible`
- the `BottomSheet` `style` adds `pointerEvents: 'none'` when `!isVisible`

When the sheet is open, behavior is identical to today.

### Why two-sibling

#308 (PlayerSheet) is the precedent: an earlier single-sibling attempt there still froze because the elevated Body was a second touch-eater. This mirrors that complete fix on the `BottomSheetModal` wrapper.

### Validation

This is a faithful port of a fork-side fix that's **tester-confirmed** on the original slow-CPU device (Redmi Note 9 / Helio G85 class) and passed `tsc` + unit tests + a release boot-gate. The diff is additive-only (no behavior change when open); `prettier` (3.8.1, lockfile-pinned) reports the file unchanged after formatting.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>