### PR TITLE
chore: pin @gorhom/bottom-sheet ^5.2.14 (pre-empt SDK-56 / reanimated-4.3 regression)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@expo/server": "^0.1.0",
         "@expo/vector-icons": "^15.0.3",
         "@fawazahmed/react-native-read-more": "^3.0.4",
-        "@gorhom/bottom-sheet": "^5.2.8",
+        "@gorhom/bottom-sheet": "^5.2.14",
         "@legendapp/list": "^1.0.5",
         "@miblanchard/react-native-slider": "^2.6.0",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -4760,9 +4760,9 @@
       }
     },
     "node_modules/@gorhom/bottom-sheet": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.8.tgz",
-      "integrity": "sha512-+N27SMpbBxXZQ/IA2nlEV6RGxL/qSFHKfdFKcygvW+HqPG5jVNb1OqehLQsGfBP+Up42i0gW5ppI+DhpB7UCzA==",
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.14.tgz",
+      "integrity": "sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg==",
       "license": "MIT",
       "dependencies": {
         "@gorhom/portal": "1.0.14",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@expo/server": "^0.1.0",
     "@expo/vector-icons": "^15.0.3",
     "@fawazahmed/react-native-read-more": "^3.0.4",
-    "@gorhom/bottom-sheet": "^5.2.8",
+    "@gorhom/bottom-sheet": "^5.2.14",
     "@legendapp/list": "^1.0.5",
     "@miblanchard/react-native-slider": "^2.6.0",
     "@react-native-async-storage/async-storage": "2.2.0",


### PR DESCRIPTION
## What

Raise the `@gorhom/bottom-sheet` floor from `^5.2.8` → `^5.2.14` (plus the matching single lockfile entry).

## Why

On the **Expo SDK 56 stack** (`react-native-reanimated` 4.3.1 / RN 0.85, new architecture — i.e. **`develop` since #294**), gorhom **5.2.8**'s imperative `BottomSheet.expand()` / `snapToIndex()` become **silent no-ops** — the ref is valid and exposes the methods, the calls run with **no error**, but the sheet's open animation never fires. Not z-order, not the snap-point type, not `FullWindowOverlay`; the gorhom open animation itself is dead on 5.2.8 under reanimated 4.3. **≥5.2.14 fixes it.**

I hit this in a downstream SDK 56 migration: it broke the mini-player → full-player expand (the tap *was* firing — play/pause on the same control worked — the sheet just never presented) and cost a build plus a few hours to bisect. The bisection that isolated it: force-call `expand()` from a temp effect over Metro and flip only the gorhom version.

## Scope / risk

- **Correction to my original framing:** `develop` has been on SDK 56 / reanimated 4.3.1 since #294 merged (2026-06-29), so this is an **active fix, not forward-looking** — any imperative `expand()`/`snapToIndex()` on `develop` today silently dies on 5.2.8. (I first opened this reading `main`, which is still SDK 55, and wrongly assumed `develop` matched.)
- Pure JS, **within the existing `^5.2.8` caret** — no native rebuild.
- 5.2.14 has **identical `dependencies` + `peerDependencies`** as 5.2.8 (`@gorhom/portal` 1.0.14, `invariant` ^2.2.4), so the lockfile delta is just this one package's `version`/`resolved`/`integrity`.
