### PR TITLE
feat(rfc-020): composable Search filter experience (code)

### DIFF
--- a/app/(tabs)/(a.home)/reciter/browse.tsx
+++ b/app/(tabs)/(a.home)/reciter/browse.tsx
@@ -9,16 +9,27 @@ export default function BrowseScreen() {
   const router = useRouter();
   const navigation = useNavigation();
   const {theme} = useTheme();
-  const {surahId, teacher, student, rewayatName, hasPhoto} =
-    useLocalSearchParams<{
-      surahId: string;
-      teacher: string;
-      student: string;
-      rewayatName: string;
-      // RFC-012 — composable Search-tab filter chips. Tiles on the Home
-      // tab can deeplink here with chips pre-applied (e.g. `?hasPhoto=1`).
-      hasPhoto: string;
-    }>();
+  const {
+    surahId,
+    teacher,
+    student,
+    rewayatName,
+    countryName,
+    translationName,
+    hasPhoto,
+  } = useLocalSearchParams<{
+    surahId: string;
+    teacher: string;
+    student: string;
+    // RFC-012 / RFC-020 — display companions for the composable filter
+    // chips, used here only to title the destination header.
+    rewayatName: string;
+    countryName: string;
+    translationName: string;
+    // RFC-012 — composable Search-tab filter chips. Tiles on the Home
+    // tab can deeplink here with chips pre-applied (e.g. `?hasPhoto=1`).
+    hasPhoto: string;
+  }>();
 
   const handleBack = () => {
     router.back();
@@ -27,9 +38,13 @@ export default function BrowseScreen() {
   // Get title based on context
   const title = rewayatName
     ? rewayatName
-    : surahId
-      ? `Browse Reciters - ${SURAHS[parseInt(surahId, 10) - 1].name}`
-      : 'Browse All';
+    : countryName
+      ? countryName
+      : translationName
+        ? `${translationName} translation`
+        : surahId
+          ? `Browse Reciters - ${SURAHS[parseInt(surahId, 10) - 1].name}`
+          : 'Browse All';
 
   // Set native header title on iOS
   useLayoutEffect(() => {

--- a/app/(tabs)/(b.search)/reciter/browse.tsx
+++ b/app/(tabs)/(b.search)/reciter/browse.tsx
@@ -7,10 +7,28 @@ import {SURAHS} from '@/data/surahData';
 export default function BrowseScreen() {
   const router = useRouter();
   const {theme} = useTheme();
-  // RFC-012 — composable Search-tab filter chips. Tiles can deeplink in
-  // with chips pre-applied (e.g. `?hasPhoto=1`).
-  const {surahId, hasPhoto} = useLocalSearchParams<{
+  // RFC-012 / RFC-020 — the reciter-browse destination reads the full
+  // composable-filter param surface so any entry point (a "Browse by X"
+  // deeplink, a Browse chip, the Search composer) lands here with its chips
+  // pre-applied and editable. Mirrors the (a.home) twin so both entries
+  // behave identically.
+  const {
+    surahId,
+    teacher,
+    student,
+    rewayatName,
+    countryName,
+    translationName,
+    hasPhoto,
+  } = useLocalSearchParams<{
     surahId: string;
+    teacher: string;
+    student: string;
+    // Display companions used to title the destination header.
+    rewayatName: string;
+    countryName: string;
+    translationName: string;
+    // RFC-012 — composable Search-tab filter chips (e.g. `?hasPhoto=1`).
     hasPhoto: string;
   }>();
 
@@ -18,10 +36,16 @@ export default function BrowseScreen() {
     router.back();
   };
 
-  // Get surah name if surahId is provided
-  const title = surahId
-    ? `Browse Reciters - ${SURAHS[parseInt(surahId, 10) - 1].name}`
-    : 'Browse All';
+  // Title mirrors the (a.home) twin.
+  const title = rewayatName
+    ? rewayatName
+    : countryName
+      ? countryName
+      : translationName
+        ? `${translationName} translation`
+        : surahId
+          ? `Browse Reciters - ${SURAHS[parseInt(surahId, 10) - 1].name}`
+          : 'Browse All';
 
   return (
     <BrowseReciters
@@ -29,6 +53,8 @@ export default function BrowseScreen() {
       onBack={handleBack}
       surahId={surahId ? parseInt(surahId, 10) : undefined}
       title={title}
+      initialTeacher={teacher}
+      initialStudent={student}
       initialHasPhoto={hasPhoto === '1' || hasPhoto === 'true'}
     />
   );

--- a/components/browse/BrowseReciters.tsx
+++ b/components/browse/BrowseReciters.tsx
@@ -38,6 +38,15 @@ import {useHeaderHeight} from 'expo-router/react-navigation';
 import branding from '@/config/branding';
 import {USE_GLASS} from '@/hooks/useGlassProps';
 import {useBottomInset} from '@/hooks/useBottomInset';
+import RecitationsList, {buildRecitationRows} from './RecitationsList';
+import SearchFilters from '@/components/search/SearchFilters';
+import {useURLFiltersAsChips} from '@/hooks/useURLFiltersAsChips';
+import {useReciterStore} from '@/store/reciterStore';
+import {
+  reciterHasFullQuran,
+  reciterMatchesCountry,
+  reciterMatchesTranslation,
+} from './browseFilterPredicates';
 
 interface BrowseRecitersProps {
   theme: Theme;
@@ -126,6 +135,45 @@ export default function BrowseReciters({
   const bottomInset = useBottomInset();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
+  // RFC-020 — the composer's active chips, resolved from the same URL params
+  // the predicates below read. Used for the named empty-state label and to
+  // know when any seam filter is active (`activeChips` is empty when
+  // `branding.searchFilters` is unset → stock behaviour). The <SearchFilters />
+  // strip calls this hook independently for its own UI.
+  const {activeChips, declaredDims} = useURLFiltersAsChips();
+  // Whether the RFC-020 composer exists for this build — identical to when
+  // <SearchFilters /> renders (it returns null with no declared dims). Gates
+  // the composer-only behaviours (named empty-state, Clear-All param wipe)
+  // so a stock build stays byte-identical.
+  const composerEnabled = declaredDims.length > 0;
+  // RECITERS populates async after mount. A scalar `isInitialized` selector
+  // (never a whole-store subscription) re-renders us on catalog load so the
+  // filter memo recomputes against the populated array.
+  const catalogReady = useReciterStore(s => s.isInitialized);
+
+  // RFC-020 — filter values driven by the composer's active chips (the same
+  // URL params <SearchFilters /> reads). rewaya (teacher/student) and
+  // has-surah (surahId) keep their existing bespoke prop-driven paths; the
+  // new dims resolve from activeChips so a composer edit flows straight into
+  // the filter memo. All empty when `branding.searchFilters` is unset.
+  const countrySlug = activeChips.find(c => c.dim === 'country')?.value;
+  const translationSlug = activeChips.find(c => c.dim === 'translation')?.value;
+  const fullQuranActive = activeChips.some(c => c.dim === 'full-quran');
+  // Active flag-facet fields joined into a stable string so the filter memo
+  // can depend on it (the fields array itself is rebuilt every render).
+  const activeFacetKey = declaredDims
+    .filter(
+      d =>
+        d.input === 'toggle' &&
+        d.dim !== 'full-quran' &&
+        activeChips.some(c => c.dim === d.dim),
+    )
+    .map(d => d.dim)
+    .join(',');
+  // The has-surah result-row mode (RecitationsList) only replaces the grid
+  // when a fork declares the `has-surah` dimension; stock keeps its grid.
+  const hasSurahDeclared = !!branding.searchFilters?.includes('has-surah');
+
   // On iOS, the native Stack header handles the top area; on Android, use custom Header
   const useNativeHeader = USE_GLASS;
   const iosHeaderHeight = useNativeHeader ? useHeaderHeight() : 0;
@@ -171,6 +219,21 @@ export default function BrowseReciters({
   useEffect(() => {
     studentRef.current = selectedStudent;
   }, [selectedStudent]);
+
+  // RFC-020 — the rewaya seam dimension reuses the existing teacher/student
+  // URL params, which feed the selectedTeacher/selectedStudent bespoke-chip
+  // state. Syncing that state FROM the params (not just seeding it at mount)
+  // lets a composer-driven rewaya add/edit/remove reach both the filter
+  // predicate and the bespoke chips. These fire only when the URL params
+  // change, so a bespoke chip tap (which mutates state, not the URL) never
+  // re-triggers them — the drill-down keeps working.
+  useEffect(() => {
+    setSelectedTeacher(initialTeacher || null);
+  }, [initialTeacher]);
+
+  useEffect(() => {
+    setSelectedStudent(initialStudent || null);
+  }, [initialStudent]);
 
   const dynamicFilterChips = useMemo((): Chip[] => {
     const chips: Chip[] = [];
@@ -222,6 +285,12 @@ export default function BrowseReciters({
   }, [selectedTeacher, selectedStudent, primaryTeachers]);
 
   const filteredReciters = useMemo(() => {
+    // RFC-020 — RECITERS (and any fork's facet fields) populate async after
+    // catalog load; tying the memo to `catalogReady` recomputes it on load.
+    // The early-return is byte-identical to the pre-load pass (an empty
+    // RECITERS filters to []).
+    if (!catalogReady) return [] as Reciter[];
+
     // Hoisted above the filter chain so the RFC-012 `has-photo` filter
     // and the existing sort step share one definition. "Has photo" matches
     // a card whose user-visible artwork resolves to something — either a
@@ -243,6 +312,20 @@ export default function BrowseReciters({
           rewaya.surah_list?.includes(surahId),
         );
       });
+    }
+
+    // RFC-020 — country / translation seam dimensions. Driven by the
+    // composer's active chips; a no-op (the value is undefined) until a fork
+    // declares the dimension AND populates the matching Reciter field.
+    if (countrySlug) {
+      result = result.filter(reciter =>
+        reciterMatchesCountry(reciter, countrySlug),
+      );
+    }
+    if (translationSlug) {
+      result = result.filter(reciter =>
+        reciterMatchesTranslation(reciter, translationSlug),
+      );
     }
 
     if (searchQuery.trim()) {
@@ -309,6 +392,21 @@ export default function BrowseReciters({
       result = result.filter(hasImage);
     }
 
+    // RFC-020 — full-quran + generic flag facets, appended AFTER the existing
+    // chain so composition stays AND-across-dimensions and legacy behaviour
+    // is unchanged. Driven by the composer's active chips; a flag facet
+    // filters on its boolean Reciter field. No-op for stock builds (nothing
+    // declared → nothing active).
+    if (fullQuranActive) {
+      result = result.filter(reciterHasFullQuran);
+    }
+    for (const field of activeFacetKey ? activeFacetKey.split(',') : []) {
+      result = result.filter(
+        reciter =>
+          (reciter as unknown as Record<string, unknown>)[field] === true,
+      );
+    }
+
     const featuredRecitersData = getFeaturedReciters(20);
     const featuredIds = new Set(featuredRecitersData.map(r => r.id));
 
@@ -328,10 +426,25 @@ export default function BrowseReciters({
     selectedStudent,
     searchQuery,
     surahId,
+    countrySlug,
+    translationSlug,
+    fullQuranActive,
+    activeFacetKey,
+    catalogReady,
     advancedFilters,
     hasPhoto,
     hasPhotoEnabled,
   ]);
+
+  // RFC-020 — when has-surah is active the destination shows one row per
+  // (reciter, rewaya) recitation of that surah instead of the reciter grid;
+  // that surface lives in <RecitationsList />. Here we only need the row
+  // COUNT for the active-filters indicator — via the shared
+  // `buildRecitationRows` builder so the count and the list never disagree.
+  const recitationCount = useMemo(
+    () => (surahId ? buildRecitationRows(filteredReciters, surahId).length : 0),
+    [filteredReciters, surahId],
+  );
 
   const handleFilterModalPress = () => {
     setIsFilterModalVisible(true);
@@ -373,6 +486,30 @@ export default function BrowseReciters({
     });
     // RFC-012 — reset the composable chip state too.
     setHasPhoto(false);
+    // RFC-020 — also clear the URL-driven seam filters so "Clear All" empties
+    // the composer chips alongside the bespoke ones. Gated on the composer
+    // existing, so a stock build makes no extra router write and stays
+    // byte-identical.
+    if (composerEnabled) {
+      const cleared: Record<string, string | undefined> = {
+        country: undefined,
+        countryName: undefined,
+        translation: undefined,
+        translationName: undefined,
+        surahId: undefined,
+        teacher: undefined,
+        student: undefined,
+        rewayatName: undefined,
+        fullQuran: undefined,
+      };
+      // Clear any active generic flag-facet params (serialized as <field>=1).
+      for (const chip of activeChips) {
+        if (chip.value === '1' && chip.dim !== 'full-quran') {
+          cleared[chip.dim] = undefined;
+        }
+      }
+      router.setParams(cleared);
+    }
   };
 
   const handleSearchFocus = () => {
@@ -389,6 +526,9 @@ export default function BrowseReciters({
     Keyboard.dismiss();
   }, []);
 
+  // Primitive so the memo below doesn't churn on the hook's per-render
+  // `activeChips` array identity (0 when searchFilters is unset).
+  const activeChipCount = activeChips.length;
   const hasActiveFilters = useMemo(() => {
     return (
       selectedTeacher !== null ||
@@ -397,7 +537,8 @@ export default function BrowseReciters({
       advancedFilters.styles.length > 0 ||
       advancedFilters.rewayat.length > 0 ||
       advancedFilters.sortBy !== 'featured' ||
-      hasPhoto // RFC-012 — `has-photo` chip counts as active
+      hasPhoto || // RFC-012 — `has-photo` chip counts as active
+      activeChipCount > 0 // RFC-020 — any composer chip counts as active
     );
   }, [
     selectedTeacher,
@@ -405,6 +546,7 @@ export default function BrowseReciters({
     searchQuery,
     advancedFilters,
     hasPhoto,
+    activeChipCount,
   ]);
 
   const handleReciterPress = useCallback(
@@ -515,6 +657,26 @@ export default function BrowseReciters({
   // Top offset: native header height on iOS, 0 on Android (custom Header handles it)
   const topOffset = useNativeHeader ? iosHeaderHeight : 0;
 
+  // RFC-020 — named empty-state. When an active filter combination yields
+  // zero results, show which filters produced it (composed from the active
+  // composer chips) instead of a blank grid, so the user can see what to
+  // relax. Falls back to a generic line for a bespoke-only empty result.
+  const renderFilterEmptyState = (unit: string) => {
+    const chipLabels =
+      activeChips.length > 0
+        ? activeChips.map(chip => chip.label).join(' + ')
+        : undefined;
+    return (
+      <View style={styles.emptyStateContainer}>
+        <Text style={styles.emptyStateText}>
+          {chipLabels
+            ? `No ${unit} match ${chipLabels}`
+            : `No ${unit} match your filters`}
+        </Text>
+      </View>
+    );
+  };
+
   return (
     <TouchableWithoutFeedback onPress={handleOutsidePress}>
       <View style={styles.container}>
@@ -572,6 +734,12 @@ export default function BrowseReciters({
             </Pressable>
           )}
         </View>
+
+        {/* RFC-020 — composable filter composer. Renders the active seam
+         * chips + an "Add a filter" palette above the bespoke teacher/student
+         * chips row (which stays untouched below). Renders nothing when
+         * `branding.searchFilters` is unset (stock upstream). */}
+        <SearchFilters />
 
         {/* Filter Chips */}
         <View style={styles.filterSectionsContainer}>
@@ -652,7 +820,11 @@ export default function BrowseReciters({
         {hasActiveFilters && (
           <View style={styles.activeFiltersContainer}>
             <Text style={styles.activeFiltersText}>
-              {filteredReciters.length} reciters found with current filters
+              {surahId && hasSurahDeclared
+                ? `${recitationCount} recitation${
+                    recitationCount === 1 ? '' : 's'
+                  } found with current filters`
+                : `${filteredReciters.length} reciters found with current filters`}
             </Text>
             <Pressable
               style={({pressed}) => [
@@ -670,15 +842,39 @@ export default function BrowseReciters({
 
         {/* Content */}
         <View style={styles.contentContainer}>
-          <BrowseGrid
-            reciters={filteredReciters}
-            onReciterPress={handleReciterPress}
-            theme={theme}
-            keyboardShouldPersistTaps="handled"
-            onScrollBeginDrag={() => Keyboard.dismiss()}
-            getRewayatIdForReciter={getRewayatIdForReciter}
-            bottomInset={bottomInset}
-          />
+          {surahId && hasSurahDeclared ? (
+            // RFC-020 — has-surah result-row mode: one row per (reciter,
+            // rewaya) recitation instead of the reciter grid. An empty
+            // combination shows the named empty-state (composer builds only),
+            // never a blank list. `catalogReady`-gated so a deeplinked filter
+            // arriving during hydration doesn't flash a false "No results".
+            catalogReady &&
+            composerEnabled &&
+            recitationCount === 0 &&
+            hasActiveFilters ? (
+              renderFilterEmptyState('recitations')
+            ) : (
+              <RecitationsList surahId={surahId} reciters={filteredReciters} />
+            )
+          ) : catalogReady &&
+            composerEnabled &&
+            filteredReciters.length === 0 &&
+            hasActiveFilters ? (
+            // RFC-020 — named empty-state for a zero-result filter combination
+            // (composer builds only; stock falls through to the grid's own
+            // empty rendering).
+            renderFilterEmptyState('reciters')
+          ) : (
+            <BrowseGrid
+              reciters={filteredReciters}
+              onReciterPress={handleReciterPress}
+              theme={theme}
+              keyboardShouldPersistTaps="handled"
+              onScrollBeginDrag={() => Keyboard.dismiss()}
+              getRewayatIdForReciter={getRewayatIdForReciter}
+              bottomInset={bottomInset}
+            />
+          )}
         </View>
 
         {/* Filter Modal */}
@@ -781,6 +977,20 @@ const createStyles = (theme: Theme) =>
       fontSize: moderateScale(12),
       fontFamily: 'Manrope-Medium',
       color: theme.colors.text,
+    },
+    // RFC-020 — named empty-state for a zero-result filter combo.
+    emptyStateContainer: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: moderateScale(32),
+      paddingBottom: moderateScale(80),
+    },
+    emptyStateText: {
+      fontSize: moderateScale(14),
+      fontFamily: 'Manrope-Medium',
+      color: Color(theme.colors.textSecondary).alpha(0.7).toString(),
+      textAlign: 'center',
     },
     separatorChip: {
       paddingHorizontal: moderateScale(6),

--- a/components/browse/RecitationsList.tsx
+++ b/components/browse/RecitationsList.tsx
@@ -1,0 +1,134 @@
+/**
+ * RecitationsList — RFC-020 `has-surah` result-row mode.
+ *
+ * When a surah filter is active, the reciter-browse destination shows one
+ * row per (reciter, rewaya) recitation of that surah instead of the reciter
+ * grid (RFC-020 §3 — result rows switch to `(reciter, rewaya)` tuples when
+ * `has-surah` is active). This component owns that surface: the row-build,
+ * the tap-to-play handler, and the `LegendList` render — so the grid vs.
+ * tuple fork reads as `surahId ? <RecitationsList/> : <BrowseGrid/>`.
+ */
+import React, {useMemo, useCallback} from 'react';
+import {Keyboard} from 'react-native';
+import {moderateScale} from 'react-native-size-matters';
+import {LegendList} from '@legendapp/list';
+import {ReciterItem} from '@/components/ReciterItem';
+import {getDisplayLabelFromName} from '@/services/rewayah/RewayahIdentity';
+import {getSurahById} from '@/services/dataService';
+import {createTracksForReciter} from '@/utils/track';
+import {expandPlayerSheet} from '@/services/player/sheetRef';
+import {usePlayerActions} from '@/hooks/usePlayerActions';
+import {useRecentlyPlayedStore} from '@/services/player/store/recentlyPlayedStore';
+import {useSettings} from '@/hooks/useSettings';
+import {useBottomInset} from '@/hooks/useBottomInset';
+import {Reciter, Rewayat} from '@/data/reciterData';
+
+/** One (reciter, rewaya) tuple covering the filtered surah. */
+export interface RecitationRow {
+  key: string;
+  reciter: Reciter;
+  rewaya: Rewayat;
+}
+
+/**
+ * Expand a reciter list into one row per rewaya that has this surah, lifted
+ * to a pure function so `BrowseReciters` can reuse it for the result count
+ * without re-rendering. Single-rewaya reciters still get one row each.
+ */
+export function buildRecitationRows(
+  reciters: Reciter[],
+  surahId: number,
+): RecitationRow[] {
+  const rows: RecitationRow[] = [];
+  for (const reciter of reciters) {
+    for (const rewaya of reciter.rewayat) {
+      if (!rewaya.surah_list?.includes(surahId)) continue;
+      rows.push({
+        key: `${reciter.id}:${rewaya.id ?? rewaya.name ?? 'unnamed'}`,
+        reciter,
+        rewaya,
+      });
+    }
+  }
+  return rows;
+}
+
+interface RecitationsListProps {
+  surahId: number;
+  reciters: Reciter[];
+}
+
+export default function RecitationsList({
+  surahId,
+  reciters,
+}: RecitationsListProps) {
+  const {updateQueue, play} = usePlayerActions();
+  const startNewChain = useRecentlyPlayedStore(s => s.startNewChain);
+  const {setReciterPreference} = useSettings();
+  const bottomInset = useBottomInset();
+
+  const recitationRows = useMemo(
+    () => buildRecitationRows(reciters, surahId),
+    [reciters, surahId],
+  );
+
+  const handleRecitationPress = useCallback(
+    async (reciter: Reciter, rewaya: Rewayat) => {
+      if (!surahId) return;
+      Keyboard.dismiss();
+      try {
+        const surah = await getSurahById(surahId);
+        if (!surah) return;
+        const rewayatId = rewaya.id ?? reciter.rewayat[0]?.id;
+        if (rewayatId) {
+          setReciterPreference(reciter.id, rewayatId);
+        }
+        const tracks = await createTracksForReciter(
+          reciter,
+          [surah],
+          rewayatId,
+        );
+        await updateQueue(tracks, 0);
+        await play();
+        await startNewChain(reciter, surah, 0, 0, rewayatId);
+
+        // Expand the now-playing PlayerSheet (the ayah-list-style player
+        // surface the mini-player itself opens on tap) so a tap on a
+        // recitation lands on the full player rather than dismissing back.
+        expandPlayerSheet();
+      } catch (error) {
+        console.error('Error playing recitation:', error);
+      }
+    },
+    [setReciterPreference, surahId, updateQueue, play, startNewChain],
+  );
+
+  return (
+    // Listen → Surah tile shows recitations (reciter + rewaya rows) instead
+    // of the grid of reciters; each row is one tap-to-play.
+    <LegendList
+      data={recitationRows}
+      keyExtractor={row => row.key}
+      estimatedItemSize={moderateScale(72)}
+      contentContainerStyle={{
+        paddingBottom: Math.max(
+          moderateScale(80),
+          bottomInset + moderateScale(16),
+        ),
+      }}
+      renderItem={({item}) => {
+        const rewayaLabel = item.rewaya.name
+          ? (getDisplayLabelFromName(item.rewaya.name) ?? item.rewaya.name)
+          : undefined;
+        return (
+          <ReciterItem
+            item={item.reciter}
+            onPress={() => handleRecitationPress(item.reciter, item.rewaya)}
+            secondaryText={rewayaLabel}
+          />
+        );
+      }}
+      onScrollBeginDrag={() => Keyboard.dismiss()}
+    />
+  );
+}

--- a/components/browse/__tests__/browseFilterPredicates.test.ts
+++ b/components/browse/__tests__/browseFilterPredicates.test.ts
@@ -1,0 +1,210 @@
+/**
+ * browseFilterPredicates — RFC-020 unit coverage for the pure reciter-level
+ * seam predicates shared by `BrowseReciters` (the destination filter chain)
+ * and the composer test surface.
+ *
+ * Covers each dimension in isolation, AND-composition (chaining two
+ * predicates narrows to the intersection — the exact behaviour the
+ * destination relies on for a multi-chip filter), and tolerance of an unset
+ * field (`country` / `translation` are absent until a fork populates them —
+ * neither should ever match). Pure module: no RN imports, so this runs
+ * without the heavy BrowseReciters dependency graph.
+ */
+import type {Reciter, Rewayat} from '@/data/reciterData';
+import {
+  reciterHasFullQuran,
+  reciterMatchesCountry,
+  reciterMatchesTranslation,
+} from '../browseFilterPredicates';
+
+function makeRewayat(surahTotal: number, id = 'rw'): Rewayat {
+  return {
+    id,
+    reciter_id: 'r',
+    name: "Hafs A'n Assem",
+    style: 'murattal',
+    server: 'https://example.test',
+    surah_total: surahTotal,
+    surah_list: Array.from({length: surahTotal}, (_, i) => i + 1),
+    source_type: 'test',
+    created_at: '2026-01-01',
+  };
+}
+
+function makeReciter(overrides: Partial<Reciter> = {}): Reciter {
+  return {
+    id: 'r',
+    name: 'Test Reciter',
+    date: null,
+    image_url: null,
+    rewayat: [makeRewayat(114)],
+    ...overrides,
+  };
+}
+
+describe('reciterHasFullQuran (full-quran dimension)', () => {
+  it('keeps a reciter with a 114-total rewaya', () => {
+    expect(
+      reciterHasFullQuran(makeReciter({rewayat: [makeRewayat(114)]})),
+    ).toBe(true);
+  });
+
+  it('rejects a reciter whose only rewaya covers fewer than 114 surahs', () => {
+    expect(reciterHasFullQuran(makeReciter({rewayat: [makeRewayat(30)]}))).toBe(
+      false,
+    );
+  });
+
+  it('keeps a reciter where ANY rewaya is complete (multi-rewaya)', () => {
+    const reciter = makeReciter({
+      rewayat: [makeRewayat(30, 'partial'), makeRewayat(114, 'full')],
+    });
+    expect(reciterHasFullQuran(reciter)).toBe(true);
+  });
+
+  it('rejects a reciter with no rewayat', () => {
+    expect(reciterHasFullQuran(makeReciter({rewayat: []}))).toBe(false);
+  });
+});
+
+describe('reciterMatchesCountry (country dimension)', () => {
+  it('slug-matches a single-word country', () => {
+    expect(
+      reciterMatchesCountry(makeReciter({country: 'Algeria'}), 'algeria'),
+    ).toBe(true);
+  });
+
+  it('slug-matches a multi-word country (spaces → dashes)', () => {
+    expect(
+      reciterMatchesCountry(
+        makeReciter({country: 'Saudi Arabia'}),
+        'saudi-arabia',
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects a non-matching slug', () => {
+    expect(
+      reciterMatchesCountry(makeReciter({country: 'Egypt'}), 'algeria'),
+    ).toBe(false);
+  });
+
+  it('rejects an unset or empty country', () => {
+    expect(reciterMatchesCountry(makeReciter(), 'algeria')).toBe(false);
+    expect(reciterMatchesCountry(makeReciter({country: ''}), 'algeria')).toBe(
+      false,
+    );
+  });
+});
+
+describe('reciterMatchesTranslation (translation dimension)', () => {
+  it('slug-matches a single-word language', () => {
+    expect(
+      reciterMatchesTranslation(
+        makeReciter({translation: 'Spanish'}),
+        'spanish',
+      ),
+    ).toBe(true);
+  });
+
+  it('slug-matches a multi-word language (spaces → dashes)', () => {
+    expect(
+      reciterMatchesTranslation(
+        makeReciter({translation: 'Simplified Chinese'}),
+        'simplified-chinese',
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects a non-matching slug', () => {
+    expect(
+      reciterMatchesTranslation(makeReciter({translation: 'English'}), 'urdu'),
+    ).toBe(false);
+  });
+
+  it('rejects an unset or empty translation', () => {
+    expect(reciterMatchesTranslation(makeReciter(), 'spanish')).toBe(false);
+    expect(
+      reciterMatchesTranslation(makeReciter({translation: ''}), 'spanish'),
+    ).toBe(false);
+  });
+});
+
+describe('AND-composition across dimensions (intersection)', () => {
+  // A small mixed catalog: country + full-quran + translation vary
+  // independently.
+  const catalog: Reciter[] = [
+    makeReciter({
+      id: 'a',
+      country: 'Algeria',
+      rewayat: [makeRewayat(114)],
+      translation: 'Spanish',
+    }),
+    makeReciter({
+      id: 'b',
+      country: 'Algeria',
+      rewayat: [makeRewayat(30)], // Algeria but not complete, no translation
+    }),
+    makeReciter({
+      id: 'c',
+      country: 'Egypt',
+      rewayat: [makeRewayat(114)],
+      translation: 'Spanish', // complete + Spanish, but Egypt
+    }),
+    makeReciter({
+      id: 'd',
+      country: 'Algeria',
+      rewayat: [makeRewayat(114)], // Algeria + complete, no translation
+    }),
+  ];
+
+  const idsMatching = (pred: (r: Reciter) => boolean): string[] =>
+    catalog.filter(pred).map(r => r.id);
+
+  it('country alone keeps every Algerian reciter', () => {
+    expect(idsMatching(r => reciterMatchesCountry(r, 'algeria'))).toEqual([
+      'a',
+      'b',
+      'd',
+    ]);
+  });
+
+  it('country AND full-quran keeps the intersection', () => {
+    expect(
+      idsMatching(
+        r => reciterMatchesCountry(r, 'algeria') && reciterHasFullQuran(r),
+      ),
+    ).toEqual(['a', 'd']);
+  });
+
+  it('country AND translation narrows further than country AND full-quran', () => {
+    expect(
+      idsMatching(
+        r =>
+          reciterMatchesCountry(r, 'algeria') &&
+          reciterMatchesTranslation(r, 'spanish'),
+      ),
+    ).toEqual(['a']);
+  });
+
+  it('all three composed keeps only the reciter in every set', () => {
+    expect(
+      idsMatching(
+        r =>
+          reciterMatchesCountry(r, 'algeria') &&
+          reciterHasFullQuran(r) &&
+          reciterMatchesTranslation(r, 'spanish'),
+      ),
+    ).toEqual(['a']);
+  });
+
+  it('dropping the country predicate widens the set (chip removal)', () => {
+    // Removing the country chip leaves full-quran + translation active → 'c'
+    // rejoins.
+    expect(
+      idsMatching(
+        r => reciterHasFullQuran(r) && reciterMatchesTranslation(r, 'spanish'),
+      ),
+    ).toEqual(['a', 'c']);
+  });
+});

--- a/components/browse/browseFilterPredicates.ts
+++ b/components/browse/browseFilterPredicates.ts
@@ -1,0 +1,61 @@
+/**
+ * browseFilterPredicates — RFC-020 pure, RN-free reciter-level predicates
+ * for the composable Search filter dimensions.
+ *
+ * Extracted so the destination (`BrowseReciters`) and the unit suite
+ * (`browseFilterPredicates.test.ts`) share the SAME predicate code — the
+ * composition test then exercises the real filter logic rather than a copy.
+ * Deliberately holds no React / react-native imports so the tests never
+ * touch the heavy BrowseReciters dependency graph.
+ *
+ * These cover the seam dimensions whose value maps to a `Reciter` field:
+ * `full-quran` (derived from `rewayat[].surah_total`), `country`, and
+ * `translation`. The `rewaya` (teacher/student) dimension keeps its existing
+ * bespoke predicate inline in `BrowseReciters`, and generic flag facets
+ * (`SearchFilterFlagFacet`) are applied generically at the call site, so
+ * neither is mirrored here.
+ */
+import {Reciter} from '@/data/reciterData';
+
+/**
+ * `full-quran` dimension — a reciter with at least one rewaya covering the
+ * complete mushaf (`surah_total === 114`). Derived, no dedicated field.
+ */
+export function reciterHasFullQuran(reciter: Reciter): boolean {
+  return reciter.rewayat.some(rewaya => rewaya.surah_total === 114);
+}
+
+/**
+ * `country` dimension — slug-compares `Reciter.country` to the param slug.
+ * The slugify shape mirrors `data/countryCollections.ts`'s `slugify` so the
+ * predicate and the picker's option list agree. Empty / null / unset
+ * countries never match (so this is a no-op until a fork populates the
+ * field — RFC-020 §1).
+ */
+export function reciterMatchesCountry(
+  reciter: Reciter,
+  countrySlug: string,
+): boolean {
+  if (!reciter.country) return false;
+  const slug = reciter.country
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+  return slug === countrySlug;
+}
+
+/**
+ * `translation` dimension — slug-compares `Reciter.translation` to the param
+ * slug (lowercase + dash-separated), matching `slugifyLanguage` in
+ * `data/translationCollections.ts`. Empty / null / unset translations never
+ * match (no-op until a fork populates the field — RFC-020 §1).
+ */
+export function reciterMatchesTranslation(
+  reciter: Reciter,
+  translationSlug: string,
+): boolean {
+  if (!reciter.translation) return false;
+  const slug = reciter.translation.toLowerCase().trim().replace(/\s+/g, '-');
+  return slug === translationSlug;
+}

--- a/components/search/BrowseChipsRow.tsx
+++ b/components/search/BrowseChipsRow.tsx
@@ -1,0 +1,116 @@
+/**
+ * BrowseChipsRow — RFC-020 rest-state "Browse" region for the Search tab
+ * landing.
+ *
+ * Renders one entry chip per declared `branding.searchFilters` dimension
+ * (declaration order, via `getComposerDimensions`) as a horizontally-
+ * scrollable strip mounted above the curated Collections tiles. A chip is
+ * the on-ramp into the compose state: tapping it deeplinks into the
+ * reciter-browse destination — which hosts the <SearchFilters /> composer —
+ * with `?openPicker=<dim>`, so the composer opens that dimension
+ * front-and-center (its value picker for value dims; an immediate apply for
+ * the flag / full-quran toggles). The chips are STATELESS entry affordances
+ * (never rendered "active"), so the Search landing itself holds no filter
+ * state to reset on re-entry (RFC-020 §2) — popping back to it naturally
+ * leaves it at rest.
+ *
+ * The curated Collections (system-playlist) tiles are a SEPARATE, static
+ * region outside the filter model and are not touched here.
+ *
+ * With `branding.searchFilters` unset (stock upstream) `getComposerDimensions`
+ * returns `[]` and this renders nothing — the Search landing stays
+ * byte-identical to today.
+ */
+import React, {useCallback} from 'react';
+import {ScrollView, StyleSheet} from 'react-native';
+import {moderateScale} from 'react-native-size-matters';
+import {useRouter} from 'expo-router';
+import {
+  getComposerDimensions,
+  type ComposerDimension,
+} from '@/hooks/useURLFiltersAsChips';
+import {RECITERS} from '@/data/reciterData';
+import {useReciterStore} from '@/store/reciterStore';
+import FilterChip from './FilterChip';
+
+/**
+ * Live count for a Browse chip — mirrors `SearchFilters.paletteOptions`
+ * EXACTLY: a cheap single scan of RECITERS for the toggle dimensions
+ * (`full-quran` + the flag facets), and no count for the value dimensions
+ * (their per-option counts live inside their pickers). Undefined until the
+ * catalog populates (RECITERS + any facet fields land async after mount).
+ */
+function toggleReciterCount(
+  dim: ComposerDimension,
+  catalogReady: boolean,
+): number | undefined {
+  if (dim.input !== 'toggle' || !catalogReady) return undefined;
+  return dim.dim === 'full-quran'
+    ? RECITERS.filter(reciter =>
+        reciter.rewayat.some(rewayat => rewayat.surah_total === 114),
+      ).length
+    : RECITERS.filter(
+        reciter =>
+          (reciter as unknown as Record<string, unknown>)[dim.dim] === true,
+      ).length;
+}
+
+export default function BrowseChipsRow() {
+  const router = useRouter();
+  // Scalar selector (never a whole-store subscription) — re-renders on
+  // catalog load so the toggle counts upgrade from undefined to live.
+  const catalogReady = useReciterStore(s => s.isInitialized);
+
+  // Declaration-order dimension list; `[]` when branding.searchFilters is
+  // unset (stock upstream).
+  const dims = getComposerDimensions();
+
+  const openDimension = useCallback(
+    (dim: string) => {
+      // The compose surface is the pushed reciter-browse destination (it
+      // hosts the <SearchFilters /> composer). `openPicker` is a transient
+      // UI intent the composer consumes once on arrival — it opens that
+      // dimension, then clears the param — so the URL stays a clean,
+      // shareable filter deeplink and the back-stack isn't polluted.
+      router.push({
+        pathname: '/(tabs)/(b.search)/reciter/browse',
+        params: {openPicker: dim},
+      });
+    },
+    [router],
+  );
+
+  // Stock upstream (no declared dims) → the Browse region does not exist.
+  if (dims.length === 0) return null;
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      style={styles.strip}
+      contentContainerStyle={styles.content}>
+      {dims.map(dim => (
+        <FilterChip
+          key={dim.dim}
+          label={dim.label}
+          count={toggleReciterCount(dim, catalogReady)}
+          accessibilityLabel={`Browse by ${dim.label}`}
+          onPress={() => openDimension(dim.dim)}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  strip: {
+    marginBottom: moderateScale(12),
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: moderateScale(8),
+    paddingVertical: moderateScale(2),
+  },
+});

--- a/components/search/ExploreView.tsx
+++ b/components/search/ExploreView.tsx
@@ -18,6 +18,7 @@ import {useBottomInset} from '@/hooks/useBottomInset';
 import {USE_GLASS, useGlassColorScheme} from '@/hooks/useGlassProps';
 import {useResponsive} from '@/hooks/useResponsive';
 import {GlassView} from 'expo-glass-effect';
+import BrowseChipsRow from './BrowseChipsRow';
 
 // CONFIGURABLE ROW HEIGHT MULTIPLIER - This is the 'x' variable you can adjust
 const ROW_HEIGHT_UNIT = 80; // Base unit 'x' in points - adjust this value to change all card heights proportionally
@@ -360,6 +361,11 @@ export const ExploreView = React.memo(
                 },
           ]}
           showsVerticalScrollIndicator={false}>
+          {/* RFC-020 — the "Browse" region: filter-dimension entry chips
+           * that deeplink into the compose destination. Renders nothing on
+           * stock upstream (branding.searchFilters unset), so the curated
+           * Collections landing below stays byte-identical. */}
+          <BrowseChipsRow />
           {tilesReady && (
             <View style={styles.masonryContainer}>
               {renderColumn(layout.leftColumn, 'left')}

--- a/components/search/FilterChip.tsx
+++ b/components/search/FilterChip.tsx
@@ -1,0 +1,156 @@
+/**
+ * FilterChip — RFC-020 shared chip primitive for the Search filter composer.
+ *
+ * Visual idiom lifted from the existing chip surfaces so the composer
+ * introduces no parallel aesthetic: `BrowseReciters`' `filterChip*` styles
+ * (the RFC-012 v1 strip) for colors/metrics, and the reanimated
+ * FadeIn/FadeOut/LinearTransition treatment for enter/exit.
+ *
+ * Renders: label + optional live count + (when `onRemove` is provided) a
+ * visible ✕ remove affordance with its own accessibility label — RFC-020's
+ * "every pre-applied filter must read as editable" mitigation.
+ */
+import React, {useMemo} from 'react';
+import {Pressable, StyleSheet, Text} from 'react-native';
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+} from 'react-native-reanimated';
+import {moderateScale} from 'react-native-size-matters';
+import {Feather} from '@expo/vector-icons';
+import Color from 'color';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+
+export interface FilterChipProps {
+  label: string;
+  /** Optional live count rendered after the label (e.g. dimension chips). */
+  count?: number;
+  /** Renders the active/selected visual state. */
+  selected?: boolean;
+  /** Optional leading Feather icon (e.g. `plus` on "Add a filter"). */
+  icon?: React.ComponentProps<typeof Feather>['name'];
+  /** Press on the chip body (open/edit). */
+  onPress?: () => void;
+  /**
+   * When provided, a ✕ affordance renders after the label and pressing it
+   * fires this (independently of `onPress`).
+   */
+  onRemove?: () => void;
+  /** Overrides the chip body's accessibility label (defaults to `label`). */
+  accessibilityLabel?: string;
+}
+
+export default function FilterChip({
+  label,
+  count,
+  selected = false,
+  icon,
+  onPress,
+  onRemove,
+  accessibilityLabel,
+}: FilterChipProps) {
+  const {theme} = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const mutedColor = Color(theme.colors.textSecondary).alpha(0.5).toString();
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(300)}
+      exiting={FadeOut.duration(200)}
+      layout={LinearTransition.duration(300)}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel ?? label}
+        accessibilityState={{selected}}
+        disabled={!onPress}
+        style={({pressed}) => [
+          styles.chip,
+          selected && styles.chipActive,
+          pressed && styles.chipPressed,
+        ]}
+        onPress={onPress}>
+        {icon ? (
+          <Feather
+            name={icon}
+            size={moderateScale(12)}
+            color={selected ? theme.colors.text : mutedColor}
+          />
+        ) : null}
+        <Text style={[styles.chipText, selected && styles.chipTextActive]}>
+          {label}
+        </Text>
+        {count !== undefined ? (
+          <Text style={styles.chipCount}>{count}</Text>
+        ) : null}
+        {onRemove ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Remove ${label} filter`}
+            hitSlop={moderateScale(8)}
+            style={({pressed}) => [
+              styles.removeButton,
+              pressed && styles.removePressed,
+            ]}
+            onPress={onRemove}>
+            <Feather
+              name="x"
+              size={moderateScale(12)}
+              color={selected ? theme.colors.text : mutedColor}
+            />
+          </Pressable>
+        ) : null}
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    // Mirrors BrowseReciters' filterChip* styles (RFC-012 v1 strip) so the
+    // composer chips are visually indistinguishable from the bespoke ones.
+    chip: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: moderateScale(4),
+      paddingHorizontal: moderateScale(12),
+      paddingVertical: moderateScale(6),
+      borderRadius: moderateScale(16),
+      backgroundColor: Color(theme.colors.text).alpha(0.04).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.text).alpha(0.06).toString(),
+      marginHorizontal: moderateScale(2),
+    },
+    chipActive: {
+      backgroundColor: Color(theme.colors.text).alpha(0.1).toString(),
+      borderColor: Color(theme.colors.text).alpha(0.2).toString(),
+    },
+    chipPressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.06).toString(),
+    },
+    chipText: {
+      fontSize: moderateScale(12),
+      fontFamily: theme.fonts.medium,
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+    },
+    chipTextActive: {
+      color: theme.colors.text,
+      fontFamily: theme.fonts.semiBold,
+    },
+    chipCount: {
+      fontSize: moderateScale(11),
+      fontFamily: theme.fonts.medium,
+      color: Color(theme.colors.textSecondary).alpha(0.5).toString(),
+    },
+    removeButton: {
+      marginLeft: moderateScale(2),
+      padding: moderateScale(2),
+      borderRadius: moderateScale(8),
+    },
+    removePressed: {
+      backgroundColor: Color(theme.colors.text).alpha(0.08).toString(),
+    },
+  });
+}

--- a/components/search/SearchFilters.tsx
+++ b/components/search/SearchFilters.tsx
@@ -1,0 +1,245 @@
+/**
+ * SearchFilters — RFC-020 chip composer strip for the Search filter
+ * experience.
+ *
+ * Renders the active filter chips inline (wrap OK — count is bounded by the
+ * `branding.searchFilters` declaration, RFC-020 §3 Q5) plus an "Add a filter"
+ * control that opens the dimension palette (only dims not already active).
+ * Picking a value dimension opens its picker sheet; flag facets +
+ * `full-quran` are one-tap toggles applied straight from the palette. All
+ * state lives in the URL via `useURLFiltersAsChips` (`router.setParams`, in
+ * place — RFC-020 §3 Q4), so this component keeps only the "which sheet is
+ * open" bit.
+ *
+ * All sheets share ONE persistent `PickerSheet` Modal instance: `visible`
+ * toggles and the CHILDREN swap. Never two Modal instances trading places —
+ * on iOS each Modal instance dispatches its present/dismiss transition
+ * independently, and dismissing one while presenting another is the
+ * documented "presentation in progress" wedge class.
+ *
+ * Mounted on the reciter-browse destination. With `branding.searchFilters`
+ * unset (stock upstream) it renders nothing.
+ */
+import React, {useEffect, useMemo, useRef, useState} from 'react';
+import {StyleSheet, View} from 'react-native';
+import {moderateScale} from 'react-native-size-matters';
+import {useLocalSearchParams, useRouter} from 'expo-router';
+import {
+  useURLFiltersAsChips,
+  type ComposerDimension,
+} from '@/hooks/useURLFiltersAsChips';
+import {RECITERS} from '@/data/reciterData';
+import {useReciterStore} from '@/store/reciterStore';
+import FilterChip from './FilterChip';
+import PickerSheet, {
+  PickerOptionGrid,
+  type PickerOption,
+} from './pickers/PickerSheet';
+import CountryPicker from './pickers/CountryPicker';
+import RewayaPicker from './pickers/RewayaPicker';
+import TranslationPicker from './pickers/TranslationPicker';
+import SurahPicker from './pickers/SurahPicker';
+
+/** Which sheet is open: the dimension palette or one dimension's picker. */
+type OpenSheet = 'palette' | 'country' | 'rewaya' | 'translation' | 'surah';
+
+/** Value-dimension id → its picker sheet. */
+const SHEET_FOR_DIM: Record<string, Exclude<OpenSheet, 'palette'>> = {
+  country: 'country',
+  rewaya: 'rewaya',
+  translation: 'translation',
+  'has-surah': 'surah',
+};
+
+/** Header title per sheet. */
+const SHEET_TITLES: Record<OpenSheet, string> = {
+  palette: 'Add a filter',
+  country: 'Country',
+  rewaya: 'Rewaya',
+  translation: 'Translation',
+  surah: 'Surah',
+};
+
+export default function SearchFilters() {
+  const styles = stylesStatic;
+  const {activeChips, declaredDims, setFilter, removeFilter} =
+    useURLFiltersAsChips();
+  const catalogReady = useReciterStore(s => s.isInitialized);
+  const [openSheet, setOpenSheet] = useState<OpenSheet | null>(null);
+  // Kept as its own state (set only when a sheet opens/switches) so the
+  // header doesn't flash a different title during the close animation.
+  const [sheetTitle, setSheetTitle] = useState<string>(SHEET_TITLES.palette);
+
+  const availableDims = useMemo<ComposerDimension[]>(
+    () =>
+      declaredDims.filter(
+        dim => !activeChips.some(chip => chip.dim === dim.dim),
+      ),
+    [declaredDims, activeChips],
+  );
+
+  // Live counts for the palette's one-tap toggles (flag facets +
+  // full-quran) — cheap single scans of RECITERS, no predicate engine
+  // (result counts are the destination's job). Value dims get per-option
+  // counts inside their pickers instead.
+  const paletteOptions = useMemo<PickerOption[]>(
+    () =>
+      availableDims.map(dim => {
+        let count: number | undefined;
+        if (dim.input === 'toggle' && catalogReady) {
+          count =
+            dim.dim === 'full-quran'
+              ? RECITERS.filter(reciter =>
+                  reciter.rewayat.some(rewayat => rewayat.surah_total === 114),
+                ).length
+              : RECITERS.filter(
+                  reciter =>
+                    (reciter as unknown as Record<string, unknown>)[dim.dim] ===
+                    true,
+                ).length;
+        }
+        return {value: dim.dim, label: dim.label, count};
+      }),
+    [availableDims, catalogReady],
+  );
+
+  // RFC-020 (Browse chip) — compose-entry from a rest-state Browse chip.
+  // The Search landing's <BrowseChipsRow /> deeplinks here with
+  // `?openPicker=<dim>`; consume that transient intent ONCE on arrival to
+  // put the tapped dimension front-and-center: open its value picker
+  // (value dims) or apply the flag / full-quran toggle straight away
+  // (reusing the hook's serialization). Then clear the param so a re-render
+  // or a shared URL never re-fires it — the filter itself lives in the real
+  // filter params, not in `openPicker`. A pushed deeplink carrying a filter
+  // param instead (no `openPicker`) lands pre-applied + removable, unchanged.
+  const router = useRouter();
+  const openPickerParams = useLocalSearchParams<{
+    openPicker?: string | string[];
+  }>();
+  const openPicker =
+    typeof openPickerParams.openPicker === 'string' &&
+    openPickerParams.openPicker
+      ? openPickerParams.openPicker
+      : undefined;
+  const consumedOpenPicker = useRef<string | null>(null);
+  useEffect(() => {
+    if (!openPicker) return;
+    // Ref-guard so it fires once even before the param clear propagates
+    // (and idempotently in tests, where the mocked setParams is a no-op).
+    if (consumedOpenPicker.current === openPicker) return;
+    consumedOpenPicker.current = openPicker;
+    router.setParams({openPicker: undefined});
+    const entry = declaredDims.find(d => d.dim === openPicker);
+    if (!entry) return;
+    if (entry.input === 'toggle') {
+      // Router dispatches are sequential, so this merges cleanly with the
+      // openPicker clear above (no setParams race).
+      setFilter(entry.dim, '1');
+    } else {
+      const sheet = SHEET_FOR_DIM[entry.dim];
+      if (sheet) {
+        setSheetTitle(SHEET_TITLES[sheet]);
+        setOpenSheet(sheet);
+      }
+    }
+  }, [openPicker, declaredDims, setFilter, router]);
+
+  // Upstream default (`searchFilters` unset) → the composer does not exist.
+  if (declaredDims.length === 0) {
+    return null;
+  }
+
+  const showSheet = (sheet: OpenSheet) => {
+    setSheetTitle(SHEET_TITLES[sheet]);
+    setOpenSheet(sheet);
+  };
+
+  const closeSheet = () => setOpenSheet(null);
+
+  const openDimension = (dim: string) => {
+    const entry = declaredDims.find(d => d.dim === dim);
+    if (!entry) return;
+    if (entry.input === 'toggle') {
+      // One-tap facets apply immediately — no picker (RFC-020 §3 Q5).
+      setFilter(dim, '1');
+      setOpenSheet(null);
+    } else {
+      const sheet = SHEET_FOR_DIM[dim];
+      if (sheet) {
+        showSheet(sheet);
+      }
+    }
+  };
+
+  const handlePicked =
+    (dim: string) => (value: string, displayName: string) => {
+      setFilter(dim, value, displayName);
+      setOpenSheet(null);
+    };
+
+  return (
+    <View style={styles.container}>
+      {activeChips.map(chip => {
+        const entry = declaredDims.find(d => d.dim === chip.dim);
+        const editable = entry?.input === 'picker';
+        return (
+          <FilterChip
+            key={chip.dim}
+            label={chip.label}
+            selected
+            onPress={editable ? () => openDimension(chip.dim) : undefined}
+            onRemove={() => removeFilter(chip.dim)}
+          />
+        );
+      })}
+
+      {availableDims.length > 0 ? (
+        <FilterChip
+          label="Add a filter"
+          icon="plus"
+          onPress={() => showSheet('palette')}
+        />
+      ) : null}
+
+      {/* ONE persistent Modal for every sheet: `visible` toggles, content
+       * swaps. A palette→picker transition changes only the children of
+       * the already-presented Modal — no dismiss/present pair, so the
+       * iOS Modal-presentation race can't wedge. Content stays lazy:
+       * only the active sheet's children mount (none while closed). */}
+      <PickerSheet
+        visible={openSheet !== null}
+        title={sheetTitle}
+        onClose={closeSheet}>
+        {openSheet === 'palette' ? (
+          <PickerOptionGrid options={paletteOptions} onSelect={openDimension} />
+        ) : null}
+        {openSheet === 'country' ? (
+          <CountryPicker onSelect={handlePicked('country')} />
+        ) : null}
+        {openSheet === 'rewaya' ? (
+          <RewayaPicker onSelect={handlePicked('rewaya')} />
+        ) : null}
+        {openSheet === 'translation' ? (
+          <TranslationPicker onSelect={handlePicked('translation')} />
+        ) : null}
+        {openSheet === 'surah' ? (
+          <SurahPicker onSelect={handlePicked('has-surah')} />
+        ) : null}
+      </PickerSheet>
+    </View>
+  );
+}
+
+// Theme-independent layout (mirrors BrowseReciters' filterBarContainer
+// metrics, but wrapping instead of horizontal-scrolling — RFC-020 §3 Q5:
+// active chips render inline, wrap is fine).
+const stylesStatic = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: moderateScale(8),
+    paddingHorizontal: moderateScale(16),
+    paddingVertical: moderateScale(6),
+  },
+});

--- a/components/search/__tests__/BrowseChipsRow.test.tsx
+++ b/components/search/__tests__/BrowseChipsRow.test.tsx
@@ -1,0 +1,209 @@
+// RNTL tests for BrowseChipsRow (RFC-020) — the rest-state "Browse" region
+// of the Search tab landing.
+//
+// Mock idiom: inline jest.mock factories, `mock`-prefixed out-of-scope vars,
+// no TS annotations inside factory bodies (babel-jest's hoisting transform
+// rejects them). expo-router's `push` is spied so the compose-entry deeplink
+// (`?openPicker=<dim>`) is pinned; branding drives the declared dimensions;
+// reciterStore controls catalog readiness for the toggle counts.
+
+import React from 'react';
+import {fireEvent, render} from '@testing-library/react-native';
+import branding from '@/config/branding';
+import type {
+  SearchFilterDimension,
+  SearchFilterFlagFacet,
+} from '@/config/branding';
+import BrowseChipsRow from '../BrowseChipsRow';
+
+const mockPush = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({push: mockPush}),
+  useLocalSearchParams: () => ({}),
+}));
+
+// Controlled declaration, mutated per test through the mocked module itself
+// (a factory can't close over test-file consts — ES imports evaluate before
+// the module body, so a captured var would still be undefined at call time).
+jest.mock('@/config/branding', () => ({
+  __esModule: true,
+  default: {searchFilters: []},
+}));
+
+let mockCatalogReady = true;
+jest.mock('@/store/reciterStore', () => ({
+  // @ts-expect-error jest.mock() factory: TS annotations are banned by babel-jest
+  useReciterStore: selector => selector({isInitialized: mockCatalogReady}),
+}));
+
+// RECITERS carry the generic flag-facet fields + rewayat surah_total (drives
+// the full-quran count). full-quran → r1,r3 (=2); featured → r1 (=1);
+// curated → r2,r3 (=2).
+jest.mock('@/data/reciterData', () => ({
+  RECITERS: [
+    {
+      id: 'r1',
+      name: 'Reciter One',
+      rewayat: [{surah_total: 114}],
+      featured: true,
+    },
+    {
+      id: 'r2',
+      name: 'Reciter Two',
+      rewayat: [{surah_total: 10}],
+      curated: true,
+    },
+    {
+      id: 'r3',
+      name: 'Reciter Three',
+      rewayat: [{surah_total: 114}],
+      curated: true,
+    },
+  ],
+}));
+
+// The hook module (imported for getComposerDimensions) pulls these in at
+// load — mocked for isolation/speed (getComposerDimensions itself only reads
+// branding, but the imports still evaluate).
+jest.mock('@/data/countryCollections', () => ({
+  getAllCountries: () => [{id: 'algeria', name: 'Algeria', reciterCount: 3}],
+}));
+jest.mock('@/data/rewayat', () => ({
+  getAllRewayatWithCounts: () => [
+    {
+      id: 'hafs-an-assem',
+      displayName: 'Hafs',
+      teacher: 'Asim',
+      student: 'Hafs',
+      reciterCount: 60,
+    },
+  ],
+}));
+jest.mock('@/data/translationCollections', () => ({
+  getAllTranslations: () => [{id: 'spanish', name: 'Spanish'}],
+}));
+
+jest.mock('react-native-size-matters', () => ({
+  // @ts-expect-error jest.mock() factory: TS annotations are banned by babel-jest
+  moderateScale: v => v,
+  // @ts-expect-error jest.mock() factory: TS annotations are banned by babel-jest
+  ScaledSheet: {create: s => s},
+}));
+
+jest.mock('color', () => {
+  const chain = {alpha: () => chain, toString: () => 'rgba(0,0,0,0.2)'};
+  return jest.fn(() => chain);
+});
+
+jest.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        background: '#ffffff',
+        text: '#000000',
+        textSecondary: '#666666',
+        card: '#f2f2f2',
+        border: '#dddddd',
+      },
+      fonts: {
+        regular: 'Manrope-Regular',
+        medium: 'Manrope-Medium',
+        semiBold: 'Manrope-SemiBold',
+      },
+    },
+  }),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const {View} = require('react-native');
+  const mkBuilder = () => {
+    const builder = {duration: () => builder};
+    return builder;
+  };
+  return {
+    __esModule: true,
+    default: {View},
+    FadeIn: mkBuilder(),
+    FadeOut: mkBuilder(),
+    LinearTransition: mkBuilder(),
+  };
+});
+
+jest.mock('@expo/vector-icons', () => ({
+  Feather: () => null,
+}));
+
+const FULL_DECLARATION: Array<SearchFilterDimension | SearchFilterFlagFacet> = [
+  'rewaya',
+  'country',
+  'has-surah',
+  'translation',
+  'full-quran',
+  {kind: 'flag', field: 'featured', label: 'Featured'},
+  {kind: 'flag', field: 'curated', label: 'Curated'},
+];
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockCatalogReady = true;
+  branding.searchFilters = [...FULL_DECLARATION];
+});
+
+describe('BrowseChipsRow — rest-state Browse region (RFC-020 §2)', () => {
+  it('renders one entry chip per declared dimension, in declaration order', () => {
+    const {getByText} = render(<BrowseChipsRow />);
+
+    expect(getByText('Rewaya')).toBeTruthy();
+    expect(getByText('Country')).toBeTruthy();
+    expect(getByText('Surah')).toBeTruthy();
+    expect(getByText('Translation')).toBeTruthy();
+    expect(getByText('Full Quran')).toBeTruthy();
+    expect(getByText('Featured')).toBeTruthy();
+    expect(getByText('Curated')).toBeTruthy();
+  });
+
+  it('shows a live reciter count on the toggle dims only (mirrors the composer palette)', () => {
+    const {getByText, getAllByText} = render(<BrowseChipsRow />);
+
+    // full-quran (r1,r3) and curated (r2,r3) each resolve to 2; featured
+    // (r1) to 1. Value dims (country/rewaya/surah/translation) render no
+    // count, so the only count nodes are these three.
+    expect(getAllByText('2')).toHaveLength(2);
+    expect(getByText('1')).toBeTruthy();
+  });
+
+  it('renders no counts until the catalog is ready', () => {
+    mockCatalogReady = false;
+    const {queryByText} = render(<BrowseChipsRow />);
+
+    // Labels still render; counts are undefined so no count node exists (no
+    // chip label contains a bare digit).
+    expect(queryByText('Featured')).toBeTruthy();
+    expect(queryByText('1')).toBeNull();
+    expect(queryByText('2')).toBeNull();
+  });
+
+  it('a chip tap deeplinks into the (b.search) composer with openPicker=<dim>', () => {
+    const {getByText} = render(<BrowseChipsRow />);
+
+    fireEvent.press(getByText('Rewaya'));
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: '/(tabs)/(b.search)/reciter/browse',
+      params: {openPicker: 'rewaya'},
+    });
+
+    fireEvent.press(getByText('Featured'));
+    expect(mockPush).toHaveBeenLastCalledWith({
+      pathname: '/(tabs)/(b.search)/reciter/browse',
+      params: {openPicker: 'featured'},
+    });
+  });
+
+  it('renders nothing when branding.searchFilters is unset (stock-upstream no-op)', () => {
+    branding.searchFilters = undefined;
+    const {toJSON} = render(<BrowseChipsRow />);
+
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/components/search/__tests__/SearchFilters.test.tsx
+++ b/components/search/__tests__/SearchFilters.test.tsx
@@ -1,0 +1,320 @@
+// RNTL tests for the SearchFilters composer strip (RFC-020).
+//
+// Mock idiom: inline jest.mock factories with `mock`-prefixed out-of-scope
+// vars and no TS annotations inside factory bodies (babel-jest hoisting
+// rule). expo-router is mocked (setParams spy + mutable params object);
+// react-native-reanimated gets a minimal View + animation-builder stub so
+// FilterChip's FadeIn/FadeOut/LinearTransition idiom renders in jsdom.
+
+import React from 'react';
+import {Modal} from 'react-native';
+import {fireEvent, render} from '@testing-library/react-native';
+import branding from '@/config/branding';
+import type {
+  SearchFilterDimension,
+  SearchFilterFlagFacet,
+} from '@/config/branding';
+import SearchFilters from '../SearchFilters';
+
+const mockSetParams = jest.fn();
+let mockParams: Record<string, string | string[]> = {};
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({setParams: mockSetParams}),
+  useLocalSearchParams: () => mockParams,
+}));
+
+// Controlled declaration, mutated per test through the mocked module
+// itself (a factory can't close over test-file consts — ES imports
+// evaluate before the module body, so a captured var would still be
+// undefined when the factory runs).
+jest.mock('@/config/branding', () => ({
+  __esModule: true,
+  default: {searchFilters: []},
+}));
+
+jest.mock('@/store/reciterStore', () => ({
+  // @ts-expect-error jest.mock() factory: TS annotations are banned by babel-jest
+  useReciterStore: selector => selector({isInitialized: true}),
+}));
+
+jest.mock('@/data/reciterData', () => ({
+  RECITERS: [
+    {
+      id: 'r1',
+      name: 'Reciter One',
+      rewayat: [{surah_total: 114}],
+      featured: true,
+    },
+    {
+      id: 'r2',
+      name: 'Reciter Two',
+      rewayat: [{surah_total: 10}],
+      curated: true,
+    },
+  ],
+}));
+
+jest.mock('@/data/countryCollections', () => ({
+  getAllCountries: () => [
+    {id: 'algeria', name: 'Algeria', reciterCount: 3},
+    {id: 'egypt', name: 'Egypt', reciterCount: 5},
+  ],
+}));
+
+// The composer sources getAllRewayatWithCounts (NOT getAllRewayatTypes,
+// which excludes hafs-an-assem by design for the Listen-tab carousel).
+// Fixture includes Hafs, a minority narration, and a zero-count entry the
+// picker must drop.
+jest.mock('@/data/rewayat', () => ({
+  getAllRewayatWithCounts: () => [
+    {
+      id: 'hafs-an-assem',
+      name: "Hafs A'n Assem",
+      displayName: 'Hafs',
+      description: '',
+      teacher: 'Asim',
+      student: 'Hafs',
+      aliases: [],
+      reciterCount: 60,
+    },
+    {
+      id: 'warsh-an-nafi',
+      name: "Warsh A'n Nafi'",
+      displayName: 'Warsh',
+      description: '',
+      teacher: "Nafi'",
+      student: 'Warsh',
+      aliases: [],
+      reciterCount: 4,
+    },
+    {
+      id: 'qalon-an-nafi',
+      name: "Qalon A'n Nafi'",
+      displayName: 'Qalun',
+      description: '',
+      teacher: "Nafi'",
+      student: 'Qalun',
+      aliases: [],
+      reciterCount: 0,
+    },
+  ],
+}));
+
+jest.mock('@/data/translationCollections', () => ({
+  getAllTranslations: () => [
+    {id: 'spanish', name: 'Spanish', languageCode: 'es', itemCount: 1},
+  ],
+}));
+
+jest.mock('react-native-size-matters', () => ({
+  // @ts-expect-error jest.mock() factory: TS annotations are banned by babel-jest
+  moderateScale: v => v,
+  // @ts-expect-error jest.mock() factory: TS annotations are banned by babel-jest
+  ScaledSheet: {create: s => s},
+}));
+
+jest.mock('color', () => {
+  const chain = {alpha: () => chain, toString: () => 'rgba(0,0,0,0.2)'};
+  return jest.fn(() => chain);
+});
+
+jest.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: {
+      colors: {
+        background: '#ffffff',
+        text: '#000000',
+        textSecondary: '#666666',
+        card: '#f2f2f2',
+        border: '#dddddd',
+      },
+      fonts: {
+        regular: 'Manrope-Regular',
+        medium: 'Manrope-Medium',
+        semiBold: 'Manrope-SemiBold',
+      },
+    },
+  }),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const {View} = require('react-native');
+  const mkBuilder = () => {
+    const builder = {duration: () => builder};
+    return builder;
+  };
+  return {
+    __esModule: true,
+    default: {View},
+    FadeIn: mkBuilder(),
+    FadeOut: mkBuilder(),
+    LinearTransition: mkBuilder(),
+  };
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({top: 0, bottom: 0, left: 0, right: 0}),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Feather: () => null,
+}));
+
+const FULL_DECLARATION: Array<SearchFilterDimension | SearchFilterFlagFacet> = [
+  'rewaya',
+  'country',
+  'has-surah',
+  'translation',
+  'full-quran',
+  {kind: 'flag', field: 'featured', label: 'Featured'},
+  {kind: 'flag', field: 'curated', label: 'Curated'},
+];
+
+beforeEach(() => {
+  mockSetParams.mockClear();
+  mockParams = {};
+  branding.searchFilters = [...FULL_DECLARATION];
+});
+
+describe('SearchFilters — composer strip (RFC-020 §2–3)', () => {
+  it('renders a removable chip for each active URL param', () => {
+    mockParams = {country: 'algeria', countryName: 'Algeria', featured: '1'};
+
+    const {getByText, getByLabelText} = render(<SearchFilters />);
+
+    expect(getByText('Country: Algeria')).toBeTruthy();
+    expect(getByText('Featured')).toBeTruthy();
+    // Every active chip carries a visible, labelled remove affordance.
+    expect(getByLabelText('Remove Country: Algeria filter')).toBeTruthy();
+    expect(getByLabelText('Remove Featured filter')).toBeTruthy();
+  });
+
+  it('pressing a chip ✕ removes that filter via router.setParams (companions cleared too)', () => {
+    mockParams = {country: 'algeria', countryName: 'Algeria'};
+
+    const {getByLabelText} = render(<SearchFilters />);
+    fireEvent.press(getByLabelText('Remove Country: Algeria filter'));
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      country: undefined,
+      countryName: undefined,
+    });
+  });
+
+  it('"Add a filter" opens the dimension palette listing only inactive declared dims', () => {
+    mockParams = {country: 'algeria', countryName: 'Algeria'};
+
+    const {getByText, queryByText} = render(<SearchFilters />);
+    fireEvent.press(getByText('Add a filter'));
+
+    // Active dim is not offered again (single value per dimension).
+    expect(queryByText('Country')).toBeNull();
+    // Inactive declared dims appear, declaration-ordered.
+    expect(getByText('Rewaya')).toBeTruthy();
+    expect(getByText('Surah')).toBeTruthy();
+    expect(getByText('Translation')).toBeTruthy();
+    expect(getByText('Full Quran')).toBeTruthy();
+    expect(getByText('Featured')).toBeTruthy();
+    expect(getByText('Curated')).toBeTruthy();
+  });
+
+  it('picking a flag facet from the palette applies it immediately as <field>=1 (no picker)', () => {
+    const {getByText, queryByText} = render(<SearchFilters />);
+
+    fireEvent.press(getByText('Add a filter'));
+    fireEvent.press(getByText('Featured'));
+
+    expect(mockSetParams).toHaveBeenCalledWith({featured: '1'});
+    // Palette closed after the one-tap apply.
+    expect(queryByText('Curated')).toBeNull();
+  });
+
+  it('picking a value dim opens its picker; a Hafs pick writes the param pair and closes the sheet', () => {
+    const {getByText, queryByText} = render(<SearchFilters />);
+
+    fireEvent.press(getByText('Add a filter'));
+    fireEvent.press(getByText('Rewaya'));
+
+    // The picker lists every rewaya with reciters — including Hafs, which
+    // getAllRewayatTypes() would have excluded — and drops zero-count rows.
+    expect(getByText('Hafs')).toBeTruthy();
+    expect(getByText('Warsh')).toBeTruthy();
+    expect(queryByText('Qalun')).toBeNull();
+
+    fireEvent.press(getByText('Hafs'));
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      teacher: 'Asim',
+      student: 'Hafs',
+      rewayatName: 'Hafs',
+    });
+    expect(queryByText('Hafs')).toBeNull();
+  });
+
+  it('palette→picker keeps ONE persistent Modal mounted — visible toggles, content swaps', () => {
+    const {getByText, UNSAFE_getByType} = render(<SearchFilters />);
+
+    // Closed: the single persistent Modal instance exists, hidden.
+    // UNSAFE_getByType throws if zero or more than one Modal is mounted,
+    // so each call below IS the exactly-one assertion.
+    expect(UNSAFE_getByType(Modal).props.visible).toBe(false);
+
+    fireEvent.press(getByText('Add a filter'));
+    expect(UNSAFE_getByType(Modal).props.visible).toBe(true);
+
+    // Palette → picker: the SAME single Modal stays presented — no
+    // dismiss/present pair (the iOS Modal-transition race class) — and
+    // only its content swaps to the rewaya picker.
+    fireEvent.press(getByText('Rewaya'));
+    expect(UNSAFE_getByType(Modal).props.visible).toBe(true);
+    expect(getByText('Hafs')).toBeTruthy();
+
+    // Closing hides the same instance (children unmount, Modal persists).
+    fireEvent.press(getByText('Hafs'));
+    expect(UNSAFE_getByType(Modal).props.visible).toBe(false);
+  });
+
+  it('renders nothing when branding.searchFilters is unset (stock-upstream no-op)', () => {
+    branding.searchFilters = undefined;
+    mockParams = {country: 'algeria'};
+
+    const {toJSON} = render(<SearchFilters />);
+
+    expect(toJSON()).toBeNull();
+  });
+});
+
+describe('SearchFilters — compose-entry from a Browse-chip deeplink (openPicker)', () => {
+  it('an openPicker=<value-dim> deeplink opens that dimension picker on arrival and clears the transient param', () => {
+    mockParams = {openPicker: 'rewaya'};
+
+    const {getByText} = render(<SearchFilters />);
+
+    // The rewaya picker is open front-and-center (its options render).
+    expect(getByText('Hafs')).toBeTruthy();
+    expect(getByText('Warsh')).toBeTruthy();
+    // The intent param is cleared so a re-render / shared URL never re-fires.
+    expect(mockSetParams).toHaveBeenCalledWith({openPicker: undefined});
+  });
+
+  it('an openPicker=<flag-facet> deeplink applies the toggle immediately — no picker', () => {
+    mockParams = {openPicker: 'featured'};
+
+    const {queryByText} = render(<SearchFilters />);
+
+    expect(mockSetParams).toHaveBeenCalledWith({openPicker: undefined});
+    expect(mockSetParams).toHaveBeenCalledWith({featured: '1'});
+    // A toggle has no value to pick — no picker sheet content mounts.
+    expect(queryByText('Hafs')).toBeNull();
+  });
+
+  it('ignores an unknown openPicker dim — clears the stray param, opens nothing', () => {
+    mockParams = {openPicker: 'not-a-dim'};
+
+    const {queryByText} = render(<SearchFilters />);
+
+    expect(mockSetParams).toHaveBeenCalledWith({openPicker: undefined});
+    expect(queryByText('Hafs')).toBeNull();
+  });
+});

--- a/components/search/pickers/CountryPicker.tsx
+++ b/components/search/pickers/CountryPicker.tsx
@@ -1,0 +1,38 @@
+/**
+ * CountryPicker — RFC-020 value picker for the `country` dimension.
+ *
+ * Content-only single-select body: lists `getAllCountries()` (name + live
+ * reciterCount comes free from the helper) in a flex-wrap option grid and
+ * reports the pick as `(CountryInfo.id, CountryInfo.name)` — the URL value
+ * + its display companion. Rendered inside `SearchFilters`' single
+ * persistent `PickerSheet` Modal (one instance, content swaps), and only
+ * while its sheet is open (lazy mounting).
+ */
+import React, {useMemo} from 'react';
+import {getAllCountries} from '@/data/countryCollections';
+import {useReciterStore} from '@/store/reciterStore';
+import {PickerOptionGrid, type PickerOption} from './PickerSheet';
+
+export interface CountryPickerProps {
+  onSelect: (value: string, displayName: string) => void;
+}
+
+export default function CountryPicker({onSelect}: CountryPickerProps) {
+  // getAllCountries() reads the async-populated RECITERS array; subscribe so
+  // the options fill in if the picker somehow mounts before catalog init.
+  const catalogReady = useReciterStore(s => s.isInitialized);
+
+  const options = useMemo<PickerOption[]>(
+    () =>
+      catalogReady
+        ? getAllCountries().map(country => ({
+            value: country.id,
+            label: country.name,
+            count: country.reciterCount,
+          }))
+        : [],
+    [catalogReady],
+  );
+
+  return <PickerOptionGrid options={options} onSelect={onSelect} />;
+}

--- a/components/search/pickers/PickerSheet.tsx
+++ b/components/search/pickers/PickerSheet.tsx
@@ -1,0 +1,217 @@
+/**
+ * PickerSheet + PickerOptionGrid — RFC-020 shared shell for the composer's
+ * value pickers.
+ *
+ * Deliberately a plain React Native `Modal` following
+ * `components/browse/FilterModal.tsx`'s pattern (container/backdrop/header/
+ * optionChip styles), NOT a gorhom sheet.
+ *
+ * `SearchFilters` mounts exactly ONE persistent PickerSheet instance for
+ * every sheet (palette + the content-only pickers): `visible` toggles and
+ * the children swap. RN's Modal present/dismiss bookkeeping only spans a
+ * single instance's `visible` transitions — two separate instances trading
+ * places dispatch their iOS transitions independently (the "presentation in
+ * progress" wedge class). Content stays lazy: only the active sheet's
+ * children render, none while closed.
+ */
+import React, {useMemo} from 'react';
+import {
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {moderateScale} from 'react-native-size-matters';
+import {Feather} from '@expo/vector-icons';
+import Color from 'color';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+
+export interface PickerSheetProps {
+  visible: boolean;
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export default function PickerSheet({
+  visible,
+  title,
+  onClose,
+  children,
+}: PickerSheetProps) {
+  const {theme} = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}>
+      <View style={styles.container}>
+        <TouchableOpacity
+          style={styles.backdrop}
+          activeOpacity={1}
+          accessibilityLabel={`Close ${title}`}
+          onPress={onClose}
+        />
+        <View style={styles.modalContent}>
+          <View style={styles.header}>
+            <Text style={styles.headerTitle}>{title}</Text>
+            <TouchableOpacity
+              style={styles.closeButton}
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+              activeOpacity={0.7}>
+              <Feather
+                name="x"
+                size={moderateScale(24)}
+                color={theme.colors.text}
+              />
+            </TouchableOpacity>
+          </View>
+          <View style={styles.body}>{children}</View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+export interface PickerOption {
+  /** Stable value handed to `onSelect` (slug/id/number-as-string). */
+  value: string;
+  /** Display name — also handed to `onSelect` as the display companion. */
+  label: string;
+  /** Optional live count (reciters matching this option). */
+  count?: number;
+}
+
+interface PickerOptionGridProps {
+  options: PickerOption[];
+  onSelect: (value: string, label: string) => void;
+}
+
+/**
+ * Flex-wrap grid of single-select option chips (FilterModal's
+ * `optionChip*` visual source). Tapping an option fires
+ * `onSelect(value, label)` — the caller closes the sheet.
+ */
+export function PickerOptionGrid({options, onSelect}: PickerOptionGridProps) {
+  const {theme} = useTheme();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <ScrollView
+      style={styles.scrollContainer}
+      contentContainerStyle={[
+        styles.scrollContent,
+        {paddingBottom: insets.bottom + moderateScale(24)},
+      ]}
+      showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled">
+      <View style={styles.optionsContainer}>
+        {options.map(option => (
+          <TouchableOpacity
+            key={option.value}
+            style={styles.optionChip}
+            onPress={() => onSelect(option.value, option.label)}
+            accessibilityRole="button"
+            accessibilityLabel={
+              option.count !== undefined
+                ? `${option.label}, ${option.count} reciters`
+                : option.label
+            }
+            activeOpacity={0.7}>
+            <Text style={styles.optionText}>{option.label}</Text>
+            {option.count !== undefined ? (
+              <Text style={styles.optionCount}>{option.count}</Text>
+            ) : null}
+          </TouchableOpacity>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'flex-end',
+    },
+    backdrop: {
+      flex: 1,
+    },
+    modalContent: {
+      backgroundColor: theme.colors.background,
+      borderTopLeftRadius: moderateScale(20),
+      borderTopRightRadius: moderateScale(20),
+      overflow: 'hidden',
+      height: '70%',
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: moderateScale(16),
+      paddingVertical: moderateScale(16),
+      borderBottomWidth: 1,
+      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+      backgroundColor: theme.colors.background,
+    },
+    headerTitle: {
+      fontSize: moderateScale(18),
+      fontFamily: theme.fonts.semiBold,
+      color: theme.colors.text,
+    },
+    closeButton: {
+      padding: moderateScale(10),
+      width: moderateScale(44),
+      height: moderateScale(44),
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    body: {
+      flex: 1,
+    },
+    scrollContainer: {
+      flex: 1,
+    },
+    scrollContent: {
+      paddingTop: moderateScale(12),
+    },
+    optionsContainer: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: moderateScale(8),
+      paddingHorizontal: moderateScale(16),
+    },
+    optionChip: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: moderateScale(6),
+      paddingHorizontal: moderateScale(12),
+      paddingVertical: moderateScale(8),
+      borderRadius: moderateScale(16),
+      backgroundColor: Color(theme.colors.card).alpha(0.5).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.border).alpha(0.1).toString(),
+    },
+    optionText: {
+      fontSize: moderateScale(14),
+      fontFamily: theme.fonts.regular,
+      color: theme.colors.textSecondary,
+    },
+    optionCount: {
+      fontSize: moderateScale(12),
+      fontFamily: theme.fonts.medium,
+      color: Color(theme.colors.textSecondary).alpha(0.6).toString(),
+    },
+  });
+}

--- a/components/search/pickers/RewayaPicker.tsx
+++ b/components/search/pickers/RewayaPicker.tsx
@@ -1,0 +1,44 @@
+/**
+ * RewayaPicker — RFC-020 value picker for the `rewaya` dimension.
+ *
+ * Content-only single-select body: lists every canonical rewaya with at
+ * least one reciter in a flex-wrap option grid and reports the pick as
+ * `(RewayatInfo.id, RewayatInfo.displayName)`. The hook resolves the id to
+ * the locked `teacher` + `student` URL param pair (one RewayatInfo pick =
+ * one pair). Rendered inside `SearchFilters`' single persistent `PickerSheet`
+ * Modal (one instance, content swaps), and only while its sheet is open.
+ */
+import React, {useMemo} from 'react';
+import {getAllRewayatWithCounts} from '@/data/rewayat';
+import {useReciterStore} from '@/store/reciterStore';
+import {PickerOptionGrid, type PickerOption} from './PickerSheet';
+
+export interface RewayaPickerProps {
+  onSelect: (value: string, displayName: string) => void;
+}
+
+export default function RewayaPicker({onSelect}: RewayaPickerProps) {
+  // reciterCount derives from the async-populated RECITERS array (zero-count
+  // entries are dropped), so subscribe to catalog init.
+  const catalogReady = useReciterStore(s => s.isInitialized);
+
+  const options = useMemo<PickerOption[]>(
+    () =>
+      catalogReady
+        ? // getAllRewayatWithCounts, NOT getAllRewayatTypes — the latter
+          // excludes `hafs-an-assem` by design (Listen-tab discovery
+          // carousel diversity), which would make the majority narration
+          // unpickable here. Zero-count rewayat still drop out.
+          getAllRewayatWithCounts()
+            .filter(rewayat => rewayat.reciterCount > 0)
+            .map(rewayat => ({
+              value: rewayat.id,
+              label: rewayat.displayName,
+              count: rewayat.reciterCount,
+            }))
+        : [],
+    [catalogReady],
+  );
+
+  return <PickerOptionGrid options={options} onSelect={onSelect} />;
+}

--- a/components/search/pickers/SurahPicker.tsx
+++ b/components/search/pickers/SurahPicker.tsx
@@ -1,0 +1,127 @@
+/**
+ * SurahPicker — RFC-020 value picker for the `has-surah` dimension.
+ *
+ * Content-only single-select body: a searchable list of the 114 `SURAHS`
+ * (number + transliterated name), a plain FlatList behind a filter TextInput
+ * (deliberately no FlashList/LegendList — static 114-row list). Reports the
+ * pick as `(String(Surah.id), Surah.name)`. Per-surah reciter counts are
+ * intentionally omitted here — result counts are the destination's job, not
+ * the picker's. Rendered inside `SearchFilters`' single persistent
+ * `PickerSheet` Modal (one instance, content swaps), and only while its sheet
+ * is open (lazy mounting).
+ */
+import React, {useCallback, useMemo, useState} from 'react';
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+  type ListRenderItemInfo,
+} from 'react-native';
+import {moderateScale} from 'react-native-size-matters';
+import Color from 'color';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {useTheme} from '@/hooks/useTheme';
+import {Theme} from '@/utils/themeUtils';
+import {SURAHS, type Surah} from '@/data/surahData';
+
+export interface SurahPickerProps {
+  onSelect: (value: string, displayName: string) => void;
+}
+
+export default function SurahPicker({onSelect}: SurahPickerProps) {
+  const {theme} = useTheme();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const [query, setQuery] = useState('');
+
+  const filteredSurahs = useMemo<Surah[]>(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return SURAHS;
+    return SURAHS.filter(
+      surah =>
+        String(surah.id) === q ||
+        surah.name.toLowerCase().includes(q) ||
+        surah.translated_name_english.toLowerCase().includes(q),
+    );
+  }, [query]);
+
+  const renderItem = useCallback(
+    ({item}: ListRenderItemInfo<Surah>) => (
+      <TouchableOpacity
+        style={styles.row}
+        onPress={() => onSelect(String(item.id), item.name)}
+        accessibilityRole="button"
+        accessibilityLabel={`${item.id}. ${item.name}`}
+        activeOpacity={0.7}>
+        <Text style={styles.rowText}>
+          {item.id}. {item.name}
+        </Text>
+      </TouchableOpacity>
+    ),
+    [styles, onSelect],
+  );
+
+  return (
+    <>
+      <View style={styles.searchWrap}>
+        <TextInput
+          style={styles.searchInput}
+          value={query}
+          onChangeText={setQuery}
+          placeholder="Search surahs"
+          placeholderTextColor={Color(theme.colors.textSecondary)
+            .alpha(0.6)
+            .toString()}
+          autoCorrect={false}
+          autoCapitalize="none"
+          accessibilityLabel="Search surahs"
+        />
+      </View>
+      <FlatList
+        data={filteredSurahs}
+        keyExtractor={surah => String(surah.id)}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingBottom: insets.bottom + moderateScale(24),
+        }}
+        renderItem={renderItem}
+      />
+    </>
+  );
+}
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    searchWrap: {
+      paddingHorizontal: moderateScale(16),
+      paddingTop: moderateScale(12),
+      paddingBottom: moderateScale(4),
+    },
+    searchInput: {
+      borderRadius: moderateScale(10),
+      backgroundColor: Color(theme.colors.text).alpha(0.05).toString(),
+      borderWidth: 1,
+      borderColor: Color(theme.colors.border).alpha(0.1).toString(),
+      paddingHorizontal: moderateScale(12),
+      paddingVertical: moderateScale(8),
+      fontSize: moderateScale(14),
+      fontFamily: theme.fonts.regular,
+      color: theme.colors.text,
+    },
+    row: {
+      paddingHorizontal: moderateScale(16),
+      paddingVertical: moderateScale(12),
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: Color(theme.colors.border).alpha(0.1).toString(),
+    },
+    rowText: {
+      fontSize: moderateScale(14),
+      fontFamily: theme.fonts.medium,
+      color: theme.colors.text,
+    },
+  });
+}

--- a/components/search/pickers/TranslationPicker.tsx
+++ b/components/search/pickers/TranslationPicker.tsx
@@ -1,0 +1,38 @@
+/**
+ * TranslationPicker — RFC-020 value picker for the `translation` dimension.
+ *
+ * Content-only single-select body: lists `getAllTranslations()` (language +
+ * live itemCount) in a flex-wrap option grid and reports the pick as
+ * `(TranslationInfo.id, TranslationInfo.name)` — the URL value + its display
+ * companion. Rendered inside `SearchFilters`' single persistent `PickerSheet`
+ * Modal (one instance, content swaps), and only while its sheet is open
+ * (lazy mounting).
+ */
+import React, {useMemo} from 'react';
+import {getAllTranslations} from '@/data/translationCollections';
+import {useReciterStore} from '@/store/reciterStore';
+import {PickerOptionGrid, type PickerOption} from './PickerSheet';
+
+export interface TranslationPickerProps {
+  onSelect: (value: string, displayName: string) => void;
+}
+
+export default function TranslationPicker({onSelect}: TranslationPickerProps) {
+  // getAllTranslations() reads the async-populated RECITERS array; subscribe
+  // to catalog init.
+  const catalogReady = useReciterStore(s => s.isInitialized);
+
+  const options = useMemo<PickerOption[]>(
+    () =>
+      catalogReady
+        ? getAllTranslations().map(translation => ({
+            value: translation.id,
+            label: translation.name,
+            count: translation.itemCount,
+          }))
+        : [],
+    [catalogReady],
+  );
+
+  return <PickerOptionGrid options={options} onSelect={onSelect} />;
+}

--- a/config/branding.d.ts
+++ b/config/branding.d.ts
@@ -52,24 +52,56 @@ export interface HomeRow {
 export interface ListenTabTopComponentProps {}
 
 /**
- * RFC-012 — identifier for a Search/Browse-tab filter dimension.
+ * RFC-012 / RFC-020 — identifier for a Search/Browse-tab filter dimension.
  *
  * Each id is a predicate the `BrowseReciters` filter pipeline can apply
  * to the reciter list. Forks declare an array in `branding.searchFilters`
  * to opt in to the user-editable chip framework; when undefined, the
  * Search tab keeps today's bespoke chip set (teacher/student) unchanged.
  *
- * v1 ships the exists-today subset only — every dimension here resolves
+ * `rewaya` / `has-surah` / `has-photo` / `recitation-style` resolve
  * against fields that already exist on `Reciter` / `Reciter.rewayat[]`.
- * Future dimensions (`country`, `translation`) require the corresponding
- * fields to be added to the `Reciter` type and populated from the
- * catalog first; they're not part of this PR.
+ * `country` / `translation` need the corresponding `Reciter` field
+ * populated from the catalog first — a fork declaring one before the
+ * field is populated gets an empty, harmless chip. `full-quran` has no
+ * dedicated field — it's derived: any of the reciter's `rewayat[]` with
+ * `surah_total === 114`.
+ *
+ * See `SearchFilterFlagFacet` for the generic boolean-field form used by
+ * fork-only facets (e.g. a curated collection flag) that shouldn't
+ * widen this shared string union.
  */
 export type SearchFilterDimension =
   | 'rewaya' // Reciter.rewayat[].name — teacher/student (already bespoke; here for future migration)
   | 'has-surah' // surah picker → Reciter.rewayat[].surah_list includes (already bespoke; here for future migration)
   | 'has-photo' // Reciter.image_url present
-  | 'recitation-style'; // Reciter.rewayat[].style — canonical slugs 'murattal'|'mojawwad'|'moalim' per data/rewayat-slugs.json (already bespoke; here for future migration)
+  | 'recitation-style' // Reciter.rewayat[].style — canonical slugs 'murattal'|'mojawwad'|'moalim' per data/rewayat-slugs.json (already bespoke; here for future migration)
+  | 'country' // Reciter.country present — requires the field populated from the catalog
+  | 'translation' // Reciter.translation present — requires the field populated from the catalog
+  | 'full-quran'; // any Reciter.rewayat[] with surah_total === 114 — derived, no dedicated field
+
+/**
+ * RFC-020 — generic boolean-facet form for tenant-specific filter chips
+ * that don't belong in the shared `SearchFilterDimension` string union
+ * (e.g. a fork's curated collection flags such as an editorial
+ * "featured" set). `field` names a boolean-or-undefined property on
+ * `Reciter`; a reciter matches the facet when that property is `true`.
+ * `label` is the chip's display text.
+ *
+ * Deliberately generic (a `string field`, not a literal union of known
+ * fork fields) so a tenant can add its own boolean `Reciter` field and
+ * surface it as a chip without widening this shared type.
+ *
+ * @example
+ * { kind: 'flag', field: 'featured', label: 'Featured' }
+ */
+export interface SearchFilterFlagFacet {
+  kind: 'flag';
+  /** A boolean (or undefined) field on `Reciter` this facet filters by. */
+  field: string;
+  /** Chip display label. */
+  label: string;
+}
 
 /** App identity values that vary across forks. */
 export interface Branding {
@@ -130,29 +162,32 @@ export interface Branding {
    */
   listenTabTopComponent?: ComponentType<ListenTabTopComponentProps>;
   /**
-   * RFC-012 — composable Search-tab filter dimensions. When set, the
-   * Search tab renders a user-editable chip per id; tiles on the Home
-   * tab can deeplink in with chips pre-applied via the matching URL
-   * params on the `reciter/browse` route. RFC-012 chips render AFTER
-   * Bayaan's existing bespoke chips (teacher/student) — trailing
-   * position is intentional so users of a forked build see the
-   * familiar chips first and the fork's additions after.
+   * RFC-012 / RFC-020 — composable Search-tab filter dimensions. When
+   * set, the Search tab renders a user-editable chip per entry; tiles on
+   * the Home tab can deeplink in with chips pre-applied via the matching
+   * URL params on the `reciter/browse` route. Chips render in
+   * declaration order, AFTER Bayaan's existing bespoke chips
+   * (teacher/student) — trailing position is intentional so users of a
+   * forked build see the familiar chips first and the fork's additions
+   * after.
    *
    * Tri-state semantics:
    *   - `undefined` (default) — "not migrated"; Search tab keeps
    *     today's bespoke chip set unchanged. Bayaan ships this.
-   *   - `[]` — "explicitly disable all RFC-012 chips". Observably the
-   *     same as `undefined` today, but the intent is distinct for
-   *     future v2 migration when bespoke chips themselves move under
-   *     this seam.
-   *   - non-empty array — opt in to the listed dimensions.
+   *   - `[]` — "explicitly disable all chips". Observably the same as
+   *     `undefined` today, but the intent is distinct for future v2
+   *     migration when bespoke chips themselves move under this seam.
+   *   - non-empty array — opt in to the listed dimensions/facets.
    *
-   * v1 ships exists-today dimensions only — see `SearchFilterDimension`.
+   * Each entry is either a `SearchFilterDimension` string (a predicate
+   * built into the shared filter pipeline) or a `SearchFilterFlagFacet`
+   * object (a tenant-supplied boolean `Reciter` field, e.g. a curated
+   * collection flag) — see both types above.
    *
    * @example
-   * searchFilters: ['rewaya', 'has-surah', 'has-photo']
+   * searchFilters: ['rewaya', 'has-photo', {kind: 'flag', field: 'featured', label: 'Featured'}]
    */
-  searchFilters?: SearchFilterDimension[];
+  searchFilters?: Array<SearchFilterDimension | SearchFilterFlagFacet>;
   /**
    * RFC-013 — optional hook returning the verse_key (e.g. `"2:197"`) the
    * PlayerSheet ayah list (`QuranView`) should anchor on for the

--- a/data/countryCollections.ts
+++ b/data/countryCollections.ts
@@ -1,0 +1,64 @@
+/**
+ * Country registry — RFC-020 `country` filter dimension.
+ *
+ * Derives the list of countries from the active catalog: each distinct
+ * `Reciter.country` value becomes a `CountryInfo` entry with a live reciter
+ * count. Reciters with no `country` value are dropped, so the list is empty
+ * until a fork populates `Reciter.country` from its catalog (RFC-020 §1
+ * field prerequisite) — at which point the `country` composer chip fills in
+ * automatically with no further wiring.
+ */
+import {RECITERS, type Reciter} from './reciterData';
+
+export interface CountryInfo {
+  /** Kebab-case slug — e.g. "saudi-arabia". Matches the URL param. */
+  id: string;
+  /** Display name — e.g. "Saudi Arabia". */
+  name: string;
+  /** Optional emoji flag (from the curated map; absent otherwise). */
+  flag?: string;
+  /** Reciters whose `country` field matches this entry, computed live. */
+  reciterCount: number;
+}
+
+/**
+ * Display metadata for curated countries, keyed by the kebab-case slug of
+ * `Reciter.country` (lowercase + spaces → hyphens). A slug present here
+ * picks up a friendly name + flag; an uncurated slug renders the raw
+ * country string with no flag (still functional). Empty by default — forks
+ * populate it as country values land in their catalog.
+ */
+const CURATED_COUNTRIES: Record<string, {name: string; flag?: string}> = {};
+
+function slugify(country: string): string {
+  return country.trim().toLowerCase().replace(/\s+/g, '-').replace(/-+/g, '-');
+}
+
+/**
+ * Aggregate `RECITERS` by `country`, returning one entry per distinct
+ * country with the reciter count. Reciters with no `country` value are
+ * dropped silently, so this returns `[]` until the field is populated.
+ */
+export function getAllCountries(): CountryInfo[] {
+  const counts = new Map<string, {name: string; count: number}>();
+  for (const reciter of RECITERS as Reciter[]) {
+    if (!reciter.country) continue;
+    const id = slugify(reciter.country);
+    const existing = counts.get(id);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      const curated = CURATED_COUNTRIES[id];
+      counts.set(id, {name: curated?.name ?? reciter.country, count: 1});
+    }
+  }
+
+  return Array.from(counts.entries())
+    .map(([id, {name, count}]) => ({
+      id,
+      name,
+      flag: CURATED_COUNTRIES[id]?.flag,
+      reciterCount: count,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/data/reciterData.ts
+++ b/data/reciterData.ts
@@ -11,6 +11,15 @@ export interface Reciter {
   date: string | null;
   image_url: string | null;
   rewayat: Rewayat[];
+  /**
+   * RFC-020 §1 field prerequisite — optional catalog fields the `country`
+   * and `translation` Search-filter dimensions resolve against. Unset by
+   * default (the catalog omits them → those dimensions surface empty,
+   * harmless chips); a fork populates them from its catalog to light the
+   * dimensions up.
+   */
+  country?: string;
+  translation?: string;
 }
 
 export interface Rewayat {

--- a/data/translationCollections.ts
+++ b/data/translationCollections.ts
@@ -1,0 +1,73 @@
+/**
+ * Translation registry — RFC-020 `translation` filter dimension.
+ *
+ * Derives the list of translation languages from the active catalog: each
+ * distinct `Reciter.translation` value becomes a `TranslationInfo` entry
+ * with a live reciter count. Reciters with no `translation` value are
+ * dropped, so the list is empty until a fork populates `Reciter.translation`
+ * from its catalog (RFC-020 §1 field prerequisite) — at which point the
+ * `translation` composer chip fills in automatically with no further wiring.
+ */
+import {RECITERS, type Reciter} from './reciterData';
+
+export interface TranslationInfo {
+  /** Kebab-case slug — e.g. "english", "urdu". Matches the URL param. */
+  id: string;
+  /** Display name — e.g. "English", "Spanish". */
+  name: string;
+  /** ISO 639-1 / 639-2 language code — e.g. "en", "ur". */
+  languageCode: string;
+  /** Number of reciters tied to this translation language. */
+  itemCount: number;
+}
+
+/**
+ * Minimal language-code map for common translation languages. Falls back to
+ * the lowercased slug when a language isn't mapped (good-enough for the URL
+ * slug + display).
+ */
+const LANGUAGE_CODE_MAP: Readonly<Record<string, string>> = {
+  english: 'en',
+  spanish: 'es',
+  russian: 'ru',
+  french: 'fr',
+  urdu: 'ur',
+  malay: 'ms',
+  indonesian: 'id',
+  turkish: 'tr',
+  german: 'de',
+  arabic: 'ar',
+};
+
+function slugifyLanguage(name: string): string {
+  return name.toLowerCase().trim().replace(/\s+/g, '-');
+}
+
+/**
+ * All translation languages present in the active catalog, with their
+ * reciter counts. Empty when no reciter has `Reciter.translation` set.
+ */
+export function getAllTranslations(): TranslationInfo[] {
+  const counts = new Map<string, {name: string; count: number}>();
+
+  for (const reciter of RECITERS as Reciter[]) {
+    const lang = reciter.translation?.trim();
+    if (!lang) continue;
+    const slug = slugifyLanguage(lang);
+    const existing = counts.get(slug);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      counts.set(slug, {name: lang, count: 1});
+    }
+  }
+
+  return Array.from(counts.entries())
+    .map(([slug, {name, count}]) => ({
+      id: slug,
+      name,
+      languageCode: LANGUAGE_CODE_MAP[slug] ?? slug,
+      itemCount: count,
+    }))
+    .sort((a, b) => b.itemCount - a.itemCount || a.name.localeCompare(b.name));
+}

--- a/hooks/__tests__/useURLFiltersAsChips.test.tsx
+++ b/hooks/__tests__/useURLFiltersAsChips.test.tsx
@@ -1,0 +1,338 @@
+// RNTL tests for useURLFiltersAsChips (RFC-020) — the URL-as-state core of
+// the Search filter composer.
+//
+// Mock idiom: inline jest.mock factories, `mock`-prefixed out-of-scope vars,
+// no TS annotations inside factory bodies (babel-jest's hoisting transform
+// rejects them). expo-router is mocked with a captured `setParams` spy + a
+// mutable params object so each test controls the URL state directly, pinning
+// the locked param-schema contract.
+
+import {renderHook} from '@testing-library/react-native';
+import branding from '@/config/branding';
+import type {
+  SearchFilterDimension,
+  SearchFilterFlagFacet,
+} from '@/config/branding';
+import {useURLFiltersAsChips} from '../useURLFiltersAsChips';
+
+const mockSetParams = jest.fn();
+let mockParams: Record<string, string | string[]> = {};
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({setParams: mockSetParams}),
+  useLocalSearchParams: () => mockParams,
+}));
+
+// Controlled declaration, mutated per test through the mocked module
+// itself (a factory can't close over test-file consts — ES imports
+// evaluate before the module body, so a captured var would still be
+// undefined when the factory runs).
+jest.mock('@/config/branding', () => ({
+  __esModule: true,
+  default: {searchFilters: []},
+}));
+
+jest.mock('@/store/reciterStore', () => ({
+  // @ts-expect-error jest.mock() factory: TS annotations are banned by babel-jest
+  useReciterStore: selector => selector({isInitialized: true}),
+}));
+
+jest.mock('@/data/countryCollections', () => ({
+  getAllCountries: () => [
+    {id: 'algeria', name: 'Algeria', reciterCount: 3},
+    {id: 'egypt', name: 'Egypt', reciterCount: 5},
+  ],
+}));
+
+// The composer sources getAllRewayatWithCounts (NOT getAllRewayatTypes,
+// which excludes hafs-an-assem by design for the Listen-tab carousel).
+// Fixture includes Hafs, a minority narration, and a zero-count entry the
+// composer must drop.
+jest.mock('@/data/rewayat', () => ({
+  getAllRewayatWithCounts: () => [
+    {
+      id: 'hafs-an-assem',
+      name: "Hafs A'n Assem",
+      displayName: 'Hafs',
+      description: '',
+      teacher: 'Asim',
+      student: 'Hafs',
+      aliases: [],
+      reciterCount: 60,
+    },
+    {
+      id: 'warsh-an-nafi',
+      name: "Warsh A'n Nafi'",
+      displayName: 'Warsh',
+      description: '',
+      teacher: "Nafi'",
+      student: 'Warsh',
+      aliases: [],
+      reciterCount: 4,
+    },
+    {
+      id: 'qalon-an-nafi',
+      name: "Qalon A'n Nafi'",
+      displayName: 'Qalun',
+      description: '',
+      teacher: "Nafi'",
+      student: 'Qalun',
+      aliases: [],
+      reciterCount: 0,
+    },
+  ],
+}));
+
+jest.mock('@/data/translationCollections', () => ({
+  getAllTranslations: () => [
+    {id: 'spanish', name: 'Spanish', languageCode: 'es', itemCount: 1},
+  ],
+}));
+
+// Chip order = declaration order. Includes 'has-photo' on purpose — the
+// composer must skip it (BrowseReciters' bespoke RFC-012 chip stays the
+// owner). The two `{kind:'flag'}` entries exercise the generic flag-facet
+// mechanism with tenant-supplied boolean fields.
+const FULL_DECLARATION: Array<SearchFilterDimension | SearchFilterFlagFacet> = [
+  'rewaya',
+  'country',
+  'has-surah',
+  'translation',
+  'full-quran',
+  {kind: 'flag', field: 'featured', label: 'Featured'},
+  {kind: 'flag', field: 'curated', label: 'Curated'},
+  'has-photo',
+];
+
+beforeEach(() => {
+  mockSetParams.mockClear();
+  mockParams = {};
+  branding.searchFilters = [...FULL_DECLARATION];
+});
+
+describe('useURLFiltersAsChips — params → chips (RFC-020 §3)', () => {
+  it('maps URL params to chips in declaration order with labels resolved from the data registries', () => {
+    mockParams = {
+      country: 'algeria',
+      teacher: "Nafi'",
+      student: 'Warsh',
+      surahId: '2',
+      featured: '1',
+    };
+
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    expect(result.current.activeChips).toEqual([
+      {dim: 'rewaya', label: 'Rewaya: Warsh', value: 'warsh-an-nafi'},
+      {dim: 'country', label: 'Country: Algeria', value: 'algeria'},
+      {dim: 'has-surah', label: 'Surah: Al-Baqarah', value: '2'},
+      {dim: 'featured', label: 'Featured', value: '1'},
+    ]);
+  });
+
+  it('falls back to the display-companion params when the registry cannot resolve a value', () => {
+    mockParams = {
+      country: 'not-in-registry',
+      countryName: 'Somewhere Else',
+      translation: 'unknown-lang',
+      translationName: 'Klingon',
+    };
+
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    expect(result.current.activeChips).toEqual([
+      {
+        dim: 'country',
+        label: 'Country: Somewhere Else',
+        value: 'not-in-registry',
+      },
+      {
+        dim: 'translation',
+        label: 'Translation: Klingon',
+        value: 'unknown-lang',
+      },
+    ]);
+  });
+
+  it('full-quran activates only on the locked `fullQuran=1` serialization', () => {
+    mockParams = {fullQuran: '1'};
+    const {result, rerender} = renderHook(() => useURLFiltersAsChips());
+    expect(result.current.activeChips).toEqual([
+      {dim: 'full-quran', label: 'Full Quran', value: '1'},
+    ]);
+
+    mockParams = {fullQuran: '0'};
+    rerender({});
+    expect(result.current.activeChips).toEqual([]);
+  });
+
+  it('skips a declared has-photo dimension entirely (bespoke BrowseReciters chip stays the owner)', () => {
+    mockParams = {hasPhoto: '1'};
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    expect(result.current.activeChips).toEqual([]);
+    expect(result.current.declaredDims.some(d => d.dim === 'has-photo')).toBe(
+      false,
+    );
+    // The rest of the declaration normalizes in order.
+    expect(result.current.declaredDims.map(d => d.dim)).toEqual([
+      'rewaya',
+      'country',
+      'has-surah',
+      'translation',
+      'full-quran',
+      'featured',
+      'curated',
+    ]);
+  });
+
+  it('returns no chips and no dims when branding.searchFilters is unset (stock-upstream no-op)', () => {
+    branding.searchFilters = undefined;
+    mockParams = {country: 'algeria'};
+
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    expect(result.current.declaredDims).toEqual([]);
+    expect(result.current.activeChips).toEqual([]);
+  });
+});
+
+describe('useURLFiltersAsChips — setFilter / removeFilter (router.setParams, in place)', () => {
+  it('setFilter writes a value dimension as its param + display companion', () => {
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    result.current.setFilter('country', 'egypt', 'Egypt');
+    expect(mockSetParams).toHaveBeenCalledTimes(1);
+    expect(mockSetParams).toHaveBeenCalledWith({
+      country: 'egypt',
+      countryName: 'Egypt',
+    });
+
+    result.current.setFilter('translation', 'spanish', 'Spanish');
+    expect(mockSetParams).toHaveBeenLastCalledWith({
+      translation: 'spanish',
+      translationName: 'Spanish',
+    });
+
+    result.current.setFilter('has-surah', '2');
+    expect(mockSetParams).toHaveBeenLastCalledWith({surahId: '2'});
+  });
+
+  it('setFilter resolves a rewaya pick to the locked teacher+student pair + rewayatName companion', () => {
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    result.current.setFilter('rewaya', 'warsh-an-nafi');
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      teacher: "Nafi'",
+      student: 'Warsh',
+      rewayatName: 'Warsh',
+    });
+  });
+
+  it('Hafs is reachable in the rewaya dim — pick resolves and the deeplink label resolves', () => {
+    // getAllRewayatTypes() would have excluded hafs-an-assem (carousel
+    // diversity), making the majority narration unpickable and degrading its
+    // deeplink label; the composer sources getAllRewayatWithCounts.
+    mockParams = {teacher: 'Asim', student: 'Hafs'};
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    expect(result.current.activeChips).toEqual([
+      {dim: 'rewaya', label: 'Rewaya: Hafs', value: 'hafs-an-assem'},
+    ]);
+
+    result.current.setFilter('rewaya', 'hafs-an-assem');
+    expect(mockSetParams).toHaveBeenLastCalledWith({
+      teacher: 'Asim',
+      student: 'Hafs',
+      rewayatName: 'Hafs',
+    });
+  });
+
+  it('setFilter serializes toggles as <param>=1 (full-quran + generic flag facets)', () => {
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    result.current.setFilter('full-quran', '1');
+    expect(mockSetParams).toHaveBeenLastCalledWith({fullQuran: '1'});
+
+    result.current.setFilter('featured', '1');
+    expect(mockSetParams).toHaveBeenLastCalledWith({featured: '1'});
+
+    result.current.setFilter('curated', '1');
+    expect(mockSetParams).toHaveBeenLastCalledWith({curated: '1'});
+  });
+
+  it('setFilter is single-value per dimension — issues one-key replacements, never appends', () => {
+    mockParams = {country: 'algeria', countryName: 'Algeria'};
+    const {result, rerender} = renderHook(() => useURLFiltersAsChips());
+
+    result.current.setFilter('country', 'egypt', 'Egypt');
+
+    // Every write for the dim is a scalar replacement of the same keys.
+    for (const call of mockSetParams.mock.calls) {
+      expect(call[0]).toEqual({country: 'egypt', countryName: 'Egypt'});
+      expect(typeof call[0].country).toBe('string');
+    }
+
+    // Simulate the router applying the update: still exactly one chip.
+    mockParams = {country: 'egypt', countryName: 'Egypt'};
+    rerender({});
+    const countryChips = result.current.activeChips.filter(
+      c => c.dim === 'country',
+    );
+    expect(countryChips).toEqual([
+      {dim: 'country', label: 'Country: Egypt', value: 'egypt'},
+    ]);
+  });
+
+  it('removeFilter clears a value dimension together with its display companion', () => {
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    result.current.removeFilter('country');
+    expect(mockSetParams).toHaveBeenLastCalledWith({
+      country: undefined,
+      countryName: undefined,
+    });
+
+    result.current.removeFilter('translation');
+    expect(mockSetParams).toHaveBeenLastCalledWith({
+      translation: undefined,
+      translationName: undefined,
+    });
+
+    result.current.removeFilter('has-surah');
+    expect(mockSetParams).toHaveBeenLastCalledWith({surahId: undefined});
+  });
+
+  it('removeFilter for the rewaya dim clears teacher, student, AND rewayatName', () => {
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    result.current.removeFilter('rewaya');
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      teacher: undefined,
+      student: undefined,
+      rewayatName: undefined,
+    });
+  });
+
+  it('flag facets round-trip generically as <field>=1', () => {
+    mockParams = {curated: '1'};
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    expect(result.current.activeChips).toEqual([
+      {dim: 'curated', label: 'Curated', value: '1'},
+    ]);
+
+    result.current.removeFilter('curated');
+    expect(mockSetParams).toHaveBeenLastCalledWith({curated: undefined});
+  });
+
+  it('removeFilter clears fullQuran with an explicit undefined', () => {
+    const {result} = renderHook(() => useURLFiltersAsChips());
+
+    result.current.removeFilter('full-quran');
+
+    expect(mockSetParams).toHaveBeenLastCalledWith({fullQuran: undefined});
+  });
+});

--- a/hooks/useURLFiltersAsChips.ts
+++ b/hooks/useURLFiltersAsChips.ts
@@ -1,0 +1,327 @@
+/**
+ * useURLFiltersAsChips — RFC-020 URL-as-state core for the Search filter
+ * composer.
+ *
+ * Maps the reciter-browse route's URL params to an ordered list of active
+ * filter chips (declaration order of `branding.searchFilters`) and exposes
+ * `setFilter` / `removeFilter` mutators that write back via
+ * `router.setParams` — IN PLACE, never `push`, so chip edits don't pollute
+ * the back stack and a filtered view's URL stays a shareable deeplink
+ * (RFC-020 §3, Q4).
+ *
+ * Locked URL param schema (reuses every existing param so legacy deeplinks
+ * keep working):
+ *   - `country=<CountryInfo.id>` (+ `countryName` display companion)
+ *   - `translation=<TranslationInfo.id>` (+ `translationName`)
+ *   - `surahId=<1..114>` — the `has-surah` dimension
+ *   - rewaya dim = the existing `teacher` + `student` PAIR (one RewayatInfo
+ *     pick = one pair; + `rewayatName` display companion)
+ *   - booleans serialize as `<name>=1`: `fullQuran=1`, and flag facets
+ *     generically as `<field>=1`; absent = off
+ *   - removing a chip clears its param(s) (the whole pair for rewaya) by
+ *     passing `undefined` to `router.setParams` (expo-router removes the key)
+ *
+ * Single value per dimension (RFC-020 §3, Q1): setting a dimension always
+ * replaces its param(s); nothing appends.
+ */
+import {useCallback} from 'react';
+import {useLocalSearchParams, useRouter} from 'expo-router';
+import branding from '@/config/branding';
+import type {
+  SearchFilterDimension,
+  SearchFilterFlagFacet,
+} from '@/config/branding';
+import {getAllCountries} from '@/data/countryCollections';
+import {getAllRewayatWithCounts} from '@/data/rewayat';
+import {getAllTranslations} from '@/data/translationCollections';
+import {SURAHS} from '@/data/surahData';
+import {useReciterStore} from '@/store/reciterStore';
+
+/** An active filter rendered as a removable chip in the composer. */
+export interface ActiveFilterChip {
+  /**
+   * Canonical dimension id — a `SearchFilterDimension` string
+   * ('country', 'rewaya', 'has-surah', 'translation', 'full-quran') or a
+   * flag facet's `field`.
+   */
+  dim: string;
+  /** Display label, e.g. `Country: Algeria` (value dims) or `Featured` (toggles). */
+  label: string;
+  /**
+   * The dimension's current value: country/translation id, surah number,
+   * the resolved RewayatInfo id for the rewaya pair, or `'1'` for toggles.
+   */
+  value: string;
+}
+
+/** A `branding.searchFilters` entry normalized for the composer. */
+export interface ComposerDimension {
+  /** Canonical dimension id (see `ActiveFilterChip.dim`). */
+  dim: string;
+  /** Palette display label, e.g. `Country` / `Featured`. */
+  label: string;
+  /**
+   * `picker` — the dimension needs a value picker sheet.
+   * `toggle` — one-tap on/off (`<param>=1`); flag facets + full-quran.
+   */
+  input: 'picker' | 'toggle';
+}
+
+/** Palette labels for the shared string dimensions. */
+const DIM_LABELS: Record<string, string> = {
+  rewaya: 'Rewaya',
+  country: 'Country',
+  'has-surah': 'Surah',
+  translation: 'Translation',
+  'full-quran': 'Full Quran',
+};
+
+/** String dims the composer can offer a value picker for today. */
+const COMPOSER_VALUE_DIMS = new Set<string>([
+  'rewaya',
+  'country',
+  'has-surah',
+  'translation',
+]);
+
+/**
+ * Normalize `branding.searchFilters` into the composer's dimension list,
+ * preserving declaration order (RFC-020 §3, Q2 — chip order is
+ * tenant-controlled).
+ *
+ * Gracefully skipped when declared:
+ *   - `has-photo` — already owned by BrowseReciters' bespoke RFC-012 chip;
+ *     surfacing it here too would double-render the control.
+ *   - `recitation-style` — has no composer value picker yet.
+ * Unknown future strings are skipped silently (forward-compat, mirroring
+ * `homeRowConfig`'s unknown-id behavior).
+ */
+export function getComposerDimensions(): ComposerDimension[] {
+  const declared: Array<SearchFilterDimension | SearchFilterFlagFacet> =
+    branding.searchFilters ?? [];
+  const out: ComposerDimension[] = [];
+  for (const entry of declared) {
+    if (typeof entry === 'string') {
+      if (entry === 'full-quran') {
+        out.push({dim: entry, label: DIM_LABELS[entry], input: 'toggle'});
+      } else if (COMPOSER_VALUE_DIMS.has(entry)) {
+        out.push({dim: entry, label: DIM_LABELS[entry], input: 'picker'});
+      }
+      // 'has-photo' / 'recitation-style' / unknown → skipped (see docstring).
+    } else {
+      out.push({dim: entry.field, label: entry.label, input: 'toggle'});
+    }
+  }
+  return out;
+}
+
+/** Normalize an expo-router param value to a single non-empty string. */
+function firstParam(value: string | string[] | undefined): string | undefined {
+  const v = Array.isArray(value) ? value[0] : value;
+  return v ? v : undefined;
+}
+
+/**
+ * The composer's rewaya lookup list: every canonical rewaya with at least
+ * one reciter. Deliberately `getAllRewayatWithCounts()` and NOT
+ * `getAllRewayatTypes()` — the latter excludes `hafs-an-assem` by design
+ * (it feeds the Listen-tab discovery carousel, where the majority narration
+ * is noise), which here would make Hafs unpickable, silently no-op
+ * `setFilter('rewaya', 'hafs-an-assem')`, and degrade a
+ * `teacher=Asim&student=Hafs` deeplink's chip label to the raw fallback.
+ */
+function composerRewayatList() {
+  return getAllRewayatWithCounts().filter(r => r.reciterCount > 0);
+}
+
+export function useURLFiltersAsChips() {
+  const router = useRouter();
+  const params = useLocalSearchParams();
+  // The RECITERS-backed registries below (getAllCountries /
+  // getAllRewayatWithCounts / getAllTranslations) are empty until the
+  // catalog populates. Subscribing to `isInitialized` re-renders us the
+  // moment it lands so chip labels upgrade from the URL display companions
+  // to registry-resolved names.
+  const catalogReady = useReciterStore(s => s.isInitialized);
+
+  const declaredDims = getComposerDimensions();
+
+  // Computed per render, deliberately un-memoized: `useLocalSearchParams`
+  // returns a fresh object every render, so a memo keyed on it would never
+  // cache; the work is bounded by the ≤7-entry declaration + small
+  // registry scans.
+  const activeChips: ActiveFilterChip[] = [];
+  for (const d of declaredDims) {
+    switch (d.dim) {
+      case 'country': {
+        const id = firstParam(params.country);
+        if (!id) break;
+        const resolved = catalogReady
+          ? getAllCountries().find(c => c.id === id)?.name
+          : undefined;
+        const name = resolved ?? firstParam(params.countryName) ?? id;
+        activeChips.push({
+          dim: d.dim,
+          label: `${d.label}: ${name}`,
+          value: id,
+        });
+        break;
+      }
+      case 'rewaya': {
+        const teacher = firstParam(params.teacher);
+        const student = firstParam(params.student);
+        if (!teacher && !student) break;
+        const info = catalogReady
+          ? composerRewayatList().find(
+              r => r.teacher === teacher && r.student === student,
+            )
+          : undefined;
+        const name =
+          info?.displayName ??
+          firstParam(params.rewayatName) ??
+          student ??
+          teacher ??
+          '';
+        activeChips.push({
+          dim: d.dim,
+          label: `${d.label}: ${name}`,
+          value: info?.id ?? name,
+        });
+        break;
+      }
+      case 'has-surah': {
+        const surahId = firstParam(params.surahId);
+        if (!surahId) break;
+        const surah = SURAHS[parseInt(surahId, 10) - 1];
+        activeChips.push({
+          dim: d.dim,
+          label: `${d.label}: ${surah?.name ?? surahId}`,
+          value: surahId,
+        });
+        break;
+      }
+      case 'translation': {
+        const id = firstParam(params.translation);
+        if (!id) break;
+        const resolved = catalogReady
+          ? getAllTranslations().find(t => t.id === id)?.name
+          : undefined;
+        const name = resolved ?? firstParam(params.translationName) ?? id;
+        activeChips.push({
+          dim: d.dim,
+          label: `${d.label}: ${name}`,
+          value: id,
+        });
+        break;
+      }
+      case 'full-quran': {
+        if (firstParam(params.fullQuran) !== '1') break;
+        activeChips.push({dim: d.dim, label: d.label, value: '1'});
+        break;
+      }
+      default: {
+        // Flag facet — generic `<field>=1` serialization.
+        if (d.input === 'toggle' && firstParam(params[d.dim]) === '1') {
+          activeChips.push({dim: d.dim, label: d.label, value: '1'});
+        }
+        break;
+      }
+    }
+  }
+
+  /**
+   * Apply a dimension's value IN PLACE (single value per dimension —
+   * setting always replaces). For value dims pass the picker's
+   * `(value, displayName)`; for the rewaya dim `value` is the picked
+   * RewayatInfo id (resolved here to the `teacher`+`student` param pair);
+   * toggles ignore `value` and serialize as `<param>=1`.
+   */
+  const setFilter = useCallback(
+    (dim: string, value: string, displayName?: string) => {
+      switch (dim) {
+        case 'country':
+          router.setParams({country: value, countryName: displayName});
+          break;
+        case 'translation':
+          router.setParams({translation: value, translationName: displayName});
+          break;
+        case 'has-surah':
+          router.setParams({surahId: value});
+          break;
+        case 'rewaya': {
+          const info = composerRewayatList().find(r => r.id === value);
+          if (!info) {
+            if (__DEV__) {
+              console.warn(
+                `[useURLFiltersAsChips] setFilter('rewaya', '${value}') — unknown RewayatInfo id; ignoring`,
+              );
+            }
+            return;
+          }
+          router.setParams({
+            teacher: info.teacher,
+            student: info.student,
+            rewayatName: displayName ?? info.displayName,
+          });
+          break;
+        }
+        case 'full-quran':
+          router.setParams({fullQuran: '1'});
+          break;
+        default: {
+          const entry = getComposerDimensions().find(d => d.dim === dim);
+          if (entry?.input === 'toggle') {
+            router.setParams({[dim]: '1'});
+          } else if (__DEV__) {
+            console.warn(
+              `[useURLFiltersAsChips] setFilter('${dim}') — dimension is not declared in branding.searchFilters; ignoring`,
+            );
+          }
+          break;
+        }
+      }
+    },
+    [router],
+  );
+
+  /**
+   * Clear a dimension IN PLACE. Clears the display companion alongside the
+   * value, and the whole `teacher`+`student` pair for the rewaya dim.
+   * Passing `undefined` removes the key (expo-router `setParams` contract).
+   */
+  const removeFilter = useCallback(
+    (dim: string) => {
+      switch (dim) {
+        case 'country':
+          router.setParams({country: undefined, countryName: undefined});
+          break;
+        case 'translation':
+          router.setParams({
+            translation: undefined,
+            translationName: undefined,
+          });
+          break;
+        case 'has-surah':
+          router.setParams({surahId: undefined});
+          break;
+        case 'rewaya':
+          router.setParams({
+            teacher: undefined,
+            student: undefined,
+            rewayatName: undefined,
+          });
+          break;
+        case 'full-quran':
+          router.setParams({fullQuran: undefined});
+          break;
+        default:
+          // Flag facets (and any future generic boolean param).
+          router.setParams({[dim]: undefined});
+          break;
+      }
+    },
+    [router],
+  );
+
+  return {activeChips, declaredDims, setFilter, removeFilter};
+}


### PR DESCRIPTION
## RFC-020 — composable Search filter experience (code)

Implements [RFC-020](https://github.com/thebayaan/Bayaan/blob/develop/docs/rfcs/020-search-filter-experience.md) (doc merged via #309) on top of the RFC-012 `branding.searchFilters` seam: a shared, user-editable chip composer for the Search/Browse reciter-filter experience.

**No-op when `branding.searchFilters` is unset — stock Bayaan is byte-for-byte unchanged.** Bayaan can opt in to the exists-today dimensions (`rewaya`, `has-surah`, `has-photo`, `recitation-style`, `full-quran`) immediately; `country` / `translation` light up once the fork populates those `Reciter` fields (RFC-020 §1).

### Decisions (as locked in RFC-020 §1–3)

| Question | Decision |
| --- | --- |
| Seam shape | **Declarative `branding.searchFilters`** — one shared chip UI; tenants supply only the dimension list (in chip order). The per-tenant component slot was rejected. |
| Dimension composition | **AND across dimensions** (intersection). **Single value per dimension** in v1 (multi-value OR-within is a deferred follow-up). |
| Chip order | **Declaration order** of `branding.searchFilters` — tenant-controlled. |
| Result rows | Switch on `has-surah`: `(reciter, rewaya)` recitation tuples when active, else reciter cards. |
| URL / deeplinks | **URL-as-state via `router.setParams`, in place** (not push) — deeplinks stay shareable; chip edits don't pollute the back stack. |
| Flow | **Progressive disclosure** — the Search tab rests on the curated landing (a "Browse" chip row); the composer + live results reveal only on a deliberate action. Curated Collections stay a separate, static region. |
| New generic form | `SearchFilterFlagFacet` (`{kind:'flag', field, label}`) — a tenant can surface its own boolean `Reciter` field as a chip without widening the shared string union. |

### What ships

- **`config/branding.d.ts`** — `searchFilters` widened to `Array<SearchFilterDimension | SearchFilterFlagFacet>`; adds `country` / `translation` / `full-quran` dimensions + the generic flag-facet form.
- **`hooks/useURLFiltersAsChips`** — the URL⇄chips core + `setFilter` / `removeFilter`.
- **`components/search/`** — `SearchFilters` (composer strip), `FilterChip`, `BrowseChipsRow` (rest-state Browse region, mounted in `ExploreView` above the curated Collections tiles), and one shared `PickerSheet` with lazy `Country` / `Rewaya` / `Translation` / `Surah` pickers.
- **`components/browse/`** — `BrowseReciters` wiring, `RecitationsList` (the `has-surah` row mode), and the RN-free `browseFilterPredicates`.
- **`data/`** — generic `countryCollections` / `translationCollections` catalog-derivations; optional `Reciter.country` / `Reciter.translation` fields (RFC-020 §1 prerequisite — unpopulated in Bayaan ⇒ empty, harmless chips).

### Test plan

| Area | Coverage | Result |
| --- | --- | --- |
| `tsc --noEmit` | full project | ✅ no new errors (identical error set to `develop`) |
| `useURLFiltersAsChips` | params→chips, `setFilter`/`removeFilter`, single-value, rewaya pair, generic facets, unset no-op | ✅ |
| `SearchFilters` | removable chips, palette, one-persistent-Modal, value picker, `openPicker` deeplink, unset no-op | ✅ |
| `BrowseChipsRow` | declaration-order chips, live toggle counts, catalog-not-ready, deeplink push, unset no-op | ✅ |
| `browseFilterPredicates` | each dimension + AND-composition (intersection) + unset-field tolerance | ✅ |
| Jest (4 suites) | — | ✅ **46 / 46 passing** |
| Prettier (repo-pinned 3.8.1) | new + touched files | ✅ clean |

### Device verification

This is the faithful upstream port of the same composer the downstream **Qariah** fork shipped and **device-verified on a physical Pixel 3 (release build)** at its sprint close — that fork's Search/Browse surface is the reference implementation, exercised end-to-end (chip compose / edit / remove, deeplink pre-apply, AND-intersection, `has-surah` recitation rows, named empty-state). The files here are a scrubbed, tenant-neutral port of that verified surface (per the standing "faithful-port + state the proxy caveat" rule).

### Tenant-neutrality

No `searchFilters` declaration is added to `config/branding.js` (the seam stays `undefined`), no fork-specific fields (e.g. curated collection flags) are declared, and no fork data ships. The generic `SearchFilterFlagFacet` type ships **undeclared** for any tenant to opt into.
