### PR TITLE
chore(types): environment-agnostic timer-handle types for RN 0.85

### DIFF
--- a/components/player/v2/PlayerSheet.tsx
+++ b/components/player/v2/PlayerSheet.tsx
@@ -94,7 +94,7 @@ export const PlayerSheet = () => {
 
   // Effect to handle sleep timer remaining time
   useEffect(() => {
-    let interval: NodeJS.Timeout;
+    let interval: ReturnType<typeof setInterval>;
     if (settings.sleepTimerEnd) {
       interval = setInterval(() => {
         // Calculate remaining time based on the end timestamp

--- a/services/StorageManager.ts
+++ b/services/StorageManager.ts
@@ -13,7 +13,7 @@ interface StorageOperation {
 export class StorageManager {
   private static instance: StorageManager;
   private batchQueue: StorageOperation[] = [];
-  private batchTimeout: NodeJS.Timeout | null = null;
+  private batchTimeout: ReturnType<typeof setTimeout> | null = null;
   private readonly BATCH_DELAY = 1000; // 1 second
   private readonly HIGH_PRIORITY_DELAY = 100; // 100ms for high priority
   private isProcessing = false;

--- a/services/player/store/downloadStore.ts
+++ b/services/player/store/downloadStore.ts
@@ -11,7 +11,7 @@ import {analyticsService} from '@/services/analytics/AnalyticsService';
 // Throttle utility to prevent excessive state updates during downloads
 const throttleMap = new Map<
   string,
-  {timer: NodeJS.Timeout | null; lastValue: number}
+  {timer: ReturnType<typeof setTimeout> | null; lastValue: number}
 >();
 
 function throttledSetProgress(

--- a/services/player/types/state.ts
+++ b/services/player/types/state.ts
@@ -97,7 +97,7 @@ export interface PlaybackSettings {
   /** Timestamp when the sleep timer should end (null if disabled) */
   sleepTimerEnd: number | null;
   /** Interval for updating the sleep timer */
-  sleepTimerInterval?: NodeJS.Timeout | null;
+  sleepTimerInterval?: ReturnType<typeof setInterval> | null;
   /** Whether to skip silence */
   skipSilence: boolean;
 }

--- a/utils/debounce.ts
+++ b/utils/debounce.ts
@@ -3,7 +3,7 @@ export function debounce<T extends (...args: unknown[]) => unknown>(
   func: T,
   wait: number,
 ): (...args: Parameters<T>) => void {
-  let timeout: NodeJS.Timeout | null = null;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
 
   return (...args: Parameters<T>): void => {
     if (timeout !== null) {


### PR DESCRIPTION
RN 0.85 (SDK 56) types `setTimeout`/`setInterval` returns as `number` on Hermes. Five timer-handle sites were still typed `NodeJS.Timeout` — they only typecheck today because `@types/node`'s globals win the resolution under tsconfig `"types": ["node"]`, and that type lies about the runtime handle (e.g. `.refresh()`/`.unref()` typecheck but would crash on Hermes's numeric handle). This switches them to `ReturnType<typeof setTimeout>` / `ReturnType<typeof setInterval>`, which is correct under any resolution order and matches the pattern the SDK 56 tree already uses elsewhere (`AmbientAudioService`, `MushafAudioService`, `PerformanceMonitor`, `mushaf/main`).

Type-level only — no behavior change, no formatting drift (5 files, 5 lines). Mirrors the fix Qariah shipped during its SDK 56 absorption, where these exact sites surfaced as type breaks. `tsc --noEmit` and the full jest suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
