### PR TITLE
fix(mushaf): preserve page across rotation via orientation key-remount

### DIFF
--- a/components/mushaf/main.tsx
+++ b/components/mushaf/main.tsx
@@ -541,6 +541,14 @@ export default function MushafViewer({
   const insets = useSafeAreaInsets();
   const {isTablet} = useResponsive();
   const {width: windowWidth, height: windowHeight} = useWindowDimensions();
+  // A paged, `inverted` FlatList preserves its pixel scroll offset when its
+  // items resize on rotation, so the visible page drifts to a different index
+  // (old offset ÷ new item width); `initialScrollIndex` is mount-only and never
+  // re-fires. Remount the list on an orientation flip via this key so it starts
+  // fresh at `initialScrollIndex = currentPage` and never inherits the stale
+  // offset. Keyed on orientation (not raw dimensions) so the on-screen keyboard
+  // shrinking the height never remounts the reader.
+  const orientationKey = windowWidth > windowHeight ? 'landscape' : 'portrait';
 
   // Measured size of the FlatList container. Using `useWindowDimensions()`
   // alone overestimates the available space on iPad because the stack
@@ -1036,6 +1044,7 @@ export default function MushafViewer({
       {/* Content area: horizontal FlatList or vertical continuous view */}
       {isVertical && viewMode === 'mushaf' ? (
         <ContinuousMushafView
+          key={orientationKey}
           ref={continuousListRef}
           textColor={readingColors.text}
           dividerColor={readingColors.textSecondary}
@@ -1046,6 +1055,7 @@ export default function MushafViewer({
         />
       ) : isVertical && viewMode === 'list' ? (
         <ContinuousListView
+          key={orientationKey}
           ref={continuousListRef}
           textColor={readingColors.text}
           labelColor={readingColors.textSecondary}
@@ -1056,6 +1066,7 @@ export default function MushafViewer({
         />
       ) : metrics.facingPages && viewMode === 'mushaf' ? (
         <FlatList
+          key={orientationKey}
           ref={flatListRef}
           data={spreads}
           renderItem={({item}) => (
@@ -1096,6 +1107,7 @@ export default function MushafViewer({
         />
       ) : (
         <FlatList
+          key={orientationKey}
           ref={flatListRef}
           data={pages}
           renderItem={({item}) => {


### PR DESCRIPTION
## What

An orientation `key` on the Mushaf reader list(s) so they remount on a portrait↔landscape flip. One-line-per-list change (+12 total: the `orientationKey` const + a `key` on each of the four reader branches).

## Why

The default Mushaf reader is a paged, **`inverted`** horizontal `FlatList` whose `getItemLayout` sizes each item at `metrics.screenWidth`. On rotation the item width changes, but the native list keeps its **pixel** `contentOffset` → the visible page drifts to a different index (old offset ÷ new item width). `initialScrollIndex` is **mount-only** and never re-fires, so nothing pulls it back. **Rotating portrait↔landscape throws the reader onto a different surah** (a tester lost their place and landed ~23 pages away).

## Fix

A `key={windowWidth > windowHeight ? 'landscape' : 'portrait'}` on all four reader branches (both continuous views + both horizontal FlatLists). On an orientation flip the list **remounts fresh**, starting at `initialScrollIndex = currentPage`, so it never inherits the stale offset — the drift can't happen. Keyed on **orientation**, not raw dimensions, so the on-screen keyboard shrinking the window height never triggers a needless remount.

### Why not `maintainVisibleContentPosition`?

Tried it first — it's the "natural" native fix. It does **not** anchor an inverted, paged list across a rotation *resize*: on-device the content drifted to a different surah while the header stayed correct. A JS `scrollToIndex` re-anchor is a frame late (flashes the wrong page), and masking that flash only treats the symptom. The key-remount prevents the drift at the source.

## Verification

Verified on a **Pixel 3 (release build)** in a downstream fork whose Mushaf reader is byte-identical to this file apart from this change (same SDK 56 / reanimated 4.3 stack as `develop`):
- Pages held across **portrait → landscape → portrait** (tested on pages 50 and 49).
- Transition settles within **~300 ms with no wrong-page frame**.
- Normal page turns unaffected (50→49 swipe).
- `tsc` clean · jest green · prettier clean.

Pure JS, no native change; applies identically on SDK 55 (`main`) since the drift is an RN offset-preservation behavior, not stack-specific.
